### PR TITLE
feat(UC-2): expire temporary user access (sweeper) + Spring wiring backfill

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -29,6 +29,9 @@ import com.ticketing.system.Core.Domain.events.IEventRepository;
 // Owns UC-3 (Browse Events as Guest), UC-7 (Browse + Search Catalogs), UC-8 (View Venue Map + Inventory).
 // Separated from EventManagementService (which is owner-side / write-heavy) so the two audiences
 // don't share an API surface — see design_walkthrough_summary.md §6.
+import org.springframework.stereotype.Service;
+
+@Service
 public class CatalogService {
 
     private static final Logger logger = LoggerFactory.getLogger(CatalogService.class);

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -37,6 +37,9 @@ import com.ticketing.system.Core.Domain.orders.ReceiptLine;
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
 import com.ticketing.system.Core.Domain.users.Session;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class CheckoutService {
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -17,6 +17,9 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
 import java.util.regex.Pattern;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class CompanyManagementService {
     private final IProductionCompanyRepository companyRepository;
     private final IUserRepository userRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -18,6 +18,9 @@ import org.slf4j.LoggerFactory;
 
 // Owner / Manager-side write service for the Event aggregate and its lifecycle.
 // UC-19 (Manage Event Catalog), UC-20 (Configure Venue Map & Inventory), UC-21 (Configure Policies).
+import org.springframework.stereotype.Service;
+
+@Service
 public class EventManagementService {
 
     private final IEventRepository eventRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
@@ -18,6 +18,9 @@ import java.util.List;
 // Reserved for additional member-side reads (UC-15 if it returns from Cancelled, profile views, etc.).
 // Separated from AuthenticationService (which is auth-flow only) so personal-data reads don't
 // stretch the auth boundary — see design_walkthrough_summary.md §6.
+import org.springframework.stereotype.Service;
+
+@Service
 public class MemberAccountService {
 
     private final AuthenticationService authenticationService; // For user identity verification, if needed for future methods.

--- a/src/main/java/com/ticketing/system/Core/Application/services/MessagingService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MessagingService.java
@@ -14,6 +14,9 @@ import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
 // Replaces per-User MessageInbox, per-Company Inbox, and the standalone Complaint flow.
 // Covers requirements II.3.3 (complaint), II.3.10 (contact company), II.4.4 (company support
 // inbox), II.6.3.1 (admin complaint queue), II.6.3.2 (admin announcements).
+import org.springframework.stereotype.Service;
+
+@Service
 public class MessagingService {
 
     private final IConversationRepository conversationRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
@@ -18,6 +18,9 @@ import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
 //
 // The Domain-Events pattern was committed at UC-35 (see design_walkthrough_summary.md §6).
 // Listener wiring (which domain events trigger dispatchFromEvent) lives in code, off-diagram.
+import org.springframework.stereotype.Service;
+
+@Service
 public class NotificationDispatchService {
 
     private final INotificationRepository notificationRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -15,6 +15,9 @@ import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.InventoryZone;
 
+import org.springframework.stereotype.Service;
+
+@Service
 public class ReservationService {
 
     private final IEventRepository eventRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -14,6 +14,9 @@ import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 
 // Owns platform-bootstrap, market-lifecycle, and global admin queries.
 // UC-1 (Initialize), UC-31 (Global History), UC-32 (Open/Close Market).
+import org.springframework.stereotype.Service;
+
+@Service
 public class SystemAdminService {
 
     private final IAdminRepository adminRepository;

--- a/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
@@ -13,6 +13,12 @@ import com.ticketing.system.Core.Domain.notifications.NotificationType;
 // V1: collects notifications in memory so tests can assert on them.
 // V2/V3: replace with WebSocket / SSE / email when real-time push is in scope.
 // All bodies are stubs — owned by the team member assigned to UC-35.
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
 public class InMemoryNotificationService implements INotificationService {
 
     @Override

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
@@ -8,6 +8,12 @@ import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 // V1 stub for IPaymentGateway. Lets V1 tests run without a real payment provider.
 // V2/V3 will replace with real adapters per I.3.2 (multiple gateway support).
 // All bodies are stubs — owned by the team member assigned to UC-33.
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
 public class StubPaymentGateway implements IPaymentGateway {
 
     @Override

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
@@ -7,6 +7,12 @@ import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 // V1 stub for ITicketIssuer. Lets V1 tests run without a real ticket-issuance provider.
 // V2/V3 will replace with real adapters per I.4.2 (multiple provider support).
 // All bodies are stubs — owned by the team member assigned to UC-34.
+import org.springframework.stereotype.Component;
+
+
+import org.springframework.stereotype.Component;
+
+@Component
 public class StubTicketIssuer implements ITicketIssuer {
 
     @Override

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryAdminRepository.java
@@ -1,0 +1,45 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Domain.Admin.Admin;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+
+/**
+ * In-memory {@link IAdminRepository} for V1.
+ *
+ * <p>Lets Spring wire SystemAdminService. A future JPA-backed adapter
+ * replaces this class without touching the application layer.
+ */
+@Repository
+public class MemoryAdminRepository implements IAdminRepository {
+
+    private final Map<Integer, Admin> adminsById = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Admin admin) {
+        adminsById.put(admin.getId(), admin);
+    }
+
+    @Override
+    public Admin findById(int adminId) {
+        return adminsById.get(adminId);
+    }
+
+    @Override
+    public Admin findByUsername(String username) {
+        if (username == null) return null;
+        for (Admin a : adminsById.values()) {
+            if (username.equals(a.getUsername())) return a;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean existsAny() {
+        return !adminsById.isEmpty();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryConversationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryConversationRepository.java
@@ -1,0 +1,92 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Domain.messaging.Conversation;
+import com.ticketing.system.Core.Domain.messaging.ConversationStatus;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
+import com.ticketing.system.Core.Domain.messaging.ParticipantType;
+
+/**
+ * In-memory {@link IConversationRepository} for V1. Lets Spring wire
+ * MessagingService.
+ *
+ * <p>{@code countUnreadForMember} requires per-message read tracking that
+ * the {@code Conversation} aggregate doesn't yet expose at this granularity
+ * — returning 0 is a safe placeholder that matches the "no unread" UX state
+ * until messaging UCs (II.3.10 / II.6.3.x) are implemented for real.
+ */
+@Repository
+public class MemoryConversationRepository implements IConversationRepository {
+
+    private final Map<String, Conversation> conversationsById = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Conversation conversation) {
+        conversationsById.put(conversation.getConversationId(), conversation);
+    }
+
+    @Override
+    public Optional<Conversation> findById(String conversationId) {
+        if (conversationId == null) return Optional.empty();
+        return Optional.ofNullable(conversationsById.get(conversationId));
+    }
+
+    @Override
+    public List<Conversation> findByParticipant(int participantId, ParticipantType participantType) {
+        List<Conversation> result = new ArrayList<>();
+        for (Conversation c : conversationsById.values()) {
+            boolean asInitiator = c.getInitiatorId() == participantId
+                    && c.getInitiatorType() == participantType;
+            boolean asCounterparty = c.getCounterpartyId() == participantId
+                    && c.getCounterpartyType() == participantType;
+            if (asInitiator || asCounterparty) result.add(c);
+        }
+        return result;
+    }
+
+    @Override
+    public List<Conversation> findByType(ConversationType type) {
+        List<Conversation> result = new ArrayList<>();
+        for (Conversation c : conversationsById.values()) {
+            if (c.getType() == type) result.add(c);
+        }
+        return result;
+    }
+
+    @Override
+    public List<Conversation> findByCompanyAsCounterparty(int companyId) {
+        List<Conversation> result = new ArrayList<>();
+        for (Conversation c : conversationsById.values()) {
+            if (c.getCounterpartyType() == ParticipantType.COMPANY
+                    && c.getCounterpartyId() == companyId) {
+                result.add(c);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public int countUnreadForMember(int memberId) {
+        // Per-message unread tracking not exposed by Conversation yet. Return
+        // 0 as a placeholder so the inbox badge renders cleanly until the
+        // messaging UCs are implemented.
+        return 0;
+    }
+
+    @Override
+    public List<Conversation> findByTypeAndStatus(ConversationType type, ConversationStatus status) {
+        List<Conversation> result = new ArrayList<>();
+        for (Conversation c : conversationsById.values()) {
+            if (c.getType() == type && c.getStatus() == status) result.add(c);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryEventRepository.java
@@ -13,6 +13,10 @@ import com.ticketing.system.Core.Domain.events.EventCategory;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 
+import org.springframework.stereotype.Repository;
+
+
+@Repository
 public class MemoryEventRepository implements IEventRepository {
 
     private final ConcurrentHashMap<Integer, Event> events = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryNotificationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryNotificationRepository.java
@@ -9,6 +9,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.stereotype.Repository;
+
+
+@Repository
 public class MemoryNotificationRepository implements INotificationRepository {
     private final Map<String, Notification> storage = new HashMap<>();
     

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryOrderReceiptRepository.java
@@ -1,0 +1,63 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+/**
+ * In-memory {@link IOrderReceiptRepository} for V1. Lets Spring wire
+ * CheckoutService / MemberAccountService / SystemAdminService.
+ *
+ * <p>Receipts are keyed by their {@code receiptId} converted to String —
+ * the interface signatures use String keys throughout. UC-31's
+ * filter/page/size global query throws until real admin reporting is built.
+ */
+@Repository
+public class MemoryOrderReceiptRepository implements IOrderReceiptRepository {
+
+    private final Map<String, OrderReceipt> receiptsById = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(OrderReceipt orderReceipt) {
+        receiptsById.put(String.valueOf(orderReceipt.getId()), orderReceipt);
+    }
+
+    @Override
+    public Optional<OrderReceipt> findById(String orderReceiptId) {
+        if (orderReceiptId == null) return Optional.empty();
+        return Optional.ofNullable(receiptsById.get(orderReceiptId));
+    }
+
+    @Override
+    public List<OrderReceipt> findByHolderUserId(int holderUserId) {
+        Integer target = holderUserId;
+        List<OrderReceipt> result = new ArrayList<>();
+        for (OrderReceipt r : receiptsById.values()) {
+            if (target.equals(r.getUserid())) result.add(r);
+        }
+        return result;
+    }
+
+    @Override
+    public List<OrderReceipt> findByEventIds(List<String> eventIds) {
+        // OrderReceipt's eventId field exists but is currently always zero
+        // (not set in the constructor). This is a UC-22 follow-up; for now,
+        // returning empty is a safe stub that the company-sales acceptance
+        // tests already tolerate.
+        return List.of();
+    }
+
+    @Override
+    public List<OrderReceipt> findGlobal(GlobalHistoryFiltersDTO filters, int page, int size) {
+        throw new UnsupportedOperationException(
+                "UC-31 admin global history requires real filter logic — not yet implemented");
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryProductionCompanyRepository.java
@@ -1,0 +1,77 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Domain.company.CompanyStatus;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+
+/**
+ * In-memory {@link IProductionCompanyRepository} for V1. Lets Spring wire
+ * CatalogService / CompanyManagementService / EventManagementService.
+ */
+@Repository
+public class MemoryProductionCompanyRepository implements IProductionCompanyRepository {
+
+    private final Map<Integer, ProductionCompany> companiesById = new ConcurrentHashMap<>();
+    private final AtomicInteger idSequence = new AtomicInteger(1);
+
+    @Override
+    public void save(ProductionCompany company) {
+        companiesById.put(company.getCompanyId(), company);
+    }
+
+    @Override
+    public void updateCompany(ProductionCompany company) {
+        companiesById.put(company.getCompanyId(), company);
+    }
+
+    @Override
+    public ProductionCompany getCompanyById(int companyId) {
+        return companiesById.get(companyId);
+    }
+
+    @Override
+    public Optional<ProductionCompany> findByName(String name) {
+        if (name == null) return Optional.empty();
+        for (ProductionCompany c : companiesById.values()) {
+            if (name.equals(c.getName())) return Optional.of(c);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return findByName(name).isPresent();
+    }
+
+    @Override
+    public List<ProductionCompany> findActive() {
+        List<ProductionCompany> result = new ArrayList<>();
+        for (ProductionCompany c : companiesById.values()) {
+            if (c.getStatus() == CompanyStatus.ACTIVE) result.add(c);
+        }
+        return result;
+    }
+
+    @Override
+    public List<ProductionCompany> findByFounder(int founderUserId) {
+        List<ProductionCompany> result = new ArrayList<>();
+        for (ProductionCompany c : companiesById.values()) {
+            if (c.getFounderId() == founderUserId) result.add(c);
+        }
+        return result;
+    }
+
+    @Override
+    public int nextId() {
+        return idSequence.getAndIncrement();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryTicketRepository.java
@@ -1,0 +1,114 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+
+/**
+ * In-memory {@link ITicketRepository} for V1. Lets Spring wire
+ * CatalogService / CheckoutService / EventManagementService /
+ * MemberAccountService.
+ *
+ * <p>Note: the interface mixes {@code int} (findById, holderUserId) and
+ * {@code String} (findByEventId, findByOrderReceiptId) keys — for the
+ * String-keyed methods we parse to int where possible and throw on the
+ * orderReceiptId join (Ticket has no orderReceiptId field yet — UC-22 work).
+ */
+@Repository
+public class MemoryTicketRepository implements ITicketRepository {
+
+    private final Map<Integer, Ticket> ticketsById = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean save(Ticket ticket) {
+        ticketsById.put(ticket.getId(), ticket);
+        return true;
+    }
+
+    @Override
+    public Ticket findById(int ticketId) {
+        return ticketsById.get(ticketId);
+    }
+
+    @Override
+    public List<Ticket> findByEventId(String eventId) {
+        int target;
+        try {
+            target = Integer.parseInt(eventId);
+        } catch (NumberFormatException e) {
+            return List.of();
+        }
+        List<Ticket> result = new ArrayList<>();
+        for (Ticket t : ticketsById.values()) {
+            if (t.getEventId() == target) result.add(t);
+        }
+        return result;
+    }
+
+    @Override
+    public List<Ticket> findAvailableInZone(String eventId, String zoneId, int quantity) {
+        int eventTarget;
+        int zoneTarget;
+        try {
+            eventTarget = Integer.parseInt(eventId);
+            zoneTarget = Integer.parseInt(zoneId);
+        } catch (NumberFormatException e) {
+            return List.of();
+        }
+        List<Ticket> result = new ArrayList<>();
+        for (Ticket t : ticketsById.values()) {
+            if (t.getEventId() == eventTarget
+                    && t.getZoneId() == zoneTarget
+                    && quantity > result.size()) {
+                result.add(t);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public int countAvailableInZone(String eventId, String zoneId) {
+        int eventTarget;
+        int zoneTarget;
+        try {
+            eventTarget = Integer.parseInt(eventId);
+            zoneTarget = Integer.parseInt(zoneId);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+        int count = 0;
+        for (Ticket t : ticketsById.values()) {
+            if (t.getEventId() == eventTarget && t.getZoneId() == zoneTarget) count++;
+        }
+        return count;
+    }
+
+    @Override
+    public List<Ticket> findByOrderReceiptId(int orderReceiptId) {
+        // Ticket has no orderReceiptId field yet (UC-22 / receipt-join feature).
+        throw new UnsupportedOperationException(
+                "findByOrderReceiptId: Ticket entity needs an orderReceiptId field first");
+    }
+
+    @Override
+    public List<Ticket> findByHolderUserId(int holderUserId) {
+        Integer target = holderUserId;
+        List<Ticket> result = new ArrayList<>();
+        for (Ticket t : ticketsById.values()) {
+            if (target.equals(t.getHolderUserId())) result.add(t);
+        }
+        return result;
+    }
+
+    @Override
+    public void saveAll(List<Ticket> tickets) {
+        if (tickets == null) return;
+        for (Ticket t : tickets) save(t);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/SchedulingConfig.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/SchedulingConfig.java
@@ -1,0 +1,19 @@
+package com.ticketing.system.Infrastructure.scheduling;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Activates Spring's {@code @Scheduled} support in production. The sweeper
+ * component ({@link SessionAndOrderSweeper}) depends on it; without this
+ * annotation the scheduled method would never fire in production.
+ *
+ * <p>Disabled in the {@code test} profile so acceptance tests don't kick
+ * off a real scheduler thread (tests drive the sweep method directly).
+ */
+@Configuration
+@EnableScheduling
+@Profile("!test")
+public class SchedulingConfig {
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
@@ -1,0 +1,139 @@
+package com.ticketing.system.Infrastructure.scheduling;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.users.ISessionRepository;
+import com.ticketing.system.Core.Domain.users.Session;
+
+/**
+ * UC-2 sweeper: scans for expired Sessions and ActiveOrders and releases
+ * the resources they held.
+ *
+ * <p>Runs on a fixed delay (default 60s; override via
+ * {@code sweeper.fixed-delay-ms}). Two passes per tick:
+ *
+ * <ol>
+ *   <li><b>Expired sessions</b> — sessions past their {@code expiresAt}.
+ *     For Guest sessions the attached cart is deleted and its tickets are
+ *     released to inventory. For Member sessions the row is deleted but the
+ *     cart (keyed by {@code userId}) is preserved per D9a — it will be
+ *     re-attached to the next Member session on login.</li>
+ *   <li><b>Expired carts</b> — ActiveOrders whose {@link CartLineItem} TTL
+ *     (10 min from {@code addedAt}) has elapsed. The cart is unusable
+ *     regardless of owner, so it's deleted and its tickets are released.
+ *     This is the only place a Member's cart is destroyed without an
+ *     explicit logout/end-session call.</li>
+ * </ol>
+ *
+ * <p>The sweep is exposed as a package-private method so tests can drive it
+ * directly with a controllable {@link Clock} (no need to wait for the
+ * {@code @Scheduled} cadence).
+ */
+@Component
+public class SessionAndOrderSweeper {
+
+    private static final Logger log = LoggerFactory.getLogger(SessionAndOrderSweeper.class);
+
+    private final ISessionRepository sessionRepository;
+    private final IActiveOrderRepository activeOrderRepository;
+    private final IEventRepository eventRepository;
+    private final Clock clock;
+
+    public SessionAndOrderSweeper(
+            ISessionRepository sessionRepository,
+            IActiveOrderRepository activeOrderRepository,
+            IEventRepository eventRepository,
+            Clock clock) {
+        this.sessionRepository = sessionRepository;
+        this.activeOrderRepository = activeOrderRepository;
+        this.eventRepository = eventRepository;
+        this.clock = clock;
+    }
+
+    @Scheduled(fixedDelayString = "${sweeper.fixed-delay-ms:60000}")
+    public void sweep() {
+        Instant now = clock.instant();
+        int sessionsCleaned = sweepExpiredSessions(now);
+        int ordersCleaned = sweepExpiredOrders();
+        if (sessionsCleaned > 0 || ordersCleaned > 0) {
+            log.info("sweeper tick: {} session(s), {} order(s) cleaned up",
+                    sessionsCleaned, ordersCleaned);
+        }
+    }
+
+    /**
+     * Returns the count of sessions deleted. Public so unit tests can drive
+     * each pass independently of the {@code @Scheduled} cadence.
+     */
+    public int sweepExpiredSessions(Instant now) {
+        List<Session> expired = sessionRepository.findExpiredBefore(now);
+        for (Session session : expired) {
+            cleanUpAttachedCart(session);
+            sessionRepository.delete(session.getSessionId());
+        }
+        return expired.size();
+    }
+
+    /** Returns the count of orders deleted. Public for the same reason. */
+    public int sweepExpiredOrders() {
+        List<ActiveOrder> expired = activeOrderRepository.findExpired();
+        for (ActiveOrder order : expired) {
+            releaseTicketsToInventory(order);
+            activeOrderRepository.delete(order);
+        }
+        return expired.size();
+    }
+
+    /**
+     * D9a-aware cart cleanup. Guest sessions cascade-delete the cart
+     * (Guest identity = the session itself). Member sessions leave the
+     * cart alone; it lives on by userId until logout-restoration or its
+     * own line-item expiry sweep.
+     */
+    private void cleanUpAttachedCart(Session session) {
+        if (session.isMember()) return;
+        Optional<ActiveOrder> cartOpt = activeOrderRepository.getBySessionId(session.getSessionId());
+        if (cartOpt.isPresent()) {
+            releaseTicketsToInventory(cartOpt.get());
+            activeOrderRepository.delete(cartOpt.get());
+        }
+    }
+
+    /**
+     * Groups the cart's line items by (eventId, zoneId) and releases the
+     * aggregated quantity per zone via {@link Event#releaseTickets(int, int)},
+     * matching what {@code CheckoutService.returnTicketsToStock} does on
+     * failed checkout.
+     */
+    private void releaseTicketsToInventory(ActiveOrder order) {
+        Map<Integer, Map<Integer, Integer>> countByEventThenZone = new HashMap<>();
+        for (CartLineItem item : order.getItems()) {
+            countByEventThenZone
+                    .computeIfAbsent(item.geteventId(), k -> new HashMap<>())
+                    .merge(item.getzoneId(), 1, Integer::sum);
+        }
+        for (Map.Entry<Integer, Map<Integer, Integer>> eventEntry : countByEventThenZone.entrySet()) {
+            Event event = eventRepository.findById(eventEntry.getKey());
+            if (event == null) continue;
+            for (Map.Entry<Integer, Integer> zoneEntry : eventEntry.getValue().entrySet()) {
+                event.releaseTickets(zoneEntry.getKey(), zoneEntry.getValue());
+            }
+            eventRepository.save(event);
+        }
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
@@ -1,0 +1,219 @@
+package com.ticketing.system.unit.infrastructure.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.users.ISessionRepository;
+import com.ticketing.system.Core.Domain.users.Session;
+import com.ticketing.system.Infrastructure.scheduling.SessionAndOrderSweeper;
+
+class SessionAndOrderSweeperTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    private ISessionRepository sessionRepo;
+    private IActiveOrderRepository orderRepo;
+    private IEventRepository eventRepo;
+    private Clock fixedClock;
+    private SessionAndOrderSweeper sweeper;
+
+    @BeforeEach
+    void setUp() {
+        sessionRepo = mock(ISessionRepository.class);
+        orderRepo = mock(IActiveOrderRepository.class);
+        eventRepo = mock(IEventRepository.class);
+        fixedClock = Clock.fixed(T0, ZoneOffset.UTC);
+        sweeper = new SessionAndOrderSweeper(sessionRepo, orderRepo, eventRepo, fixedClock);
+
+        // Defaults: nothing expired.
+        when(sessionRepo.findExpiredBefore(any())).thenReturn(List.of());
+        when(orderRepo.findExpired()).thenReturn(List.of());
+        when(orderRepo.getBySessionId(any())).thenReturn(Optional.empty());
+    }
+
+    // ---------------------------------------------------------------------
+    // Empty / no-op sweeps
+    // ---------------------------------------------------------------------
+
+    @Test
+    void emptySweep_noWorkDone() {
+        sweeper.sweep();
+
+        verify(sessionRepo).findExpiredBefore(T0);
+        verify(orderRepo).findExpired();
+        verify(sessionRepo, never()).delete(any());
+        verify(orderRepo, never()).delete(any());
+    }
+
+    // ---------------------------------------------------------------------
+    // Session sweep — Guest cleanup with cart
+    // ---------------------------------------------------------------------
+
+    @Test
+    void expiredGuestSessionWithCart_deletesSessionAndCart_releasesTickets() {
+        Session guest = new Session("guest-sid", null, T0.minusSeconds(7200), T0.minusSeconds(60));
+        when(sessionRepo.findExpiredBefore(T0)).thenReturn(List.of(guest));
+
+        ActiveOrder cart = ActiveOrder.forGuest("guest-sid");
+        cart.addReservation(1, 10, 2, 50.0, LocalDateTime.now());  // 2 tickets, event=1, zone=10
+        when(orderRepo.getBySessionId("guest-sid")).thenReturn(Optional.of(cart));
+
+        Event event = mock(Event.class);
+        when(eventRepo.findById(1)).thenReturn(event);
+
+        int cleaned = sweeper.sweepExpiredSessions(T0);
+
+        assertEquals(1, cleaned);
+        verify(orderRepo).delete(cart);
+        verify(sessionRepo).delete("guest-sid");
+        verify(event).releaseTickets(10, 2);     // 2 tickets in zone 10 released
+        verify(eventRepo).save(event);
+    }
+
+    @Test
+    void expiredGuestSessionWithoutCart_deletesSessionOnly() {
+        Session guest = new Session("orphan-sid", null, T0.minusSeconds(7200), T0.minusSeconds(60));
+        when(sessionRepo.findExpiredBefore(T0)).thenReturn(List.of(guest));
+        when(orderRepo.getBySessionId("orphan-sid")).thenReturn(Optional.empty());
+
+        sweeper.sweepExpiredSessions(T0);
+
+        verify(sessionRepo).delete("orphan-sid");
+        verify(orderRepo, never()).delete(any());
+        verify(eventRepo, never()).save(any());
+    }
+
+    // ---------------------------------------------------------------------
+    // Session sweep — Member cleanup (D9a: cart preserved)
+    // ---------------------------------------------------------------------
+
+    @Test
+    void expiredMemberSession_deletesSession_butPreservesCart_D9a() {
+        Session member = new Session("member-sid", 5, T0.minusSeconds(86400 + 60),
+                T0.minusSeconds(60));
+        when(sessionRepo.findExpiredBefore(T0)).thenReturn(List.of(member));
+
+        sweeper.sweepExpiredSessions(T0);
+
+        verify(sessionRepo).delete("member-sid");
+        // Member's cart MUST survive the session expiry — restored on next login.
+        verify(orderRepo, never()).getBySessionId(any());
+        verify(orderRepo, never()).delete(any());
+        verify(eventRepo, never()).save(any());
+    }
+
+    // ---------------------------------------------------------------------
+    // Cart sweep — line-item expiry deletes cart regardless of owner
+    // ---------------------------------------------------------------------
+
+    @Test
+    void cartWithExpiredItems_deletedAndTicketsReleased() {
+        ActiveOrder expiredCart = ActiveOrder.forMember(5, "sid-1");
+        expiredCart.addReservation(2, 20, 3, 30.0, LocalDateTime.now());
+        when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
+
+        Event event = mock(Event.class);
+        when(eventRepo.findById(2)).thenReturn(event);
+
+        int cleaned = sweeper.sweepExpiredOrders();
+
+        assertEquals(1, cleaned);
+        verify(orderRepo).delete(expiredCart);
+        verify(event).releaseTickets(20, 3);
+        verify(eventRepo).save(event);
+    }
+
+    @Test
+    void cartWithExpiredItemsAcrossMultipleEvents_releasesPerZoneAggregated() {
+        ActiveOrder cart = ActiveOrder.forGuest("sid-multi");
+        cart.addReservation(1, 10, 2, 50.0, LocalDateTime.now());   // 2 in event=1 zone=10
+        cart.addReservation(1, 20, 1, 75.0, LocalDateTime.now());   // 1 in event=1 zone=20
+        cart.addReservation(2, 30, 1, 100.0, LocalDateTime.now());  // 1 in event=2 zone=30
+        when(orderRepo.findExpired()).thenReturn(List.of(cart));
+
+        Event event1 = mock(Event.class);
+        Event event2 = mock(Event.class);
+        when(eventRepo.findById(1)).thenReturn(event1);
+        when(eventRepo.findById(2)).thenReturn(event2);
+
+        sweeper.sweepExpiredOrders();
+
+        verify(event1).releaseTickets(10, 2);
+        verify(event1).releaseTickets(20, 1);
+        verify(event2).releaseTickets(30, 1);
+        verify(eventRepo, times(1)).save(event1);  // saved once after both zones updated
+        verify(eventRepo, times(1)).save(event2);
+        verify(orderRepo).delete(cart);
+    }
+
+    @Test
+    void cartWithEventMissingFromRepo_skipsReleaseGracefully() {
+        ActiveOrder cart = ActiveOrder.forGuest("sid-1");
+        cart.addReservation(99, 10, 1, 25.0, LocalDateTime.now());
+        when(orderRepo.findExpired()).thenReturn(List.of(cart));
+        when(eventRepo.findById(99)).thenReturn(null);  // event vanished
+
+        sweeper.sweepExpiredOrders();
+
+        // Cart is still deleted even though the inventory release was a no-op.
+        verify(orderRepo).delete(cart);
+        verify(eventRepo, never()).save(any());
+    }
+
+    // ---------------------------------------------------------------------
+    // Combined sweep — both passes
+    // ---------------------------------------------------------------------
+
+    @Test
+    void combinedSweep_handlesSessionsAndOrders_logsAggregate() {
+        Session guest = new Session("sid-g", null, T0.minusSeconds(3600), T0.minusSeconds(60));
+        when(sessionRepo.findExpiredBefore(T0)).thenReturn(List.of(guest));
+        when(orderRepo.getBySessionId("sid-g")).thenReturn(Optional.empty());
+
+        ActiveOrder expiredCart = ActiveOrder.forMember(5, "sid-m");
+        expiredCart.addReservation(1, 10, 1, 30.0, LocalDateTime.now());
+        when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
+
+        Event event = mock(Event.class);
+        when(eventRepo.findById(1)).thenReturn(event);
+
+        sweeper.sweep();  // entry point — drives both passes
+
+        verify(sessionRepo).delete("sid-g");
+        verify(orderRepo).delete(expiredCart);
+        verify(event).releaseTickets(10, 1);
+    }
+
+    @Test
+    void emptyOrderItems_releaseTicketsIsNoOp() {
+        // Defensive: an ActiveOrder with no line items shouldn't blow up.
+        ActiveOrder emptyCart = ActiveOrder.forGuest("sid-empty");
+        when(orderRepo.findExpired()).thenReturn(List.of(emptyCart));
+
+        sweeper.sweepExpiredOrders();
+
+        verify(orderRepo).delete(emptyCart);
+        verify(eventRepo, never()).findById(anyInt());
+        verify(eventRepo, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary

Closes issue #21 (UC-2: Expire Temporary User Access) with a scheduled sweeper that releases sessions and carts past their TTL. Includes a prerequisite Spring DI cleanup that the sweeper depends on.

## What landed (3 commits)

### 1. `feat(infra): in-memory adapter stubs for the 5 missing aggregates`
Adds `Memory{Admin,Conversation,OrderReceipt,ProductionCompany,Ticket}Repository` so Spring can wire `CatalogService`, `CheckoutService`, `CompanyManagementService`, `EventManagementService`, `MemberAccountService`, `MessagingService`, and `SystemAdminService` end to end. Each adapter implements basic CRUD; admin-side filters that need real domain logic (UC-31 global history, UC-22 receipt-by-eventIds, per-message unread counts) throw or return safe defaults until those UCs ship.

### 2. `chore(spring): annotate beans across services / repos / adapters`
Adds the missing `@Service` / `@Repository` / `@Component` stereotypes:
- 9 services gain `@Service` (`AuthenticationService` already had it).
- 2 repos gain `@Repository` (`MemoryEventRepository`, `MemoryNotificationRepository`).
- 3 external adapters gain `@Component` (`StubPaymentGateway`, `StubTicketIssuer`, `InMemoryNotificationService`).

### 3. `feat(UC-2): SessionAndOrderSweeper for expired-resource cleanup`
Two passes per scheduled tick (fixedDelay 60s, configurable via `sweeper.fixed-delay-ms`):

1. **Expired sessions** — `sessionRepository.findExpiredBefore(now)`. For Guests: cascade-delete the attached cart, release its tickets back to inventory via `Event.releaseTickets`. For Members: delete the session row but **preserve the cart** (D9a — it lives by `userId` until next login restoration).
2. **Expired carts** — `activeOrderRepository.findExpired()` returns carts whose `CartLineItem` TTL (10 min from `addedAt`) has elapsed. The cart is unusable regardless of owner, so it's deleted and its tickets are released. This is the only path that destroys a Member cart outside an explicit logout.

`SchedulingConfig` (`@Configuration @EnableScheduling @Profile("!test")`) activates Spring's scheduling in prod. Disabled in the `test` profile so acceptance tests don't spawn a real scheduler thread — tests drive the sweep method directly with a fixed `Clock`.

## Test status

- **461 tests, 0 failures, 0 errors, 131 skipped.**
- 9 new unit tests for the sweeper covering: empty sweep, Guest+cart cleanup, Guest-without-cart, D9a Member preservation, cart-item-expiry deletion, multi-event aggregation, missing-event graceful fallback, combined sweep, and empty-cart defensive case.

## UC-2 acceptance criteria

- [x] Expired Active Order is cancelled and tickets released to inventory.
- [x] Access that is still valid is not revoked.
- ⏸ Expired Lottery Purchase Code revoked — out of scope; lottery is model-only per project decision.

## Notes for reviewers

- The Spring annotation backfill (commits 1+2) is bundled because the sweeper depends on `ISessionRepository`, `IActiveOrderRepository`, `IEventRepository`, and `Clock` being injectable. Could be split into a separate PR if preferred, but they're cohesive enough that bundling keeps the history readable.
- `CartLineItem.isExpired()` uses `LocalDateTime.now()` directly (not the injected `Clock`). The sweeper's session sweep is fully time-deterministic via `Clock`; the cart-item sweep relies on real wall-clock time. Not blocking, but worth noting for future testability.
- `@Profile("!test")` on `SchedulingConfig` is deliberate. Acceptance tests load the full Spring context but should not see scheduled work firing on its own.

Closes #21
Refs #181