### PR TITLE
Error recovery

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -1,10 +1,14 @@
 package com.ticketing.system.Core.Application.services;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.dto.BuyerContextDTO;

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -3,12 +3,9 @@ package com.ticketing.system.Core.Application.services;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.dto.BuyerContextDTO;
@@ -21,7 +18,6 @@ import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.InventoryZone;
-
 
 @Service
 @Slf4j

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -1,5 +1,4 @@
 package com.ticketing.system.Core.Application.services;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +17,7 @@ import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.InventoryZone;
+
 
 @Service
 @Slf4j

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -482,68 +482,75 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
         }
 
         payButton.setEnabled(false);
-payButton.setText("Processing…");
+        payButton.setText("Processing…");
 
-String idempotencyKey = UUID.randomUUID().toString();
-String paymentMethodToken = "tok_" + cardNumber.getValue().replaceAll("\\s+", "");
-String currency = "USD";
+        String idempotencyKey = UUID.randomUUID().toString();
+        String paymentMethodToken = "tok_" + cardNumber.getValue().replaceAll("\\s+", "");
+        String currency = "USD";
 
-try {
-    CheckoutResultDTO result;
+        try {
+            CheckoutResultDTO result;
 
-    if (isMember) {
-        result = checkoutService.checkoutMember(
-                memberToken,
-                idempotencyKey,
-                currency,
-                paymentMethodToken);
-    } else {
-        result = checkoutService.checkoutGuest(
-                sessionId,
-                guestEmail.getValue().trim(),
-                idempotencyKey,
-                currency,
-                paymentMethodToken,
-                guestAge.getValue());
+            if (isMember) {
+                result = checkoutService.checkoutMember(
+                        memberToken,
+                        idempotencyKey,
+                        currency,
+                        paymentMethodToken);
+            } else {
+                result = checkoutService.checkoutGuest(
+                        sessionId,
+                        guestEmail.getValue().trim(),
+                        idempotencyKey,
+                        currency,
+                        paymentMethodToken,
+                        guestAge.getValue());
+            }
+
+            Toasts.success("Payment successful — "
+                    + formatCents(Math.round(result.totalCharged() * 100))
+                    + " charged.");
+            UI.getCurrent().navigate("order/" + result.orderReceiptId());
+
+        } catch (RuntimeException e) {
+            log.error("Checkout failed for {} user", isMember ? "member" : "guest", e);
+            handlePaymentError(e);
+        }
     }
 
-    Toasts.success("Payment successful — "
-            + formatCents(Math.round(result.totalCharged() * 100))
-            + " charged.");
-    UI.getCurrent().navigate("order/" + result.orderReceiptId());
-
-} catch (RuntimeException e) {
-    log.error("Checkout failed for {} user", isMember ? "member" : "guest", e);
-    handlePaymentError(e);
-}
-    }
+    // Maps a checkout failure to a clear, actionable message + recovery navigation (SLR.3.2).
+    // CheckoutService re-wraps failures as RuntimeException(cause), so we unwrap one level.
+    // Today only PaymentGatewayException is surfaced as a distinct type; the PolicyViolation /
+    // InsufficientInventory / ConcurrentReservation / Session- & ActiveOrderExpired branches are
+    // forward-looking — they activate once checkout/domain throw those typed exceptions (until
+    // then those failures arrive as IllegalStateException and hit the generic branch below).
     private void handlePaymentError(RuntimeException ex) {
-    Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+        Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
 
-    if (cause instanceof PolicyViolationException pve) {
-        Toasts.failure("Purchase not allowed: " + pve.getMessage());
-    } else if (cause instanceof PaymentGatewayException) {
-        Toasts.failure("Payment declined. Please check your card details and try again.");
-    } else if (cause instanceof InsufficientInventoryException) {
-        Toasts.failure("Some tickets are no longer available. Please review your cart.");
-        UI.getCurrent().navigate("cart");
-        return;
-    } else if (cause instanceof ConcurrentReservationException) {
-        Toasts.warn("Your cart was modified by another session. Please review and try again.");
-    } else if (cause instanceof SessionExpiredException || cause instanceof ActiveOrderExpiredException) {
-        Toasts.failure("Your session expired. Please start a new order.");
-        UI.getCurrent().navigate("browse");
-        return;
-    } else {
-        Toasts.failure("Checkout failed — your card was not charged. Please try again.");
+        if (cause instanceof PolicyViolationException pve) {
+            Toasts.failure("Purchase not allowed: " + pve.getMessage());
+        } else if (cause instanceof PaymentGatewayException) {
+            Toasts.failure("Payment declined. Please check your card details and try again.");
+        } else if (cause instanceof InsufficientInventoryException) {
+            Toasts.failure("Some tickets are no longer available. Please review your cart.");
+            UI.getCurrent().navigate("cart");
+            return;
+        } else if (cause instanceof ConcurrentReservationException) {
+            Toasts.warn("Your cart was modified by another session. Please review and try again.");
+        } else if (cause instanceof SessionExpiredException || cause instanceof ActiveOrderExpiredException) {
+            Toasts.failure("Your session expired. Please start a new order.");
+            UI.getCurrent().navigate("browse");
+            return;
+        } else {
+            Toasts.failure("Checkout couldn't be completed — no charge remains on your card. Please try again.");
+        }
+        resetPayButton();
     }
-    resetPayButton();
-}
 
