### PR TITLE
refactor(auth): add javadoc and operational loggers across the auth slice

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/LogoutRequestDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/LogoutRequestDTO.java
@@ -1,8 +1,12 @@
 package com.ticketing.system.Core.Application.dto;
 
-// Input to AuthenticationService.logout() (UC-14). The token identifies the session
-// to invalidate. UC-14 per II.3.1 is purely a session-termination concern; cart state
-// is governed by separate rules (II.3.0.1, II.3.0.3) and is not touched here.
+/**
+ * Input to {@code AuthenticationService.logout()}. UC-14.
+ *
+ * <p>The token identifies the session to invalidate. UC-14 per II.3.1 is purely
+ * a session-termination concern; cart state is governed by II.3.0.1 / II.3.0.3
+ * and is not touched here.
+ */
 public record LogoutRequestDTO(
     String token
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/interfaces/ISessionManager.java
+++ b/src/main/java/com/ticketing/system/Core/Application/interfaces/ISessionManager.java
@@ -2,37 +2,49 @@ package com.ticketing.system.Core.Application.interfaces;
 
 import java.util.Optional;
 
-// Port for session / token management. Implemented in Infrastructure by JwtSessionManager.
-// Used by AuthenticationService (UC-12/14) and NotificationDispatchService (UC-35/36 — online check).
+/**
+ * Port for session / token management. Implemented in Infrastructure by
+ * {@code JwtSessionManager}. Used by {@code AuthenticationService} (UC-12/14)
+ * and {@code NotificationDispatchService} (UC-35/36 — online check).
+ */
 public interface ISessionManager {
 
-    // UC-12 — issue a token after successful login.
+    /** Issues a token after successful login. UC-12. */
     String generateToken(int userId, String username);
 
-    // Token validation — true if token is well-formed, signature valid, and not expired.
-    // Throws InvalidTokenException for malformed; SessionExpiredException for expired.
+    /**
+     * Validates a token's signature and expiry. UC-12.
+     *
+     * @return {@code true} for a well-formed, signed, unexpired token; {@code false}
+     *     only for {@code null} / blank input
+     * @throws com.ticketing.system.Core.Domain.exceptions.InvalidTokenException
+     *     malformed, bad signature, or revoked
+     * @throws com.ticketing.system.Core.Domain.exceptions.SessionExpiredException
+     *     past the {@code exp} claim
+     */
     boolean validateToken(String token);
 
-    // Returns the user ID encoded in the token.
+    /** Returns the user id encoded in the token. */
     int extractUserId(String token);
 
-    // Returns the username encoded in the token.
+    /** Returns the username encoded in the token. */
     String extractUsername(String token);
 
-    // Quick expiry check without throwing.
+    /** Quick expiry check; returns {@code true} for expired, revoked, or malformed tokens. */
     boolean isExpired(String token);
 
-    // UC-12 — epoch millis at which the token expires (read from the exp claim).
+    /** Epoch millis at which the token expires (read from the {@code exp} claim). UC-12. */
     long extractExpiration(String token);
 
-    // UC-14 — invalidate a token explicitly (server-side denylist or stateful session end).
+    /** Invalidates a token explicitly via the denylist. Idempotent. UC-14. */
     void invalidate(String token);
 
-    // UC-35/36 — used by NotificationDispatchService to route live vs. PENDING storage.
-    // Returns true if the user has a currently-active session.
+    /** Whether the given user has a currently-active session. UC-35/36. */
     boolean isOnline(int userId);
 
-    // Optional — returns the userId if the token is valid, empty otherwise.
-    // Convenience for handlers that don't want to throw on bad tokens.
+    /**
+     * Returns the userId if the token is valid, {@code Optional.empty()} otherwise.
+     * Convenience wrapper for callers that prefer not to handle exceptions.
+     */
     Optional<Integer> tryExtractUserId(String token);
 }

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -1,7 +1,10 @@
 package com.ticketing.system.Core.Application.services;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
@@ -19,8 +22,19 @@ import com.ticketing.system.Core.Domain.exceptions.WeakPasswordException;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
 
+/**
+ * Application service for the auth slice — registration (UC-11), login (UC-12),
+ * and logout (UC-14).
+ *
+ * <p>Orchestrates the User repository, password hasher, and session manager.
+ * Cross-service effects (e.g. UC-13 order restoration on login, UC-37
+ * notification flush) are integrated via direct service calls when those UCs
+ * are implemented.
+ */
 @Service
 public class AuthenticationService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuthenticationService.class);
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
 
