### PR TITLE
fix(dev-seed): run the demo seed end-to-end; fix repeat-purchase checkout bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,8 @@ src/main/frontend/generated/
 scripts/*
 docs/*
 
+# Runtime log output (logs/event-ticket-system.log + rolled .gz archives)
+logs/
+
 # Claude Code per-project skills + agent tooling (run skill, drivers, screenshots).
 .claude/

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -196,7 +196,10 @@ public class CheckoutService {
             saveMemberReceipt(userId, orderReceiptId, totalPrice, receiptLines, paymentResult, issuanceResult);
 
             order.buy();
-            activeOrderRepository.save(order);
+            // Purchase complete — receipt + tickets are already persisted (separate aggregates);
+            // delete the consumed cart so the buyer can start a fresh order. ActiveOrder has no
+            // terminal status, so saving it would leave it stuck in CHECKOUT_IN_PROGRESS forever.
+            activeOrderRepository.delete(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);
             cacheCheckoutResult(idempotencyKey, buyerKey, result);
@@ -325,7 +328,10 @@ public class CheckoutService {
             saveGuestReceipt(guestEmail, guestSessionId, orderReceiptId, totalPrice, receiptLines, paymentResult, issuanceResult);
 
             order.buy();
-            activeOrderRepository.save(order);
+            // Purchase complete — receipt + tickets are already persisted (separate aggregates);
+            // delete the consumed cart so the buyer can start a fresh order. ActiveOrder has no
+            // terminal status, so saving it would leave it stuck in CHECKOUT_IN_PROGRESS forever.
+            activeOrderRepository.delete(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);
             cacheCheckoutResult(idempotencyKey, buyerKey, result);

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoDataSeeder.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoDataSeeder.java
@@ -153,9 +153,24 @@ public class DemoDataSeeder implements ApplicationRunner {
         Map<String, EventDetailDTO> events =
             new DemoEvents(eventManagementService, eventRepository, users, companies, demoClock).seed();
 
-        new DemoOrders(reservationService, checkoutService, users, events).seed();
-        new DemoMessaging(authenticationService, messagingService, userRepository, users, companies).seed();
-        new DemoNotifications(notificationRepository, users, demoClock).seed();
+        // Leaf seeders: tolerate stages whose feature is not built yet (UnsupportedOperationException)
+        // by skipping them; any other exception still aborts the seed so real bugs surface.
+        runTolerant("orders", () ->
+            new DemoOrders(reservationService, checkoutService, users, events).seed());
+        runTolerant("messaging", () ->
+            new DemoMessaging(authenticationService, messagingService, userRepository, users, companies).seed());
+        runTolerant("notifications", () ->
+            new DemoNotifications(notificationRepository, users, demoClock).seed());
+    }
+
+    /** Runs a leaf sub-seeder, skipping it (with a log line) only when the feature it needs is not
+     *  implemented yet. Any other exception propagates so genuine bugs still fail the seed. */
+    private void runTolerant(String stage, Runnable subSeeder) {
+        try {
+            subSeeder.run();
+        } catch (UnsupportedOperationException notImplemented) {
+            log.warn("demo seed: skipped '{}' — feature not implemented yet ({})", stage, notImplemented.getMessage());
+        }
     }
 
     private boolean alreadySeeded() {

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
@@ -231,7 +231,15 @@ public final class DemoEvents {
 
         Event event = eventRepository.findById(Integer.parseInt(created.eventId()));
         forceStatusOnSale(event);
-        eventRepository.save(event);
+        // Existing events must be locked before save (MemoryEventRepository contract); the
+        // reflection-forced status write is a direct repo save, so lock/unlock around it.
+        int eventId = event.getId();
+        eventRepository.lockForUpdate(eventId);
+        try {
+            eventRepository.save(event);
+        } finally {
+            eventRepository.unlock(eventId);
+        }
         return created;
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
@@ -21,14 +21,23 @@ import org.springframework.stereotype.Component;
 @Component
 public class InMemoryNotificationService implements INotificationService {
 
+    // V1 stub behaviour (as the class doc states): collect notifications in memory instead of
+    // throwing, so reservation/checkout flows complete. UC-35 replaces this with a real push channel.
+    private final java.util.List<Notification> sentNotifications = new java.util.concurrent.CopyOnWriteArrayList<>();
+
     @Override
     public boolean send(int recipientUserId, Notification notification) {
-        throw new UnsupportedOperationException("UC-35: in-memory send not implemented");
+        sentNotifications.add(notification);
+        return true;
     }
 
     @Override
     public boolean isReachable(int recipientUserId) {
-        throw new UnsupportedOperationException("UC-35: not implemented");
+        return true;
+    }
+
+    public java.util.List<Notification> getSentNotifications() {
+        return java.util.List.copyOf(sentNotifications);
     }
     @Override
 public void notifyPurchaseCompleted(int userId, double totalPrice, List<Integer> ticketIds) {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -45,6 +45,17 @@
         <logger name="com.ticketing.system.Infrastructure.logging" level="INFO"/>
     </springProfile>
 
+    <!-- Dev profile: local run with Memory* repos + demo seed (no DB). Console + rolling file. -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+        <logger name="com.ticketing.system" level="DEBUG"/>
+        <logger name="com.ticketing.system.Core.Domain" level="DEBUG"/>
+        <logger name="com.ticketing.system.Infrastructure.logging" level="DEBUG"/>
+    </springProfile>
+
     <!-- Test profile: DEBUG for our code, console only. -->
     <springProfile name="test">
         <root level="WARN">


### PR DESCRIPTION
## Make the dev demo seeder run end-to-end

Takes the `dev` demo seed from "fails immediately with no logs" to a clean `demo data seeded successfully` — 12 users · 4 companies · 13 events · 8 orders/checkouts · 30 notifications (messaging skipped: it's unimplemented — the `V2-WIRE-MSG` work).

### Real app bugs (not just the seeder)
- **CheckoutService — repeat purchases were impossible.** A completed purchase left the `ActiveOrder` in `CHECKOUT_IN_PROGRESS` (`ActiveOrder.buy()` clears items but not status; the success path `save`d instead of deleting), so the buyer's *next* reserve threw "Cannot modify active order while checkout is in progress." We now **delete** the consumed cart on success — the receipt + tickets are separate aggregates and already persisted.
- **`InMemoryNotificationService.send` threw `UnsupportedOperationException`**, blocking every reservation/checkout notification. Now it collects in memory (the documented V1 stub behaviour). Refs #304.

### Dev tooling / seeder
- **logback `dev` block** — there was no `<springProfile name="dev">`, so under `dev` logback had no appenders and silently dropped every app log. Added console + rolling file (`logs/event-ticket-system.log`).
- **`DemoEvents`** — lock the event before the reflection-forced `ON_SALE` save (`MemoryEventRepository` requires lock-before-save).
- **`DemoDataSeeder`** — skip a leaf sub-seeder only on `UnsupportedOperationException` (unimplemented feature, e.g. messaging); any real bug still fails the seed.
- `logs/` added to `.gitignore`.

### Tests
Full suite: **712 pass**, no regressions (incl. the 40-test `CheckoutServiceAcceptanceTest` with the delete-on-purchase change).

Refs #304.
