### PR TITLE
feat(UC-1): Initialize Ticketing Platform (#8)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Core.Application.services;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -10,12 +11,16 @@ import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
 import com.ticketing.system.Core.Application.dto.MarketStateDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.dtoMappers.OrderReceiptMapper;
+import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
+import com.ticketing.system.Core.Domain.Admin.Admin;
 import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Core.Domain.exceptions.MissingDefaultAdminException;
 import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 
@@ -35,6 +40,20 @@ public class SystemAdminService {
     private final IEventRepository eventRepository;
     private final List<IPaymentGateway> paymentGateways;
     private final List<ITicketIssuer> ticketIssuers;
+    private final IPasswordHasher passwordHasher;
+
+    // UC-1 / I.1.4 — default System Admin auto-created when none exists. "admin" is a
+    // recognized admin username (AuthSession.ADMIN_USERNAMES); its password should be
+    // rotated after first login.
+    private static final int    DEFAULT_ADMIN_ID       = 1;
+    private static final String DEFAULT_ADMIN_USERNAME = "admin";
+    private static final String DEFAULT_ADMIN_PASSWORD = "admin";
+
+    // Platform lifecycle state (in-memory for V1). openMarket()/closeMarket() (UC-32, #307)
+    // build on top of this status.
+    private enum PlatformStatus { UNINITIALIZED, READY, OPEN, CLOSED }
+    private volatile PlatformStatus status = PlatformStatus.UNINITIALIZED;
+    private volatile LocalDateTime lastInitializedAt;
 
     public SystemAdminService(
             ISessionManager sessionManager,
@@ -43,7 +62,8 @@ public class SystemAdminService {
             ITicketRepository ticketRepository,
             IEventRepository eventRepository,
             List<IPaymentGateway> paymentGateways,
-            List<ITicketIssuer> ticketIssuers
+            List<ITicketIssuer> ticketIssuers,
+            IPasswordHasher passwordHasher
     ) {
         this.sessionManager = sessionManager;
         this.adminRepository = adminRepository;
@@ -52,16 +72,64 @@ public class SystemAdminService {
         this.eventRepository = eventRepository;
         this.paymentGateways = paymentGateways;
         this.ticketIssuers = ticketIssuers;
+        this.passwordHasher = passwordHasher;
     }
 
-    // UC-1 — invariants + I.1.2 gateway check + I.1.3 issuer check + I.1.4 default-admin.
-    public void initializePlatform() {
-        throw new UnsupportedOperationException("UC-1: not implemented");
+    // UC-1 — I.1.1 invariants + I.1.2 payment-gateway check + I.1.3 issuer check + I.1.4 default-admin.
+    // Brings the platform to a healthy, market-openable state. Idempotent: a second call on an
+    // already-initialized platform is a graceful no-op.
+    public synchronized void initializePlatform() {
+        log.info("Platform initialization requested.");
+
+        // Re-initializing an already-initialized platform is handled gracefully.
+        if (status != PlatformStatus.UNINITIALIZED) {
+            log.info("Platform already initialized (status={}); ignoring re-initialization.", status);
+            return;
+        }
+
+        // I.1.2 — at least one payment service must be reachable.
+        if (paymentGateways.stream().noneMatch(this::isReachable)) {
+            throw new ExternalServiceUnavailableException("no reachable payment service");
+        }
+
+        // I.1.3 — at least one ticket-issuance service must be reachable.
+        if (ticketIssuers.stream().noneMatch(this::isReachable)) {
+            throw new ExternalServiceUnavailableException("no reachable ticket issuance service");
+        }
+
+        // I.1.4 — guarantee at least one System Admin (auto-create a default if none).
+        createDefaultAdminIfMissing();
+
+        this.lastInitializedAt = LocalDateTime.now();
+        this.status = PlatformStatus.READY;
+        log.info("Platform initialized — status READY.");
     }
 
     // UC-1 / I.1.4 — auto-create the default admin if none exists.
     public void createDefaultAdminIfMissing() {
-        throw new UnsupportedOperationException("UC-1 / I.1.4: not implemented");
+        if (adminRepository.existsAny()) {
+            log.info("A System Admin already exists; no default needed.");
+            return;
+        }
+
+        log.warn("No System Admin found — creating default admin '{}'. Rotate its password after first login.",
+                DEFAULT_ADMIN_USERNAME);
+        try {
+            Admin defaultAdmin = new Admin(
+                    DEFAULT_ADMIN_ID,
+                    DEFAULT_ADMIN_USERNAME,
+                    passwordHasher.hash(DEFAULT_ADMIN_PASSWORD),
+                    true);
+            defaultAdmin.checkInvariants();
+            adminRepository.save(defaultAdmin);
+        } catch (RuntimeException e) {
+            throw new MissingDefaultAdminException(e.getMessage());
+        }
+
+        // Confirm the write actually took — a silent persistence failure must fail init.
+        if (!adminRepository.existsAny()) {
+            throw new MissingDefaultAdminException("default admin was not persisted");
+        }
     }
 
     // UC-32 — open the trading market after re-verifying gateways/issuers/admin.
@@ -81,6 +149,35 @@ public class SystemAdminService {
 
 
 
+
+    // *HELPER METHODS* — UC-1 I.1.2/I.1.3 reachability probe (maps to the WSEP `handshake`).
+    // A thrown verification (e.g. a real HTTP adapter timing out) is treated as "unreachable"
+    // so a flaky provider can never crash bootstrap — it just doesn't count toward the quorum.
+    private boolean isReachable(IPaymentGateway gateway) {
+        try {
+            boolean ok = gateway.verifyConnection();
+            if (!ok) {
+                log.warn("Payment gateway '{}' reported unreachable.", gateway.getId());
+            }
+            return ok;
+        } catch (RuntimeException e) {
+            log.warn("Payment gateway '{}' verification failed: {}", gateway.getId(), e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean isReachable(ITicketIssuer issuer) {
+        try {
+            boolean ok = issuer.verifyConnection();
+            if (!ok) {
+                log.warn("Ticket issuer '{}' reported unreachable.", issuer.getId());
+            }
+            return ok;
+        } catch (RuntimeException e) {
+            log.warn("Ticket issuer '{}' verification failed: {}", issuer.getId(), e.getMessage());
+            return false;
+        }
+    }
 
 
 
@@ -116,8 +213,8 @@ public class SystemAdminService {
 
 
 
-    // *HELPER METHODS* for viewGlobalHistory() that normalize and validate the filters, and enforce admin RBAC. 
-    // this method enforces that the event filter is consistent with the company filter (if provided), and that the date range is valid. 
+    // *HELPER METHODS* for viewGlobalHistory() that normalize and validate the filters, and enforce admin RBAC.
+    // this method enforces that the event filter is consistent with the company filter (if provided), and that the date range is valid.
     // It also logs the filters being applied for audit purposes.
     private GlobalHistoryFiltersDTO normalizeGlobalHistoryFilters(GlobalHistoryFiltersDTO filters) {
         // If no filters are provided, return a default filter that matches all receipts.
@@ -139,7 +236,7 @@ public class SystemAdminService {
                     f.toDate());
         }
 
-        // If companyId is provided, we need to ensure that the eventIds filter (if provided) is a subset of the events for that company. 
+        // If companyId is provided, we need to ensure that the eventIds filter (if provided) is a subset of the events for that company.
         // If eventIds is null, we will use all events for that company.
         List<Integer> companyEventIds = eventRepository.findIdsByCompany(f.companyId());
 
@@ -166,7 +263,7 @@ public class SystemAdminService {
                 f.toDate());
     }
 
-   
+
     // *HELPER METHOD* to convert the list of event IDs in the filters to a set for efficient lookup later. Returns null if no event filter is applied.
     private Set<Integer> selectedEventIdsOrNull(GlobalHistoryFiltersDTO filters) {
         if (filters.eventIds() == null) {
@@ -175,10 +272,6 @@ public class SystemAdminService {
         // Convert to set for efficient lookup later.
         return filters.eventIds().stream().collect(Collectors.toSet());
     }
-    
-
-
-
 
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -20,6 +20,7 @@ import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Core.Domain.exceptions.InitializationIntegrityException;
 import com.ticketing.system.Core.Domain.exceptions.MissingDefaultAdminException;
 import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
@@ -27,6 +28,7 @@ import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import lombok.extern.slf4j.Slf4j;
 // Owns platform-bootstrap, market-lifecycle, and global admin queries.
 // UC-1 (Initialize), UC-31 (Global History), UC-32 (Open/Close Market).
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -41,13 +43,13 @@ public class SystemAdminService {
     private final List<IPaymentGateway> paymentGateways;
     private final List<ITicketIssuer> ticketIssuers;
     private final IPasswordHasher passwordHasher;
+    private final SystemIntegrityVerifier integrityVerifier;
 
-    // UC-1 / I.1.4 — default System Admin auto-created when none exists. "admin" is a
-    // recognized admin username (AuthSession.ADMIN_USERNAMES); its password should be
-    // rotated after first login.
-    private static final int    DEFAULT_ADMIN_ID       = 1;
-    private static final String DEFAULT_ADMIN_USERNAME = "admin";
-    private static final String DEFAULT_ADMIN_PASSWORD = "admin";
+    // UC-1 / I.1.4 — default System Admin credentials. Bound from platform.admin.* in
+    // application.yml (env-overridable); never hardcoded here.
+    private final String defaultAdminUsername;
+    private final String defaultAdminPassword;
+    private static final int DEFAULT_ADMIN_ID = 1;
 
     // Platform lifecycle state (in-memory for V1). openMarket()/closeMarket() (UC-32, #307)
     // build on top of this status.
@@ -63,7 +65,10 @@ public class SystemAdminService {
             IEventRepository eventRepository,
             List<IPaymentGateway> paymentGateways,
             List<ITicketIssuer> ticketIssuers,
-            IPasswordHasher passwordHasher
+            IPasswordHasher passwordHasher,
+            SystemIntegrityVerifier integrityVerifier,
+            @Value("${platform.admin.username}") String defaultAdminUsername,
+            @Value("${platform.admin.password}") String defaultAdminPassword
     ) {
         this.sessionManager = sessionManager;
         this.adminRepository = adminRepository;
@@ -73,6 +78,9 @@ public class SystemAdminService {
         this.paymentGateways = paymentGateways;
         this.ticketIssuers = ticketIssuers;
         this.passwordHasher = passwordHasher;
+        this.integrityVerifier = integrityVerifier;
+        this.defaultAdminUsername = defaultAdminUsername;
+        this.defaultAdminPassword = defaultAdminPassword;
     }
 
     // UC-1 — I.1.1 invariants + I.1.2 payment-gateway check + I.1.3 issuer check + I.1.4 default-admin.
@@ -100,6 +108,11 @@ public class SystemAdminService {
         // I.1.4 — guarantee at least one System Admin (auto-create a default if none).
         createDefaultAdminIfMissing();
 
+        // Step 4 / I.1.1 — re-assert the platform post-conditions, then the system-wide
+        // structural correctness constraints, as explicit gates before going live.
+        verifyInitializationInvariants();
+        integrityVerifier.verify();
+
         this.lastInitializedAt = LocalDateTime.now();
         this.status = PlatformStatus.READY;
         log.info("Platform initialized — status READY.");
@@ -112,13 +125,13 @@ public class SystemAdminService {
             return;
         }
 
-        log.warn("No System Admin found — creating default admin '{}'. Rotate its password after first login.",
-                DEFAULT_ADMIN_USERNAME);
+        log.warn("No System Admin found — creating default admin '{}'. Override its password via "
+                + "PLATFORM_ADMIN_PASSWORD and rotate after first login.", defaultAdminUsername);
         try {
             Admin defaultAdmin = new Admin(
                     DEFAULT_ADMIN_ID,
-                    DEFAULT_ADMIN_USERNAME,
-                    passwordHasher.hash(DEFAULT_ADMIN_PASSWORD),
+                    defaultAdminUsername,
+                    passwordHasher.hash(defaultAdminPassword),
                     true);
             defaultAdmin.checkInvariants();
             adminRepository.save(defaultAdmin);
@@ -149,6 +162,20 @@ public class SystemAdminService {
 
 
 
+
+    // *HELPER* — UC-1 step 4 / I.1.1: re-assert the platform post-conditions as a single gate.
+    // Defensive against an external service dropping between the initial check and this point.
+    private void verifyInitializationInvariants() {
+        if (paymentGateways.stream().noneMatch(this::isReachable)) {
+            throw new InitializationIntegrityException("no reachable payment service");
+        }
+        if (ticketIssuers.stream().noneMatch(this::isReachable)) {
+            throw new InitializationIntegrityException("no reachable ticket issuance service");
+        }
+        if (!adminRepository.existsAny()) {
+            throw new InitializationIntegrityException("no System Admin present");
+        }
+    }
 
     // *HELPER METHODS* — UC-1 I.1.2/I.1.3 reachability probe (maps to the WSEP `handshake`).
     // A thrown verification (e.g. a real HTTP adapter timing out) is treated as "unreachable"

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemIntegrityVerifier.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemIntegrityVerifier.java
@@ -1,0 +1,109 @@
+package com.ticketing.system.Core.Application.services;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.exceptions.SystemIntegrityViolationException;
+import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
+import com.ticketing.system.Core.Domain.users.IUserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Verifies the platform's structural correctness against persisted state, invoked from
+ * {@code SystemAdminService.initializePlatform()} after the I.1 post-conditions hold.
+ *
+ * <p>This javadoc is the single coverage map for <i>every</i> correctness/integrity requirement
+ * in {@code requirements.md} (§1 correctness constraints, §2 integrations, §3 commercial rules,
+ * and the relevant SLRs). Only <b>scannable structural state</b> is checked in this class;
+ * connection rules are checked at initialization, and behavioural / transaction rules are
+ * enforced at their call sites — cited below so nothing is silently dropped.
+ *
+ * <h3>Scanned here (structural state)</h3>
+ * <ul>
+ *   <li><b>§1 #6 active company has ≥1 Owner — VERIFIED.</b></li>
+ *   <li><b>§1 #4 producer (owner/manager) is a registered user — VERIFIED.</b></li>
+ *   <li>§1 #1 unique username, #8 ≤1 active order/buyer/event, #12 sellable ≤ inventory, and the
+ *       II.4.8.3 appointment tree (single appointer, no ownership cycles) — all structural but
+ *       need aggregate enumeration the V1 repos do not expose → V3 scan.</li>
+ * </ul>
+ *
+ * <h3>Checked at initialization (connection rules)</h3>
+ * <ul>
+ *   <li>§1 #2 ≥1 System Admin, §2 ≥1 payment + ≥1 ticket-issuance connection — asserted by
+ *       {@code SystemAdminService.verifyInitializationInvariants()}.</li>
+ * </ul>
+ *
+ * <h3>Enforced at their call sites (behavioural / transaction rules — not scannable state)</h3>
+ * <ul>
+ *   <li>§1 #5 auth-on-write, #9 reservation lock, #10 atomic checkout, #11 exclusive order
+ *       ownership — per-operation guards in the reservation/checkout services.</li>
+ *   <li>§3 #1 charge only after the transaction confirms, #2 funds only as a result of a purchase,
+ *       #3 purchase succeeds only after BOTH payment AND issuance, #4 auto-refund + notify on a
+ *       broken atomic checkout — {@code CheckoutService} + the UC-4 refund pipeline.</li>
+ *   <li>§3 #5 state law: mandatory receipts ({@code OrderReceipt}); anti-scalping + under-18 limits
+ *       (purchase policy at checkout).</li>
+ *   <li>SLR.1 no double-sold seat — per-aggregate locking; SLR.2 privacy — DTO boundary + BCrypt.</li>
+ * </ul>
+ *
+ * <h3>Deliberately not upheld</h3>
+ * <ul>
+ *   <li>§1 #3 admin is a Member — the team models admins as a disjoint pool (documented override).</li>
+ *   <li>§1 #7 company default policy — satisfied by construction ({@code NoPurchasePolicy} default).</li>
+ * </ul>
+ *
+ * <p><b>V1/V2 note:</b> the in-memory repos are empty when this runs at boot (runner is
+ * {@code @Order(0)}, before the dev seeders), so the scans pass trivially today; their value is
+ * realized in V3 when persisted state is loaded and re-validated on startup (SLR.6 / SLR.7). The
+ * logic is proven by unit tests now, and this class is the growth point for the V3 scans.
+ */
+@Service
+@Slf4j
+public class SystemIntegrityVerifier {
+
+    private final IUserRepository userRepository;
+    private final IProductionCompanyRepository companyRepository;
+
+    public SystemIntegrityVerifier(IUserRepository userRepository,
+                                   IProductionCompanyRepository companyRepository) {
+        this.userRepository = userRepository;
+        this.companyRepository = companyRepository;
+    }
+
+    public void verify() {
+        verifyActiveCompaniesHaveOwner();   // constraint #6
+        verifyProducersAreUsers();          // constraint #4
+        log.info("System integrity verified.");
+    }
+
+    // #6 — every active production company has at least one Owner.
+    private void verifyActiveCompaniesHaveOwner() {
+        for (ProductionCompany company : companyRepository.findActive()) {
+            if (company.getOwnerIds().isEmpty()) {
+                throw new SystemIntegrityViolationException(
+                        "active company '" + company.getName() + "' has no owner");
+            }
+        }
+    }
+
+    // #4 — every producer (owner or manager) of an active company resolves to a known user.
+    private void verifyProducersAreUsers() {
+        for (ProductionCompany company : companyRepository.findActive()) {
+            List<Integer> producerIds = new ArrayList<>(company.getOwnerIds());
+            producerIds.addAll(company.getManagers());
+            for (int userId : producerIds) {
+                try {
+                    userRepository.getUserById(userId);
+                } catch (UserNotFoundException e) {
+                    throw new SystemIntegrityViolationException(
+                            "company '" + company.getName() + "' has producer " + userId
+                                    + " that is not a registered user");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/ExternalServiceUnavailableException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/ExternalServiceUnavailableException.java
@@ -1,0 +1,11 @@
+package com.ticketing.system.Core.Domain.exceptions;
+
+// Thrown during UC-1 (I.1.2 / I.1.3) and UC-32 (I.2.2) when no external payment or
+// ticket-issuance service is reachable, so the platform cannot be brought up / the
+// market cannot be opened. Maps to the WSEP `handshake` action returning non-OK.
+public class ExternalServiceUnavailableException extends DomainException {
+
+    public ExternalServiceUnavailableException(String reason) {
+        super("Required external service unavailable: " + reason);
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/InitializationIntegrityException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/InitializationIntegrityException.java
@@ -1,0 +1,11 @@
+package com.ticketing.system.Core.Domain.exceptions;
+
+// Thrown by UC-1 step 4 / I.1.1 when the platform post-conditions do not hold at the
+// integrity gate (e.g. no admin present after setup, or a required external service became
+// unreachable between the initial check and the gate).
+public class InitializationIntegrityException extends DomainException {
+
+    public InitializationIntegrityException(String reason) {
+        super("Platform initialization integrity check failed: " + reason);
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/SystemIntegrityViolationException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/SystemIntegrityViolationException.java
@@ -1,0 +1,10 @@
+package com.ticketing.system.Core.Domain.exceptions;
+
+// Thrown when a structural correctness constraint (requirements.md §1) is violated by the
+// persisted state — detected by SystemIntegrityVerifier during UC-1 initialization.
+public class SystemIntegrityViolationException extends DomainException {
+
+    public SystemIntegrityViolationException(String reason) {
+        super("System integrity violation: " + reason);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/PlatformInitializationRunner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/PlatformInitializationRunner.java
@@ -1,0 +1,43 @@
+package com.ticketing.system.Infrastructure;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.exceptions.DomainException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Runs platform initialization (UC-1) at startup. Non-fatal by design: if external services
+ * are unreachable or the default admin cannot be created, the platform stays uninitialized and
+ * the market cannot open (UC-32 guards that) — but the process still boots, so the health
+ * endpoint and ops tooling remain available to diagnose and recover.
+ *
+ * <p>{@code @Order(0)} runs this before the dev seeders ({@code @Order(1)}/{@code (2)}).
+ * Excluded from the {@code test} profile so acceptance tests drive initialization explicitly.
+ */
+@Component
+@Profile("!test")
+@Order(0)
+@Slf4j
+public class PlatformInitializationRunner implements ApplicationRunner {
+
+    private final SystemAdminService systemAdminService;
+
+    public PlatformInitializationRunner(SystemAdminService systemAdminService) {
+        this.systemAdminService = systemAdminService;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            systemAdminService.initializePlatform();
+        } catch (DomainException e) {
+            log.error("Platform NOT initialized — market cannot open until resolved: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
@@ -31,9 +31,17 @@ public class StubPaymentGateway implements IPaymentGateway {
         return GATEWAY_ID;
     }
 
+    // Toggleable for UC-1/UC-32 tests: lets a test simulate an unreachable provider so the
+    // initialize / open-market failure paths can be exercised. Production default: reachable.
+    private volatile boolean reachable = true;
+
+    public void setReachable(boolean reachable) {
+        this.reachable = reachable;
+    }
+
     @Override
     public boolean verifyConnection() {
-        return true;
+        return reachable;
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
@@ -26,9 +26,17 @@ public class StubTicketIssuer implements ITicketIssuer {
         return ISSUER_ID;
     }
 
+    // Toggleable for UC-1/UC-32 tests: lets a test simulate an unreachable provider so the
+    // initialize / open-market failure paths can be exercised. Production default: reachable.
+    private volatile boolean reachable = true;
+
+    public void setReachable(boolean reachable) {
+        this.reachable = reachable;
+    }
+
     @Override
     public boolean verifyConnection() {
-        return true;
+        return reachable;
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,10 @@ management:
 vaadin:
   launch-browser: false
   allowed-packages: com.ticketing.system.Presentation
+
+# Default System Admin (UC-1 / I.1.4) — auto-created at initialization when none exists.
+# Defaults live here only; override in production via env, and never ship the default password.
+platform:
+  admin:
+    username: ${PLATFORM_ADMIN_USERNAME:admin}
+    password: ${PLATFORM_ADMIN_PASSWORD:admin}

--- a/src/test/java/com/ticketing/system/acceptance/AdminAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/AdminAcceptanceTest.java
@@ -1,23 +1,61 @@
 package com.ticketing.system.acceptance;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Infrastructure.external.StubPaymentGateway;
+import com.ticketing.system.Infrastructure.external.StubTicketIssuer;
+
+// Fresh context per method so each test starts UNINITIALIZED, with reachable stubs and an
+// empty admin repo (the demo seeders are @Profile("dev"), so "test" boots with no admin).
 @SpringBootTest
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class AdminAcceptanceTest {
 
+    @Autowired SystemAdminService systemAdminService;
+    @Autowired IAdminRepository adminRepository;
+    @Autowired StubPaymentGateway stubPaymentGateway;
+    @Autowired StubTicketIssuer stubTicketIssuer;
+
     // UC-1
-    @Test @Disabled("UC-1 main: initialize platform — all checks pass → READY")
-    void GivenValidEnvironment_WhenInitialize_ThenReady() {}
-    @Test @Disabled("UC-1 negative: I.1.2 missing payment gateway → init fails")
-    void GivenNoGateway_WhenInitialize_ThenFails() {}
-    @Test @Disabled("UC-1 negative: I.1.3 missing ticket issuer → init fails")
-    void GivenNoIssuer_WhenInitialize_ThenFails() {}
-    @Test @Disabled("UC-1 alt: I.1.4 no admin → auto-create default")
-    void GivenNoAdmin_WhenInitialize_ThenDefaultCreated() {}
+    @Test
+    void GivenValidEnvironment_WhenInitialize_ThenReady() {
+        systemAdminService.initializePlatform();
+        assertTrue(adminRepository.existsAny());
+    }
+
+    @Test
+    void GivenNoGateway_WhenInitialize_ThenFails() {
+        stubPaymentGateway.setReachable(false);
+        assertThrows(ExternalServiceUnavailableException.class,
+                () -> systemAdminService.initializePlatform());
+    }
+
+    @Test
+    void GivenNoIssuer_WhenInitialize_ThenFails() {
+        stubTicketIssuer.setReachable(false);
+        assertThrows(ExternalServiceUnavailableException.class,
+                () -> systemAdminService.initializePlatform());
+    }
+
+    @Test
+    void GivenNoAdmin_WhenInitialize_ThenDefaultCreated() {
+        assertFalse(adminRepository.existsAny());
+        systemAdminService.initializePlatform();
+        assertTrue(adminRepository.existsAny());
+    }
 
     // UC-32
     @Test @Disabled("UC-32 main: openMarket re-verifies + opens")

--- a/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
@@ -1,8 +1,12 @@
 package com.ticketing.system.unit.application;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -17,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
+import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
@@ -27,6 +32,8 @@ import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.Tickets.Ticket;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Core.Domain.exceptions.MissingDefaultAdminException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 import com.ticketing.system.Core.Domain.orders.ReceiptLine;
@@ -41,6 +48,7 @@ class SystemAdminServiceTest {
     private IOrderReceiptRepository orderReceiptRepository;
     private ITicketRepository ticketRepository;
     private IEventRepository eventRepository;
+    private IPasswordHasher passwordHasher;
     private SystemAdminService service;
 
 
@@ -51,6 +59,8 @@ class SystemAdminServiceTest {
         orderReceiptRepository = mock(IOrderReceiptRepository.class);
         ticketRepository = mock(ITicketRepository.class);
         eventRepository = mock(IEventRepository.class);
+        passwordHasher = mock(IPasswordHasher.class);
+        when(passwordHasher.hash(anyString())).thenReturn("hashed-password");
         service = new SystemAdminService(
                 sessionManager,
                 adminRepository,
@@ -58,24 +68,58 @@ class SystemAdminServiceTest {
                 ticketRepository,
                 eventRepository,
                 List.of(),
-                List.of()
+                List.of(),
+                passwordHasher
         );
         when(sessionManager.validateToken(ADMIN_TOKEN)).thenReturn(true);
         when(sessionManager.extractUserId(ADMIN_TOKEN)).thenReturn(ADMIN_USER_ID);
         when(adminRepository.findById(ADMIN_USER_ID)).thenReturn(new Admin(ADMIN_USER_ID, "admin", "hash", true));
     }
 
-    @Test @Disabled("UC-1: I.1.1 verify invariants on startup")
-    void givenValidState_whenInitializePlatform_thenSucceeds() {}
+    // --- UC-1: initializePlatform ---
 
-    @Test @Disabled("UC-1: I.1.2 missing payment gateway → market does not open")
-    void givenNoPaymentGateway_whenInitializePlatform_thenFails() {}
+    @Test
+    void givenAllServicesReachableAndAdminExists_whenInitializePlatform_thenSucceeds() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        assertDoesNotThrow(svc::initializePlatform);
+    }
 
-    @Test @Disabled("UC-1: I.1.3 missing ticket issuer → market does not open")
-    void givenNoTicketIssuer_whenInitializePlatform_thenFails() {}
+    @Test
+    void givenNoReachablePaymentGateway_whenInitializePlatform_thenThrows() {
+        SystemAdminService svc = serviceWith(List.of(), List.of(reachableIssuer()));
+        assertThrows(ExternalServiceUnavailableException.class, svc::initializePlatform);
+    }
 
-    @Test @Disabled("UC-1: I.1.4 no admin → auto-generates default")
-    void givenNoAdmin_whenInitializePlatform_thenDefaultAdminCreated() {}
+    @Test
+    void givenNoReachableTicketIssuer_whenInitializePlatform_thenThrows() {
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of());
+        assertThrows(ExternalServiceUnavailableException.class, svc::initializePlatform);
+    }
+
+    @Test
+    void givenNoAdmin_whenInitializePlatform_thenDefaultAdminCreated() {
+        when(adminRepository.existsAny()).thenReturn(false, true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        svc.initializePlatform();
+        verify(adminRepository).save(any(Admin.class));
+    }
+
+    @Test
+    void givenNoAdminAndCreationDoesNotPersist_whenInitializePlatform_thenThrows() {
+        // existsAny() stays false even after save() → auto-creation failed.
+        when(adminRepository.existsAny()).thenReturn(false);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        assertThrows(MissingDefaultAdminException.class, svc::initializePlatform);
+    }
+
+    @Test
+    void givenAlreadyInitialized_whenInitializePlatformAgain_thenSecondCallIsNoOp() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        svc.initializePlatform();
+        assertDoesNotThrow(svc::initializePlatform);
+    }
 
     @Test @Disabled("UC-32: openMarket re-runs all verifications + flips state")
     void givenInitializedPlatform_whenOpenMarket_thenStateOpen() {}
@@ -184,5 +228,26 @@ class SystemAdminServiceTest {
         PurchaseHistoryDTO.PurchaseRecordDTO record = result.get(0).records().get(0);
         assertEquals(75.0, record.totalPaid());
         assertEquals(2, record.tickets().size());
+    }
+
+
+    // --- helpers ---
+
+    private SystemAdminService serviceWith(List<IPaymentGateway> gateways, List<ITicketIssuer> issuers) {
+        return new SystemAdminService(
+                sessionManager, adminRepository, orderReceiptRepository,
+                ticketRepository, eventRepository, gateways, issuers, passwordHasher);
+    }
+
+    private IPaymentGateway reachablePayment() {
+        IPaymentGateway gateway = mock(IPaymentGateway.class);
+        when(gateway.verifyConnection()).thenReturn(true);
+        return gateway;
+    }
+
+    private ITicketIssuer reachableIssuer() {
+        ITicketIssuer issuer = mock(ITicketIssuer.class);
+        when(issuer.verifyConnection()).thenReturn(true);
+        return issuer;
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
@@ -26,6 +26,7 @@ import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Application.services.SystemIntegrityVerifier;
 import com.ticketing.system.Core.Domain.Admin.Admin;
 import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
@@ -49,6 +50,7 @@ class SystemAdminServiceTest {
     private ITicketRepository ticketRepository;
     private IEventRepository eventRepository;
     private IPasswordHasher passwordHasher;
+    private SystemIntegrityVerifier integrityVerifier;
     private SystemAdminService service;
 
 
@@ -60,6 +62,7 @@ class SystemAdminServiceTest {
         ticketRepository = mock(ITicketRepository.class);
         eventRepository = mock(IEventRepository.class);
         passwordHasher = mock(IPasswordHasher.class);
+        integrityVerifier = mock(SystemIntegrityVerifier.class);
         when(passwordHasher.hash(anyString())).thenReturn("hashed-password");
         service = new SystemAdminService(
                 sessionManager,
@@ -69,7 +72,10 @@ class SystemAdminServiceTest {
                 eventRepository,
                 List.of(),
                 List.of(),
-                passwordHasher
+                passwordHasher,
+                integrityVerifier,
+                "admin",
+                "admin"
         );
         when(sessionManager.validateToken(ADMIN_TOKEN)).thenReturn(true);
         when(sessionManager.extractUserId(ADMIN_TOKEN)).thenReturn(ADMIN_USER_ID);
@@ -236,7 +242,8 @@ class SystemAdminServiceTest {
     private SystemAdminService serviceWith(List<IPaymentGateway> gateways, List<ITicketIssuer> issuers) {
         return new SystemAdminService(
                 sessionManager, adminRepository, orderReceiptRepository,
-                ticketRepository, eventRepository, gateways, issuers, passwordHasher);
+                ticketRepository, eventRepository, gateways, issuers, passwordHasher,
+                integrityVerifier, "admin", "admin");
     }
 
     private IPaymentGateway reachablePayment() {

--- a/src/test/java/com/ticketing/system/unit/application/SystemIntegrityVerifierTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemIntegrityVerifierTest.java
@@ -1,0 +1,65 @@
+package com.ticketing.system.unit.application;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.services.SystemIntegrityVerifier;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.exceptions.SystemIntegrityViolationException;
+import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
+import com.ticketing.system.Core.Domain.users.IUserRepository;
+import com.ticketing.system.Core.Domain.users.User;
+
+class SystemIntegrityVerifierTest {
+
+    private final IUserRepository userRepository = mock(IUserRepository.class);
+    private final IProductionCompanyRepository companyRepository = mock(IProductionCompanyRepository.class);
+    private final SystemIntegrityVerifier verifier = new SystemIntegrityVerifier(userRepository, companyRepository);
+
+    @Test
+    void givenEmptySystem_whenVerify_thenPasses() {
+        when(companyRepository.findActive()).thenReturn(List.of());
+        assertDoesNotThrow(verifier::verify);
+    }
+
+    @Test
+    void givenActiveCompanyWithOwnerAndKnownProducers_whenVerify_thenPasses() {
+        ProductionCompany company = mock(ProductionCompany.class);
+        when(company.getOwnerIds()).thenReturn(List.of(5));
+        when(company.getManagers()).thenReturn(List.of(6));
+        when(companyRepository.findActive()).thenReturn(List.of(company));
+        when(userRepository.getUserById(5)).thenReturn(mock(User.class));
+        when(userRepository.getUserById(6)).thenReturn(mock(User.class));
+
+        assertDoesNotThrow(verifier::verify);
+    }
+
+    @Test
+    void givenActiveCompanyWithNoOwner_whenVerify_thenThrows() {   // constraint #6
+        ProductionCompany company = mock(ProductionCompany.class);
+        when(company.getOwnerIds()).thenReturn(List.of());
+        when(company.getName()).thenReturn("Ghost Co");
+        when(companyRepository.findActive()).thenReturn(List.of(company));
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    @Test
+    void givenProducerThatIsNotAUser_whenVerify_thenThrows() {     // constraint #4
+        ProductionCompany company = mock(ProductionCompany.class);
+        when(company.getOwnerIds()).thenReturn(List.of(5));
+        when(company.getManagers()).thenReturn(List.of());
+        when(company.getName()).thenReturn("Phantom Co");
+        when(companyRepository.findActive()).thenReturn(List.of(company));
+        when(userRepository.getUserById(5)).thenThrow(new UserNotFoundException(5));
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/PlatformInitializationRunnerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/PlatformInitializationRunnerTest.java
@@ -1,0 +1,35 @@
+package com.ticketing.system.unit.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Infrastructure.PlatformInitializationRunner;
+
+class PlatformInitializationRunnerTest {
+
+    @Test
+    void whenRun_thenInitializePlatformInvoked() {
+        SystemAdminService service = mock(SystemAdminService.class);
+        PlatformInitializationRunner runner = new PlatformInitializationRunner(service);
+
+        runner.run(null);
+
+        verify(service).initializePlatform();
+    }
+
+    @Test
+    void givenInitFails_whenRun_thenSwallowedSoBootContinues() {
+        SystemAdminService service = mock(SystemAdminService.class);
+        doThrow(new ExternalServiceUnavailableException("no reachable payment service"))
+                .when(service).initializePlatform();
+        PlatformInitializationRunner runner = new PlatformInitializationRunner(service);
+
+        assertDoesNotThrow(() -> runner.run(null));
+    }
+}


### PR DESCRIPTION
## UC-1: Initialize Ticketing Platform

Completes #8 — brings the platform to a healthy, market-openable state at startup and verifies the system's correctness constraints.

### What this delivers
- **`initializePlatform()`** — idempotent: verifies ≥1 reachable payment + ticket-issuance service (`verifyConnection` / WSEP `handshake`), auto-creates a default System Admin if none, runs the integrity gate, marks the platform `READY`.
- **Boot trigger** — `PlatformInitializationRunner` (`@Profile("!test")`, `@Order(0)`) runs it at startup, **non-fatal**: if a dependency is unreachable the platform stays uninitialized (the market-open gate, #9, blocks traffic) but the process still boots so health/ops stay available.
- **Configurable default admin** — credentials in `application.yml` (`platform.admin.*`, env-overridable like `jwt.secret`); no hardcoded credential in Java; startup warns to set `PLATFORM_ADMIN_PASSWORD`.
- **Explicit integrity step (I.1.1 / step 4)** — `verifyInitializationInvariants()` re-asserts the post-conditions; `SystemIntegrityVerifier` scans the structural correctness constraints it can (**#6** active company has an owner, **#4** producers are users) and its javadoc maps where every other correctness/integrity rule (§1/§2/§3 + SLRs) is enforced.

### Acceptance criteria (all tested)
- [x] succeeds when services connected + admin exists
- [x] fails if no payment reachable
- [x] fails if no ticket issuance reachable
- [x] fails if no admin and auto-creation fails
- [x] re-init handled gracefully

### Tests
**720 pass.** New: `SystemIntegrityVerifierTest`, `PlatformInitializationRunnerTest`; expanded `SystemAdminServiceTest` (6 UC-1) + `AdminAcceptanceTest` (4 UC-1, `@DirtiesContext` for isolation).

### Deferred to V3 → #315
**#1** unique-username, **#8** ≤1-active-order, **#12** sellable≤inventory, and the appointment-tree scan are structural but need aggregate enumeration the V1 repos don't expose (and run against empty state at V1 boot). The real external WSEP HTTP adapter + continuous health check remain #155.

Closes #8