@@ -37,15 +51,27 @@ public class AuthenticationService {
         this.sessionManager = sessionManager;
     }
 
+    /** Delegates to {@link ISessionManager#extractUserId}. */
     public int extractUserId(String token) {
         return sessionManager.extractUserId(token);
     }
 
+    /** Delegates to {@link ISessionManager#validateToken}. */
     public boolean validateToken(String token) {
         return sessionManager.validateToken(token);
     }
 
-    // UC-11 — register a new Member; session intentionally remains Guest per II.1.4.
+    /**
+     * Registers a new Member. UC-11.
+     *
+     * <p>Session intentionally remains Guest per II.1.4 — caller must explicitly
+     * log in to upgrade to Member-Visitor.
+     *
+     * @throws InvalidEmailFormatException email fails format check
+     * @throws WeakPasswordException password fails strength rules
+     * @throws DuplicateUsernameException username already taken
+     * @throws DuplicateEmailException email already registered
+     */
     public void register(RegisterRequestDTO request) {
         validateEmail(request.email());
         validatePassword(request.rawPassword());
@@ -60,6 +86,8 @@ public class AuthenticationService {
         String hashed = passwordHasher.hash(request.rawPassword());
         User user = new User(userRepository.nextId(), request.username(), request.email(), hashed);
         userRepository.save(user);
+
+        log.info("member registered: username={} id={}", user.getUsername(), user.getUserId());
     }
 
     private static void validateEmail(String email) {
@@ -84,28 +112,48 @@ public class AuthenticationService {
         }
     }
 
-    // UC-12 — issue a JWT after credential verification.
-    // Domain-event publication (MemberLoggedIn for UC-13 / UC-37 consumers) is deferred;
-    // see docs/plan-domain-events.md.
+    /**
+     * Authenticates a Member and issues a JWT. UC-12.
+     *
+     * <p>"Unknown username" and "wrong password" raise the same exception to
+     * avoid username enumeration via the response.
+     *
+     * @throws AuthenticationFailedException invalid credentials
+     */
     public AuthTokenDTO login(LoginRequestDTO request) {
-        User user = userRepository.findByUsername(request.username())
-                .orElseThrow(AuthenticationFailedException::new);
+        User user;
+        try {
+            user = userRepository.findByUsername(request.username())
+                    .orElseThrow(AuthenticationFailedException::new);
 
-        if (!user.verifyPassword(request.rawPassword(), passwordHasher)) {
-            throw new AuthenticationFailedException();
+            if (!user.verifyPassword(request.rawPassword(), passwordHasher)) {
+                throw new AuthenticationFailedException();
+            }
+        } catch (AuthenticationFailedException e) {
+            log.warn("login failed for username={}", request.username());
+            throw e;
         }
 
         String token = sessionManager.generateToken(user.getUserId(), user.getUsername());
         long expiresAt = sessionManager.extractExpiration(token);
+
+        log.info("member logged in: username={} id={}", user.getUsername(), user.getUserId());
+
         return new AuthTokenDTO(token, expiresAt, user.getUserId(), user.getUsername());
     }
 
-    // UC-14 — terminate the authenticated session by revoking the token; per II.3.1 the
-    // session state downgrades back to Guest-Visitor. Cart state is not touched here
-    // (II.3.0.1 / II.3.0.3 govern Active Orders separately). Idempotent: logout with a
-    // null / blank / already-revoked token is a no-op.
+    /**
+     * Terminates the authenticated session by revoking the token. UC-14.
+     *
+     * <p>Per II.3.1 the session state downgrades back to Guest-Visitor. Cart
+     * state is not touched here (II.3.0.1 / II.3.0.3 govern Active Orders
+     * separately). Idempotent: logout with a {@code null} / blank /
+     * already-revoked token is a no-op.
+     */
     public void logout(LogoutRequestDTO request) {
+        Optional<Integer> userIdOpt = sessionManager.tryExtractUserId(request.token());
         sessionManager.invalidate(request.token());
+        userIdOpt.ifPresent(userId -> log.info("member logged out: id={}", userId));
     }
 
     // Deferred from V1. Not in the UC-12 spec, no acceptance test gates it, and a

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/DuplicateEmailException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/DuplicateEmailException.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Core.Domain.exceptions;
 
+/** Thrown when registration attempts to use an email already on record. UC-11. */
 public class DuplicateEmailException extends DomainException {
 
     public DuplicateEmailException(String email) {

--- a/src/main/java/com/ticketing/system/Core/Domain/users/IUserRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/IUserRepository.java
@@ -2,30 +2,32 @@ package com.ticketing.system.Core.Domain.users;
 
 import java.util.Optional;
 
-// Aggregate-root entry point for the User aggregate.
+/** Aggregate-root entry point for the User aggregate. */
 public interface IUserRepository {
 
+    /** @throws com.ticketing.system.Core.Domain.exceptions.UserNotFoundException if no user with that id exists */
     User getUserById(int targetId);
 
     boolean sendInvitation(int targetId, int companyId);
 
+    /** Persists changes to an existing User. */
     void updateUser(User targetUser);
 
-    // UC-11 / UC-12 — by-username lookup for registration uniqueness check + login.
+    /** By-username lookup. Used by UC-11 (uniqueness check) and UC-12 (login). */
     Optional<User> findByUsername(String username);
 
-    // UC-11 — secondary uniqueness lookup.
+    /** By-email lookup. Used by UC-11 as a secondary uniqueness check. */
     Optional<User> findByEmail(String email);
 
-    // UC-11 — fast existence check used during registration validation.
+    /** Fast existence check used during UC-11 registration validation. */
     boolean existsByUsername(String username);
 
-    // UC-11 — mint a fresh userId before constructing a User aggregate.
+    /** Mints a fresh userId. Storage owns ID generation rather than the service. UC-11. */
     int nextId();
 
-    // UC-11 — persist newly-registered User (User aggregate creation).
+    /** Persists a newly-registered User. UC-11. */
     void save(User user);
 
-    // II.6.2.x (Cancelled in v0) — defensive: defined for completeness.
+    /** Removes a user by id. Defensive — II.6.2.x is cancelled in v0. */
     void delete(int userId);
 }

--- a/src/main/java/com/ticketing/system/Core/Domain/users/User.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/User.java
@@ -101,12 +101,18 @@ public List<ManagementInvitation> getManagementInvitations() {
         return username;
     }
 
+    /** Email registered at sign-up. Used for uniqueness checks. UC-11. */
     public String getEmail() {
         return email;
     }
 
-    // UC-12 — verifies a candidate raw password against the stored hash.
-    // Hash never leaves this entity; the hasher does the comparison in place.
+    /**
+     * Verifies a candidate raw password against the stored hash. UC-12.
+     *
+     * <p>The hash never leaves this entity — the hasher does the comparison
+     * in place. The {@link IPasswordHasher} collaborator is passed in rather
+     * than held as a field so the entity stays a pure domain object.
+     */
     public boolean verifyPassword(String rawPassword, IPasswordHasher hasher) {
         return hasher.matches(rawPassword, this.password);
     }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryUserRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryUserRepository.java
@@ -11,6 +11,13 @@ import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
 
+/**
+ * In-memory {@link IUserRepository} for V1.
+ *
+ * <p>Storage is a thread-safe {@code ConcurrentHashMap}; IDs are minted from
+ * an {@code AtomicInteger} starting at 1. A future JPA-backed adapter will
+ * replace this class without touching the application layer.
+ */
 @Repository
 public class MemoryUserRepository implements IUserRepository {
 

--- a/src/main/java/com/ticketing/system/Infrastructure/security/BcryptPasswordHasher.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/security/BcryptPasswordHasher.java
@@ -5,16 +5,25 @@ import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 
+/**
+ * BCrypt-backed implementation of {@link IPasswordHasher}. UC-11 / UC-12.
+ *
+ * <p>Uses Spring Security's {@link BCryptPasswordEncoder} with the default cost
+ * factor (10). Each {@link #hash} call generates a fresh salt; the salt is
+ * embedded in the returned string so verification only needs the stored value.
+ */
 @Component
 public class BcryptPasswordHasher implements IPasswordHasher {
 
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
+    /** Hashes a raw password with a fresh random salt. UC-11. */
     @Override
     public String hash(String rawPassword) {
         return encoder.encode(rawPassword);
     }
 
+    /** Verifies a candidate raw password against a stored BCrypt hash. UC-12. */
     @Override
     public boolean matches(String rawPassword, String storedHash) {
         if (rawPassword == null || storedHash == null) return false;

--- a/src/main/java/com/ticketing/system/Infrastructure/security/JwtSessionManager.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/security/JwtSessionManager.java
@@ -8,6 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.SecretKey;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -21,8 +23,21 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 
+/**
+ * jjwt-backed implementation of {@link ISessionManager}. UC-12 / UC-14.
+ *
+ * <p>Tokens are HS256-signed using {@code jwt.secret} from configuration and
+ * expire after {@code jwt.expiration-minutes}. Revocation (UC-14) is tracked
+ * in an in-memory denylist; revoked tokens fail every reader because the
+ * denylist check lives inside the central {@link #parseClaims} helper.
+ *
+ * <p>The denylist grows for the JVM's lifetime — fine for V1; a real
+ * deployment should sweep entries whose natural {@code exp} has passed.
+ */
 @Component
 public class JwtSessionManager implements ISessionManager {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtSessionManager.class);
 
     private static final String CLAIM_USERNAME = "username";
 
@@ -88,7 +103,9 @@ public class JwtSessionManager implements ISessionManager {
     @Override
     public void invalidate(String token) {
         if (token == null || token.isBlank()) return;
-        revokedTokens.add(token);
+        if (revokedTokens.add(token)) {
+            log.debug("token revoked");
+        }
     }
 
     @Override
@@ -107,6 +124,7 @@ public class JwtSessionManager implements ISessionManager {
 
     private Claims parseClaims(String token) {
         if (revokedTokens.contains(token)) {
+            log.debug("rejected revoked token");
             throw new InvalidTokenException("token has been revoked");
         }
         try {

--- a/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
@@ -243,4 +243,5 @@ class AuthenticationServiceTest {
         service.logout(new LogoutRequestDTO("not-a-real-token"));
         verify(mockSessionManager).invalidate("not-a-real-token");
     }
+
 }


### PR DESCRIPTION
## Summary

Polish pass on the auth slice (UC-11 / UC-12 / UC-14). Pure docs + observability — no behavior changes.

- Class-level and method-level Javadoc across the auth surface: `User` (verifyPassword, getEmail), `IUserRepository`, `BcryptPasswordHasher`, `ISessionManager` + `JwtSessionManager`, `AuthenticationService`, `MemoryUserRepository`, `DuplicateEmailException`, `LogoutRequestDTO`.
- INFO loggers for successful register / login / logout in `AuthenticationService`.
- WARN logger for failed login — single generic message for both "unknown user" and "wrong password" so the log doesn't leak which check failed.
- DEBUG loggers in `JwtSessionManager` when a token is revoked or when a revoked token is rejected.

## Test plan

- [x] `mvn clean test` — 274 passing, 0 failures
- [x] Manual: enable `logging.level.com.ticketing=DEBUG`, walk register / login / logout, confirm logs appear and **no password or token material leaks** into them.

## What to review

- Log levels — is WARN right for "failed login," or should it be INFO?
- Javadoc clarity — would a teammate picking up the auth slice understand the public API from these docs alone?
- Anything sensitive being logged that shouldn't be?

## Not in this PR

No closing keywords — this isn't tied to a single issue. It's quality-of-life polish on already-merged UC work.