-private void resetPayButton() {
-    payButton.setEnabled(totalCents > 0);
-    payButton.setText("Pay " + formatCents(totalCents));
-}
+    private void resetPayButton() {
+        payButton.setEnabled(totalCents > 0);
+        payButton.setText("Pay " + formatCents(totalCents));
+    }
 
     private static String formatCents(long cents) {
         long abs  = Math.abs(cents);

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -15,7 +15,14 @@ import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Core.Domain.exceptions.ActiveOrderExpiredException;
+import com.ticketing.system.Core.Domain.exceptions.ConcurrentReservationException;
+import com.ticketing.system.Core.Domain.exceptions.InsufficientInventoryException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
+import com.ticketing.system.Core.Domain.exceptions.SessionExpiredException;
 import com.ticketing.system.Presentation.session.AuthSession;
+import java.util.UUID;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.DetachEvent;
@@ -37,7 +44,6 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 
-import java.util.UUID;
 
 /**
  * Checkout view — wired to real CheckoutService and ReservationService.
@@ -269,9 +275,10 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
                     "function tick(){" +
                     "  const s=Math.max(0,Math.floor((end-Date.now())/1000));" +
                     "  t.textContent=pad(Math.floor(s/60))+':'+pad(s%60);" +
-                    "  if(s>0) setTimeout(tick,1000);" +
-                    "}" +
-                    "tick();",
+                               "  if (s > 0) { setTimeout(tick, 1000); }" +
+            "  else { document.querySelectorAll('vaadin-button.bz-pay-btn').forEach(b => b.setAttribute('disabled', '')); }" +
+            "}" +
+            "tick();",
                     endMs);
         }
     }
@@ -421,6 +428,7 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
         col.add(Lk.divider());
 
         payButton = new Button("Pay " + formatCents(totalCents), e -> attemptPay());
+        payButton.addClassName("bz-pay-btn");
         payButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_LARGE);
         payButton.setWidthFull();
         payButton.addClickShortcut(Key.ENTER);
@@ -473,39 +481,69 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
             return;
         }
 
-        String idempotencyKey = UUID.randomUUID().toString();
-        String paymentMethodToken = "tok_" + cardNumber.getValue().replaceAll("\\s+", "");
-        String currency = "USD";
+        payButton.setEnabled(false);
+payButton.setText("Processing…");
 
-        try {
-            CheckoutResultDTO result;
+String idempotencyKey = UUID.randomUUID().toString();
+String paymentMethodToken = "tok_" + cardNumber.getValue().replaceAll("\\s+", "");
+String currency = "USD";
 
-            if (isMember) {
-                result = checkoutService.checkoutMember(
-                        memberToken,
-                        idempotencyKey,
-                        currency,
-                        paymentMethodToken);
-            } else {
-                result = checkoutService.checkoutGuest(
-                        sessionId,
-                        guestEmail.getValue().trim(),
-                        idempotencyKey,
-                        currency,
-                        paymentMethodToken,
-                        guestAge.getValue());
-            }
+try {
+    CheckoutResultDTO result;
 
-            Toasts.success("Payment successful — "
-                    + formatCents(Math.round(result.totalCharged() * 100))
-                    + " charged.");
-            UI.getCurrent().navigate("order/" + result.orderReceiptId());
-
-        } catch (RuntimeException e) {
-            log.error("Checkout failed for {} user", isMember ? "member" : "guest", e);
-            Toasts.failure("Payment could not be completed. Please try again or contact support.");
-        }
+    if (isMember) {
+        result = checkoutService.checkoutMember(
+                memberToken,
+                idempotencyKey,
+                currency,
+                paymentMethodToken);
+    } else {
+        result = checkoutService.checkoutGuest(
+                sessionId,
+                guestEmail.getValue().trim(),
+                idempotencyKey,
+                currency,
+                paymentMethodToken,
+                guestAge.getValue());
     }
+
+    Toasts.success("Payment successful — "
+            + formatCents(Math.round(result.totalCharged() * 100))
+            + " charged.");
+    UI.getCurrent().navigate("order/" + result.orderReceiptId());
+
+} catch (RuntimeException e) {
+    log.error("Checkout failed for {} user", isMember ? "member" : "guest", e);
+    handlePaymentError(e);
+}
+    }
+    private void handlePaymentError(RuntimeException ex) {
+    Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
+
+    if (cause instanceof PolicyViolationException pve) {
+        Toasts.failure("Purchase not allowed: " + pve.getMessage());
+    } else if (cause instanceof PaymentGatewayException) {
+        Toasts.failure("Payment declined. Please check your card details and try again.");
+    } else if (cause instanceof InsufficientInventoryException) {
+        Toasts.failure("Some tickets are no longer available. Please review your cart.");
+        UI.getCurrent().navigate("cart");
+        return;
+    } else if (cause instanceof ConcurrentReservationException) {
+        Toasts.warn("Your cart was modified by another session. Please review and try again.");
+    } else if (cause instanceof SessionExpiredException || cause instanceof ActiveOrderExpiredException) {
+        Toasts.failure("Your session expired. Please start a new order.");
+        UI.getCurrent().navigate("browse");
+        return;
+    } else {
+        Toasts.failure("Checkout failed — your card was not charged. Please try again.");
+    }
+    resetPayButton();
+}
+
+private void resetPayButton() {
+    payButton.setEnabled(totalCents > 0);
+    payButton.setText("Pay " + formatCents(totalCents));
+}
 
     private static String formatCents(long cents) {
         long abs  = Math.abs(cents);


### PR DESCRIPTION
## Implement Error Recovery UX (SLR.3.2)

Adds clear, actionable error feedback to `CheckoutView`'s payment flow.

**What this PR does**
- `handlePaymentError()` maps a checkout failure to a user-facing message and recovery navigation — → cart on `InsufficientInventoryException`, → browse on `SessionExpired` / `ActiveOrderExpired`.
- The Pay button is disabled and shows "Processing…" during the call, and is reset on recoverable errors; the hold-timer countdown also disables it on expiry.

**Honest scope note**
`CheckoutService` re-wraps failures as `RuntimeException(cause)`, so the handler unwraps one cause level. Today only `PaymentGatewayException` is surfaced as a distinct type; the `PolicyViolation` / `InsufficientInventory` / `ConcurrentReservation` / `Session-` & `ActiveOrderExpired` branches are **forward-looking** — they activate once the checkout/domain layer throws those typed exceptions (tracked in #322). Until then those failures show an honest generic message.

Scope: `CheckoutView` only — no `Toasts` or `CheckoutService` changes (those already exist on `dev`).