### PR TITLE
Event lifecycle (DRAFT→SCHEDULED→ON_SALE), construction invariants, + notification refactor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ docs/*
 .project
 .factorypath
 
+# settings
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,13 @@ docs/*
 
 # Claude Code per-project skills + agent tooling (run skill, drivers, screenshots).
 .claude/
+
+# Local configuration files (e.g. for IDEs, build tools, etc.)
+.idea/
+.vscode/
+
+# binaries
+.classpath
+.project
+.factorypath
+

--- a/src/main/java/com/ticketing/system/Core/Application/dto/EventUpdateDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/EventUpdateDTO.java
@@ -1,16 +1,16 @@
 package com.ticketing.system.Core.Application.dto;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
-// Input to EventManagementService.editEvent() (UC-19).
-// All fields nullable — represents a partial update.
-// The service applies the immutability rules (II.3.5.2) per field — see open question #9.
+// Input to EventManagementService.editEventDetails() (UC-19).
+// All fields nullable — represents a partial update; null means "leave this field alone".
+// The service converts location/showDates into their domain equivalents and the Event
+// aggregate applies the II.3.5.2 state rules (DRAFT/SCHEDULED only).
 public record EventUpdateDTO(
     String eventId,
-    String name,                        // nullable
-    String description,                 // nullable
-    String category,                    // nullable
-    String location,                    // nullable
-    List<LocalDateTime> showDates       // nullable — null means leave alone, empty means remove all
+    String name,                  // nullable
+    String description,           // nullable
+    String category,              // nullable
+    LocationDTO location,         // nullable
+    List<ShowDateDTO> showDates   // nullable — null means leave alone; non-empty replaces the schedule
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/interfaces/INotificationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/interfaces/INotificationService.java
@@ -2,11 +2,11 @@ package com.ticketing.system.Core.Application.interfaces;
 
 import java.util.List;
 
-import com.ticketing.system.Core.Domain.notifications.Notification;
-
-// Port for the live push channel (WebSocket / SSE / email — V2/V3 decision).
-// V1 implementation is InMemoryNotificationService for test assertions.
-// Used by NotificationDispatchService for online-recipient delivery (UC-35).
+// High-level, application-facing notification facade. Each notifyXxx method translates a
+// business event into a Notification domain object and delegates to NotificationDispatchService,
+// which persists it and routes delivery. The low-level push channel (WebSocket / SSE / email)
+// is a separate port, IPushNotificationService.
+// V1 implementation is NotificationService.
 public interface INotificationService {
 
     void notifyPurchaseCompleted(int userId, double totalPrice, List<Integer> list);

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -202,9 +202,9 @@ public class CheckoutService {
             inventorySaleConfirmed = true;
 
             order.buy();
-            // Purchase complete — receipt + tickets are already persisted (separate aggregates);
-            // delete the consumed cart so the buyer can start a fresh order. ActiveOrder has no
-            // terminal status, so saving it would leave it stuck in CHECKOUT_IN_PROGRESS forever.
+            // The sale is committed and the receipt is the durable record; the cart has done its job.
+            // Delete the consumed order (don't save it) — buy() leaves it CHECKOUT_IN_PROGRESS, so a
+            // save would strand an empty, unmodifiable cart that wedges the buyer's next reservation.
             activeOrderRepository.delete(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);
@@ -340,9 +340,9 @@ public class CheckoutService {
             inventorySaleConfirmed = true;
 
             order.buy();
-            // Purchase complete — receipt + tickets are already persisted (separate aggregates);
-            // delete the consumed cart so the buyer can start a fresh order. ActiveOrder has no
-            // terminal status, so saving it would leave it stuck in CHECKOUT_IN_PROGRESS forever.
+            // The sale is committed and the receipt is the durable record; the cart has done its job.
+            // Delete the consumed order (don't save it) — buy() leaves it CHECKOUT_IN_PROGRESS, so a
+            // save would strand an empty, unmodifiable cart that wedges the buyer's next reservation.
             activeOrderRepository.delete(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -187,13 +187,19 @@ public class CheckoutService {
             lockEvents(lockedEventIds);
 
             validateEventsStillOnSale(snapshotItems);
+            // Fail-fast ownership check (read-only): the reservation must still be ours and RESERVED.
             validateCanConfirmInventorySale(snapshotItems, orderKey);
-            confirmInventorySale(snapshotItems, orderKey);
-            inventorySaleConfirmed = true;
 
+            // Persist tickets + receipt BEFORE the irreversible RESERVED→SOLD confirmation. If any of
+            // this fails, the inventory is still RESERVED, so the normal (!inventorySaleConfirmed)
+            // rollback cleanly returns it to stock and refunds — nothing is stranded as SOLD.
             int orderReceiptId = orderReceiptRepository.nextId();
             List<ReceiptLine> receiptLines = saveTicketsAndBuildReceiptLines(userId, orderReceiptId, pricedItems, issuanceResult);
             saveMemberReceipt(userId, orderReceiptId, totalPrice, receiptLines, paymentResult, issuanceResult);
+
+            // Point of no return: commit the sale last, once everything fallible has succeeded.
+            confirmInventorySale(snapshotItems, orderKey);
+            inventorySaleConfirmed = true;
 
             order.buy();
             activeOrderRepository.save(order);
@@ -316,13 +322,19 @@ public class CheckoutService {
             lockEvents(lockedEventIds);
 
             validateEventsStillOnSale(snapshotItems);
+            // Fail-fast ownership check (read-only): the reservation must still be ours and RESERVED.
             validateCanConfirmInventorySale(snapshotItems, orderKey);
-            confirmInventorySale(snapshotItems, orderKey);
-            inventorySaleConfirmed = true;
 
+            // Persist tickets + receipt BEFORE the irreversible RESERVED→SOLD confirmation. If any of
+            // this fails, the inventory is still RESERVED, so the normal (!inventorySaleConfirmed)
+            // rollback cleanly returns it to stock and refunds — nothing is stranded as SOLD.
             int orderReceiptId = orderReceiptRepository.nextId();
             List<ReceiptLine> receiptLines = saveTicketsAndBuildReceiptLines(null, orderReceiptId, pricedItems, issuanceResult);
             saveGuestReceipt(guestEmail, guestSessionId, orderReceiptId, totalPrice, receiptLines, paymentResult, issuanceResult);
+
+            // Point of no return: commit the sale last, once everything fallible has succeeded.
+            confirmInventorySale(snapshotItems, orderKey);
+            inventorySaleConfirmed = true;
 
             order.buy();
             activeOrderRepository.save(order);
@@ -994,7 +1006,13 @@ public class CheckoutService {
 
         resetCheckoutStatusAfterFailure(orderLockKey, phase1Complete, inventorySaleConfirmed);
 
-        safelyReturnTicketsToStock(order);
+        // Only roll back inventory/cart when the sale was NOT confirmed. Once confirmInventorySale
+        // has run, the inventory is SOLD and the order is still CHECKOUT_IN_PROGRESS, so a release
+        // would throw (nothing is RESERVED any more) and clear() would throw (ensureModifiable).
+        // Mirrors handleGuestCheckoutFailure.
+        if (!inventorySaleConfirmed) {
+            safelyReturnTicketsToStock(order);
+        }
 
         if (inventorySaleConfirmed) {
             log.error(
@@ -1124,30 +1142,57 @@ public class CheckoutService {
         Map<Integer, Map<Integer, List<CartLineItem>>> grouped = groupItemsByEventAndZone(returnToStock);
 
         for (Map.Entry<Integer, Map<Integer, List<CartLineItem>>> eventEntry : grouped.entrySet()) {
-            Event event = eventRepository.findById(eventEntry.getKey());
+            int eventId = eventEntry.getKey();
+            Event event = eventRepository.findById(eventId);
 
             if (event == null) {
                 continue;
             }
 
+            // Release each (event, zone) independently: a single zone that can no longer be
+            // released (e.g. its reservation was already confirmed/expired) must not abort the
+            // rollback for the remaining zones and events. We log and continue, then save the
+            // event if anything in it was actually released.
+            boolean anyReleased = false;
             for (Map.Entry<Integer, List<CartLineItem>> zoneEntry : eventEntry.getValue().entrySet()) {
                 int zoneId = zoneEntry.getKey();
                 List<CartLineItem> zoneItems = zoneEntry.getValue();
 
                 List<String> seatNumbers = extractSeatNumbers(zoneItems);
 
-                if (seatNumbers.isEmpty()) {
-                    event.releaseInventory(zoneId, InventorySelection.standing(zoneItems.size(), orderKey));
-                } else {
-                    event.releaseInventory(zoneId, InventorySelection.seated(seatNumbers, orderKey));
+                try {
+                    if (seatNumbers.isEmpty()) {
+                        event.releaseInventory(zoneId, InventorySelection.standing(zoneItems.size(), orderKey));
+                    } else {
+                        event.releaseInventory(zoneId, InventorySelection.seated(seatNumbers, orderKey));
+                    }
+                    anyReleased = true;
+                } catch (RuntimeException zoneReleaseFailure) {
+                    log.warn(
+                            "Could not release inventory during checkout rollback. eventId={}, zoneId={}, orderKey={}",
+                            eventId, zoneId, orderKey, zoneReleaseFailure);
                 }
             }
 
-            eventRepository.save(event);
+            if (anyReleased) {
+                eventRepository.save(event);
+            }
         }
 
-        order.clear();
-        activeOrderRepository.save(order);
+        safelyClearCart(order);
+    }
+
+
+    // We clear and persist the cart after a rollback without letting a failure here mask the
+    // original checkout failure. The release loop above is resilient and always reaches this point,
+    // so the clear is no longer skipped by an earlier release throwing.
+    private void safelyClearCart(ActiveOrder order) {
+        try {
+            order.clear();
+            activeOrderRepository.save(order);
+        } catch (RuntimeException clearFailure) {
+            log.warn("Could not clear cart during checkout rollback for orderKey={}", order.getOrderKey(), clearFailure);
+        }
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -108,7 +108,7 @@ public class CompanyManagementService {
             ProductionCompany company = companyRepository.getCompanyById(request.companyId());
             notificationService.notifyOwnerAppointmentPending(request.targetUserId(), request.companyId(), company.getName());
         } catch (Exception e) {
-            log.warn("Owner appointment created but notification failed for userId={}", request.targetUserId());
+            log.warn("Owner appointment created but notification failed for userId={}", request.targetUserId(), e);
         }
 
         log.info("Owner appointment created successfully: appointerId={}, targetUserId={}, companyId={}",
@@ -138,7 +138,7 @@ public class CompanyManagementService {
             ProductionCompany company = companyRepository.getCompanyById(request.companyId());
             notificationService.notifyRoleChanged(request.targetUserId(), request.companyId(), company.getName(), "MANAGER");
         } catch (Exception e) {
-            log.warn("Manager appointment created but notification failed for userId={}", request.targetUserId());
+            log.warn("Manager appointment created but notification failed for userId={}", request.targetUserId(), e);
         }
 
         log.info("Manager appointment created successfully: ownerId={}, targetUserId={}, companyId={}, permissions={}",
@@ -175,7 +175,7 @@ public class CompanyManagementService {
             try {
                 notificationService.notifyRoleChanged(userId, response.companyId(), company.getName(), appointment.getRole().name());
             } catch (Exception e) {
-                log.warn("Appointment accepted but notification failed for userId={}", userId);
+                log.warn("Appointment accepted but notification failed for userId={}", userId, e);
             }
         } else {
             user.rejectInvitation(response.companyId()); // transitions the pending appointment to rejected state, status-based lookups will no longer return it.
@@ -217,7 +217,7 @@ public class CompanyManagementService {
             ProductionCompany company = companyRepository.getCompanyById(edit.companyId());
             notificationService.notifyRoleChanged(edit.targetUserId(), edit.companyId(), company.getName(), "MANAGER (permissions updated)");
         } catch (Exception e) {
-            log.warn("Manager permissions updated but notification failed for userId={}", edit.targetUserId());
+            log.warn("Manager permissions updated but notification failed for userId={}", edit.targetUserId(), e);
         }
 
         log.info("Manager permissions updated successfully for user {} in company {}", edit.targetUserId(),
@@ -249,7 +249,7 @@ public class CompanyManagementService {
         try {
             notificationService.notifyManagerRevoked(revokeRequest.targetUserId(), revokeRequest.companyId(), company.getName());
         } catch (Exception e) {
-            log.warn("Role revoked but notification failed for userId={}", revokeRequest.targetUserId());
+            log.warn("Role revoked but notification failed for userId={}", revokeRequest.targetUserId(), e);
         }
 
         log.info("Manager revoked successfully");

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -630,6 +630,35 @@ public class EventManagementService {
 
 
 
+    // UC-19 — owner opens an event's sales: SCHEDULED -> ON_SALE.
+    // The actual transition (and its venue-map/show-date/invariant guards) lives in
+    // Event.transitionToOnSale(); this method enforces auth, ownership, and locking.
+    public void publishEvent(String token, int companyId, int eventId) {
+        int userId = validateTokenAndGetUserId(token);
+
+        eventRepository.lockForUpdate(eventId);
+        try {
+            Event event = eventRepository.findById(eventId);
+
+            if (event.getCompanyId() != companyId) {
+                throw new RuntimeException("Event does not belong to this company");
+            }
+
+            User user = userRepository.getUserById(userId);
+            user.requirePermissionInCompany(companyId, Permission.CONFIGURE_VENUE);
+
+            event.transitionToOnSale(); // SCHEDULED -> ON_SALE (idempotent if already ON_SALE)
+            eventRepository.save(event);
+
+            log.info("Event {} published (ON_SALE) by user {}", eventId, userId);
+        } finally {
+            eventRepository.unlock(eventId);
+        }
+    }
+
+
+
+
     // UC-19 — soft cancel; fires EventCancelled domain event for UC-4 refund
     // pipeline.
     public void cancelEventAndRefund(String token, int eventId) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -805,7 +805,7 @@ public class EventManagementService {
             try {
                 notificationService.notifyEventCancelled(userId, eventId, eventName);
             } catch (Exception e) {
-                log.warn("Failed to send cancellation notification to userId={} for eventId={}", userId, eventId);
+                log.warn("Failed to send cancellation notification to userId={} for eventId={}", userId, eventId, e);
             }
         }
     }

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -17,6 +17,7 @@ import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
 import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
+import com.ticketing.system.Core.Application.dto.ShowDateDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
@@ -42,6 +43,7 @@ import com.ticketing.system.Core.Domain.users.User;
 import com.ticketing.system.Core.Domain.users.Permission;
 import com.ticketing.system.Core.Domain.events.Seat;
 import com.ticketing.system.Core.Domain.events.SeatedZone;
+import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.OrPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
@@ -138,6 +140,7 @@ public class EventManagementService {
         Event newEvent = new Event(
                 newEventId,
                 request.name(),
+                request.description(),
                 request.rating(),
                 request.artistsNames(),
                 request.category(),
@@ -155,7 +158,7 @@ public class EventManagementService {
                 String.valueOf(newEventId),
                 newEvent.getName(),
                 newEvent.getRating(),
-                request.description(),
+                newEvent.getDescription(),
                 newEvent.getCategory(),
                 request.location(),
                 String.valueOf(newEvent.getCompanyId()),
@@ -263,7 +266,17 @@ public class EventManagementService {
                 }
             }
 
-            event.editDetails(update.name(), newCategory);
+            Location newLocation = update.location() == null
+                    ? null
+                    : new Location(update.location().country(), update.location().city());
+
+            List<ShowDate> newShowDates = update.showDates() == null
+                    ? null
+                    : update.showDates().stream()
+                            .map(sd -> new ShowDate(sd.startsAt(), sd.endsAt()))
+                            .toList();
+
+            event.editDetails(update.name(), update.description(), newCategory, newLocation, newShowDates);
             eventRepository.save(event);
 
             log.info("Event {} details updated by user {}", eventId, userId);
@@ -581,7 +594,7 @@ public class EventManagementService {
 
 
     // Detail view for owner-side editing pages.
-    public EventDetailDTO getEventDetail(String token, String eventId) {
+    public EventDetailDTO getEventDetail(String token, String eventId) {  //TODO: make this eventId an int
         int userId = validateTokenAndGetUserId(token);
 
         int id;
@@ -604,7 +617,7 @@ public class EventManagementService {
                 String.valueOf(event.getId()),
                 event.getName(),
                 event.getRating(),
-                null, // Event domain doesn't persist description
+                event.getDescription(),
                 event.getCategory(),
                 location,
                 String.valueOf(event.getCompanyId()),

--- a/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
@@ -44,7 +44,15 @@ public class NotificationDispatchService {
      * 4. Updates status to DELIVERED if push succeeds.
      */
     public void dispatch(Notification notification) {
-        log.info("Dispatching notification for userId={}, type={}", 
+        // Precondition: a freshly-built notification must be PENDING. Enforced before any
+        // persistence/push so we never store an unexpected status or have markDelivered() throw
+        // mid-flow (Notification.markDelivered() requires the current status to be PENDING).
+        if (!notification.isPending()) {
+            throw new IllegalArgumentException(
+                    "dispatch() requires a PENDING notification, but got status: " + notification.getStatus());
+        }
+
+        log.info("Dispatching notification for userId={}, type={}",
                 notification.getRecipientUserId(), notification.getType());
 
         // Step 1: Persist (UC-36 logic integrated)

--- a/src/main/java/com/ticketing/system/Core/Application/services/NotificationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/NotificationService.java
@@ -2,6 +2,7 @@ package com.ticketing.system.Core.Application.services;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -122,7 +123,8 @@ public class NotificationService implements INotificationService {
                 NotificationType.EVENT_CANCELLED,
                 NotificationStatus.PENDING,
                 message,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                Map.<String, Object>of("eventId", eventId, "eventName", eventName)
         );
         dispatcher.dispatch(notification);
     }
@@ -136,7 +138,8 @@ public class NotificationService implements INotificationService {
                 NotificationType.MANAGER_REVOKED,
                 NotificationStatus.PENDING,
                 message,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                Map.<String, Object>of("companyId", companyId, "companyName", companyName)
         );
         dispatcher.dispatch(notification);
     }
@@ -150,7 +153,8 @@ public class NotificationService implements INotificationService {
                 NotificationType.OWNER_APPOINTMENT_PENDING,
                 NotificationStatus.PENDING,
                 message,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                Map.<String, Object>of("companyId", companyId, "companyName", companyName)
         );
         dispatcher.dispatch(notification);
     }
@@ -164,7 +168,8 @@ public class NotificationService implements INotificationService {
                 NotificationType.ROLE_CHANGED,
                 NotificationStatus.PENDING,
                 message,
-                LocalDateTime.now()
+                LocalDateTime.now(),
+                Map.<String, Object>of("companyId", companyId, "companyName", companyName, "newRole", newRole)
         );
         dispatcher.dispatch(notification);
     }

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -128,7 +128,7 @@ public class ReservationService {
             // Reserve inventory first before modifying the active order, so that if we fail to reserve inventory (e.g. not enough tickets available), we do not end up with an active order that has reservations that were not successfully made. This also ensures that we only modify the active order if we are able to successfully reserve the requested tickets, which keeps our data consistent and avoids having active orders that reflect reservations that do not actually exist.
             event.reserveInventory(zoneId, selectionWithKey);
             inventoryReserved = true;
-            //* */
+            
             // Now that we have successfully reserved the inventory, we can safely modify the active order to reflect the new reservation. If any of the validations for modifying the active order fail (e.g. trying to reserve more tickets than allowed by purchase policy, etc.), we will throw an exception and roll back the inventory reservation in the catch block, ensuring that we do not end up with an active order that has reservations that were not successfully made.
             activeOrder.addReservation(eventId, zoneId, selection, pricePerTicket, LocalDateTime.now());
             orderModified = true;
@@ -657,6 +657,47 @@ public class ReservationService {
                     log.info("No active order found for sessionId={}, returning null", sessionId);
                     return null;
                 });
+    }
+
+    // When a buyer enters the checkout page, reset the hold timer of every reserved ticket
+    // in their active order to a fresh full window (CartLineItem.EXPIRATION_LIMIT, 10 min),
+    // so the buyer gets the maximum time to complete payment. We only renew when the cart is
+    // still fully valid: if it is empty, already in checkout, or has any expired item, we
+    // leave it untouched so the existing expiry/sweeper path can reject the stale cart. The
+    // reset runs under the per-order lock (the same lock the expiry sweeper acquires first),
+    // so it cannot race the sweeper. The enriched DTO is built by reusing restoreActiveOrder.
+    public ActiveOrderDTO renewReservationsForMemberCheckout(int userId) {
+        String orderLockKey = "user:" + userId;
+        activeOrderRepository.lockForUpdate(orderLockKey);
+        try {
+            ActiveOrder order = activeOrderRepository.getByUserId(userId);
+            if (order != null && !order.isEmpty()
+                    && !order.isCheckoutInProgress() && !order.hasExpiredItem()) {
+                order.renewReservationTimers(LocalDateTime.now());
+                activeOrderRepository.save(order);
+                log.info("Renewed reservation timers on checkout entry for userId={}", userId);
+            }
+        } finally {
+            activeOrderRepository.unlock(orderLockKey);
+        }
+        return restoreActiveOrder(userId);
+    }
+
+    public ActiveOrderDTO renewReservationsForGuestCheckout(String sessionId) {
+        String orderLockKey = "sess:" + sessionId;
+        activeOrderRepository.lockForUpdate(orderLockKey);
+        try {
+            ActiveOrder order = activeOrderRepository.getBySessionId(sessionId).orElse(null);
+            if (order != null && !order.isEmpty()
+                    && !order.isCheckoutInProgress() && !order.hasExpiredItem()) {
+                order.renewReservationTimers(LocalDateTime.now());
+                activeOrderRepository.save(order);
+                log.info("Renewed reservation timers on checkout entry for sessionId={}", sessionId);
+            }
+        } finally {
+            activeOrderRepository.unlock(orderLockKey);
+        }
+        return restoreActiveOrderForGuest(sessionId);
     }
 
     // Helper method to abandon the active order for a user (member or guest) - this is used by the frontend when a user explicitly clicks "Abandon Cart" or when they log out, to clear their active order and release any reserved inventory back to the events. For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we release any reserved inventory back to the events and then delete the active order. If no active order is found, we simply return without doing anything. This ensures that we do not leave any reserved inventory hanging around for abandoned carts, which keeps our inventory accurate and allows other users to purchase those tickets if they are still available.

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -30,7 +30,7 @@ public class ReservationService {
     private final IActiveOrderRepository activeOrderRepository;
     private final ISessionManager iSessionManager;
     private final INotificationService notificationService;
-    
+
     @Value("${constants.ticket-reservation-duration}")
     private int reservationTimeoutMinutes;
 
@@ -46,23 +46,22 @@ public class ReservationService {
 
     }
 
-
-
-    
-
     // ---------------------------------------------------------------------
     // Public API - use these methods from new code/controllers/tests
     // ---------------------------------------------------------------------
 
-    public ReservationResultDTO reserveForMember(String token, int eventId, int zoneId, InventorySelectionDTO selectionDto) {
+    public ReservationResultDTO reserveForMember(String token, int eventId, int zoneId,
+            InventorySelectionDTO selectionDto) {
         return reserve(authenticateMember(token), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
-    public ReservationResultDTO reserveForGuest(String sessionId, int eventId, int zoneId, InventorySelectionDTO selectionDto) {
+    public ReservationResultDTO reserveForGuest(String sessionId, int eventId, int zoneId,
+            InventorySelectionDTO selectionDto) {
         return reserve(authenticateGuest(sessionId), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
-    public ReservationResultDTO removeForMember(String token, int eventId, int zoneId, InventorySelectionDTO selectionDto) {
+    public ReservationResultDTO removeForMember(String token, int eventId, int zoneId,
+            InventorySelectionDTO selectionDto) {
         return remove(authenticateMember(token), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
@@ -71,22 +70,9 @@ public class ReservationService {
         return remove(authenticateGuest(sessionId), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
-    
-
-    
-
-
-
-
-
-
-
-
-
     // ---------------------------------------------------------------------
     // Unified flows of reserve & remove
     // ---------------------------------------------------------------------
-
 
     private ReservationResultDTO reserve(BuyerContextDTO buyer, int eventId, int zoneId, InventorySelection selection) {
         log.info("Entered reserve: buyerType={}, eventId={}, zoneId={}, quantity={}, seats={}",
@@ -134,11 +120,11 @@ public class ReservationService {
             // }
 
             double pricePerTicket = zone.getprice();
-            
+
             // Bind the selection to this order's key so the zone records which order holds the reservation.
             // This enables the 3-phase checkout to verify ownership in Phase 3 without holding event locks during payment/issuance.
             InventorySelection selectionWithKey = selectionWithOrderKey(selection, activeOrder.getOrderKey());
-            
+
             // Reserve inventory first before modifying the active order, so that if we fail to reserve inventory (e.g. not enough tickets available), we do not end up with an active order that has reservations that were not successfully made. This also ensures that we only modify the active order if we are able to successfully reserve the requested tickets, which keeps our data consistent and avoids having active orders that reflect reservations that do not actually exist.
             event.reserveInventory(zoneId, selectionWithKey);
             inventoryReserved = true;
@@ -203,22 +189,8 @@ public class ReservationService {
                 }
             }
         }
-        
+
     }
-    
-
-
-
-
-
-
-
-
-
-    
-
-
-
 
     private ReservationResultDTO remove(BuyerContextDTO buyer, int eventId, int zoneId, InventorySelection selection) {
         log.info("Entered remove: buyerType={}, eventId={}, zoneId={}, quantity={}, seats={}",
@@ -316,15 +288,15 @@ public class ReservationService {
                     selection,
                     orderModified,
                     inventoryReleased,
-                    removedPricePerTicket
-            );
-            
+                    removedPricePerTicket);
+
             notifyFailureAfterUnlock = true;
             failureNotificationReason = "Remove reservation failed: " + e.getMessage();
 
             log.warn("remove failed: eventId={}, zoneId={}, selectionQuantity={}, seats={}, reason={}",
                     eventId, zoneId,
-                    selection == null ? null : selection.getQuantity(), selection == null ? null : selection.getSeatNumbers(),
+                    selection == null ? null : selection.getQuantity(),
+                    selection == null ? null : selection.getSeatNumbers(),
                     e.getMessage());
 
             throw e;
@@ -361,14 +333,8 @@ public class ReservationService {
                 }
             }
         }
-        
+
     }
-
-    
-
-
-
-
 
     // Helper method to convert the InventorySelectionDTO from the API layer to the InventorySelection domain object that is used in the service layer and domain layer.
     private InventorySelection toDomainSelection(InventorySelectionDTO selectionDto) {
@@ -390,16 +356,12 @@ public class ReservationService {
         }
     }
 
-    
-
-
-
     // ---------------------------------------------------------------------
     // Authentication / request parsing
     // ---------------------------------------------------------------------
 
     // Helper methods to authenticate the buyer based on the type of request (member vs guest) and extract the necessary information to create a BuyerContextDTO, which is used in the main flows to represent the buyer's context (e.g. whether they are a member or guest, their user ID if they are a member, their session ID if they are a guest, etc.). These methods also handle validation of the input tokens/session IDs and throw appropriate exceptions if the authentication fails (e.g. invalid token, expired token, missing session ID, etc.), which can be caught by the frontend to show appropriate error messages to the user.
-    
+
     private BuyerContextDTO authenticateMember(String token) {
         return BuyerContextDTO.member(validateTokenAndGetUserId(token));
     }
@@ -408,9 +370,6 @@ public class ReservationService {
         validateSessionId(sessionId);
         return BuyerContextDTO.guest(sessionId);
     }
-
-
-
 
     private int validateTokenAndGetUserId(String token) {
         if (token == null || token.isBlank()) {
@@ -433,17 +392,12 @@ public class ReservationService {
         return userId;
     }
 
-
-
-
     private void validateSessionId(String sessionId) {
         if (sessionId == null || sessionId.isBlank()) {
             log.warn("Request rejected: missing session ID");
             throw new IllegalArgumentException("Missing session ID");
         }
     }
-
-    
 
     // Validation of the main input arguments for both reserve and remove flows. This method is called at the beginning of both flows to ensure that the input is valid before we do any work. This helps us fail fast on invalid input and avoid doing unnecessary work or creating entities that we will not use if the input is invalid. It also ensures that we do not attempt to reserve or remove inventory for an event or zone that does not exist, which keeps our data consistent and avoids having active orders that reflect reservations or removals for events or zones that do not actually exist.
     private void validateReservationArguments(int eventId, int zoneId, InventorySelection selection) {
@@ -472,9 +426,6 @@ public class ReservationService {
         }
     }
 
-
-
-
     // ---------------------------------------------------------------------
     // helper functions - these are not part of the main flows but are used by multiple public methods, so they help keep the main flows clean and avoid code duplication.
     // ---------------------------------------------------------------------
@@ -490,7 +441,6 @@ public class ReservationService {
 
         return event;
     }
-
 
     // Helper method to get the inventory zone from the event's venue map and validate that it exists. This is used in both reserve and remove flows to ensure that we are working with a valid event and zone before we attempt to reserve or remove inventory, which keeps our data consistent and avoids having active orders that reflect reservations or removals for events or zones that do not actually exist. By centralizing this logic in a helper method, we also avoid code duplication and keep the main flows cleaner and more focused on the reservation and removal logic rather than the details of how we look up zones from events.
     private InventoryZone getZoneOrThrow(Event event, int zoneId) {
@@ -513,7 +463,6 @@ public class ReservationService {
 
     //getZone inconsistency — ReservationService.getZoneOrThrow (line 320) catches IllegalArgumentException and checks for null. Means VenueMap.getZone 
     // sometimes throws and sometimes returns null. Worth tightening that contract to one or the other so callers don't need to handle both.
-    
 
     // For members, we get or create an active order based on their user ID. For guests, we get or create an active order based on their session ID. This method abstracts away the logic of determining whether to use user ID or session ID and ensures that we always have an active order to work with in the main flows, which simplifies the logic in those flows and keeps them focused on the reservation and removal logic rather than the details of how we manage active orders for different types of buyers.
     private ActiveOrder getOrCreateActiveOrder(BuyerContextDTO buyer) {
@@ -533,7 +482,6 @@ public class ReservationService {
                 });
     }
 
-
     // For members, we get the active order based on their user ID. For guests, we get the active order based on their session ID. This method abstracts away the logic of determining whether to use user ID or session ID and ensures that we can easily retrieve the active order for the buyer in the main flows, which simplifies the logic in those flows and keeps them focused on the reservation and removal logic rather than the details of how we manage active orders for different types of buyers. We also throw an exception if no active order is found for the buyer, which allows us to handle that case in the main flows (e.g. show an error message to the user if they try to remove a reservation but they do not have an active order).
     private ActiveOrder getActiveOrderOrThrow(BuyerContextDTO buyer) {
         if (buyer.isMember()) {
@@ -548,11 +496,9 @@ public class ReservationService {
                 .orElseThrow(() -> new IllegalArgumentException("Active order not found"));
     }
 
-
     // ---------------------------------------------------------------------
     // Rollback / notifications / DTOs
     // ---------------------------------------------------------------------
-
 
     // Helper method to roll back any changes made during the reservation or removal process if an exception occurs, in order to keep our data consistent. This includes releasing any inventory that was reserved and re-adding any reservations that were removed from the active order. We also log any exceptions that occur during the rollback process for monitoring and debugging purposes, but we do not rethrow those exceptions since we want to ensure that the original exception from the reservation or removal process is what gets propagated to indicate the failure of the operation, while still making a best effort to roll back any changes to keep our data consistent.
     private void rollbackReservationIfNeeded(Event event, ActiveOrder activeOrder, int eventId, int zoneId,
@@ -584,12 +530,11 @@ public class ReservationService {
             // best-effort rollback; the main exception is rethrown by caller
         }
     }
-    
 
     // rollback the cart if inventory release fails, and rollback inventory if the later cart/save flow fails
     private void rollbackRemoveIfNeeded(Event event, ActiveOrder activeOrder, int eventId, int zoneId,
-                                        InventorySelection selection, boolean orderModified,
-                                        boolean inventoryReleased,double pricePerTicket) {
+            InventorySelection selection, boolean orderModified,
+            boolean inventoryReleased, double pricePerTicket) {
         if (!inventoryReleased && !orderModified) {
             return;
         }
@@ -626,15 +571,11 @@ public class ReservationService {
         }
     }
 
-
-
-
     private void notifyReservationSuccessIfMember(BuyerContextDTO buyer, int eventId, int zoneId, int quantity) {
         if (buyer.isMember()) {
             notificationService.notifyTicketReservationSuccess(buyer.userId(), eventId, zoneId, quantity);
         }
     }
-
 
     private void notifyReservationFailureIfMember(BuyerContextDTO buyer, int eventId, int zoneId, String reason) {
         if (buyer != null && buyer.isMember()) {
@@ -642,20 +583,17 @@ public class ReservationService {
         }
     }
 
-
     private void notifyRemoveSuccessIfMember(BuyerContextDTO buyer, int eventId, int zoneId, int quantity) {
         if (buyer.isMember()) {
             notificationService.notifyRemoveTicketReservationSuccess(buyer.userId(), eventId, zoneId, quantity);
         }
     }
 
-
     private void notifyRemoveFailureIfMember(BuyerContextDTO buyer, int eventId, int zoneId, String reason) {
         if (buyer != null && buyer.isMember()) {
             notificationService.notifyRemoveTicketReservationFailure(buyer.userId(), eventId, zoneId, reason);
         }
     }
-
 
     // Helper method to build the reservation result DTO that is returned by the reserve and remove methods, which includes details about the reservation such as event ID, zone ID, quantity reserved/removed, seat numbers if applicable, and the expiration time of the reservation (based on the current time plus the configured reservation timeout). This information can be used by the frontend to show the user their current reservations and how long they have before they expire, etc.
     private ReservationResultDTO buildReservationResult(int eventId, int zoneId, InventorySelection selection) {
@@ -666,20 +604,6 @@ public class ReservationService {
                 selection.getSeatNumbers(),
                 LocalDateTime.now().plusMinutes(this.reservationTimeoutMinutes));
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     // method to restore an active order for a user (member) - this is used by the frontend when a user logs in or returns to the site after navigating away, to restore their active order and show them their current reservations in the cart. For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we convert it to an ActiveOrderDTO and return it. If no active order is found, we return null. We also enrich the DTO with event names for better UX in the frontend, so that the frontend can show the event names directly in the cart without needing to make extra calls to get event details for each line item.
     public ActiveOrderDTO restoreActiveOrder(int userId) {
@@ -713,9 +637,6 @@ public class ReservationService {
                 enrichedLines);
     }
 
-
-
-
     public ActiveOrderDTO restoreActiveOrderForGuest(String sessionId) {
         return activeOrderRepository.getBySessionId(sessionId)
                 .map(order -> {
@@ -737,9 +658,6 @@ public class ReservationService {
                     return null;
                 });
     }
-
-
-
 
     // Helper method to abandon the active order for a user (member or guest) - this is used by the frontend when a user explicitly clicks "Abandon Cart" or when they log out, to clear their active order and release any reserved inventory back to the events. For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we release any reserved inventory back to the events and then delete the active order. If no active order is found, we simply return without doing anything. This ensures that we do not leave any reserved inventory hanging around for abandoned carts, which keeps our inventory accurate and allows other users to purchase those tickets if they are still available.
     public void abandonActiveOrder(BuyerContextDTO buyer) {
@@ -804,7 +722,8 @@ public class ReservationService {
                     Event event = eventRepository.findById(line.eventId());
 
                     if (event == null) {
-                        log.warn("Event {} not found while abandoning active order. Skipping inventory release.", line.eventId());
+                        log.warn("Event {} not found while abandoning active order. Skipping inventory release.",
+                                line.eventId());
                         continue;
                     }
                     // Create an InventorySelection for the line item. If the line has a seat number, we create a seated selection with that seat number. 
@@ -817,7 +736,8 @@ public class ReservationService {
                     event.releaseInventory(line.zoneId(), selection);
                     eventRepository.save(event);
                 } catch (RuntimeException e) {
-                    log.warn("Failed to release inventory while abandoning active order. eventId={}, zoneId={}, seatNumber={}, reason={}",
+                    log.warn(
+                            "Failed to release inventory while abandoning active order. eventId={}, zoneId={}, seatNumber={}, reason={}",
                             line.eventId(), line.zoneId(), line.seatNumber(), e.getMessage());
                 }
             }
@@ -840,101 +760,120 @@ public class ReservationService {
     }
 
     /**
- * Removes a line from the cart, automatically determining whether the user is a Member or Guest.
- * The UI just calls this method, no need to handle InventorySelectionDTO or user type.
- */
-public ReservationResultDTO removeLine(String userTokenOrSessionId, int eventId, int zoneId, InventorySelectionDTO selection) {
-   
-    boolean isMember = isMember(userTokenOrSessionId); 
-    if (isMember) {
-        return removeForMember(userTokenOrSessionId, eventId, zoneId, selection);
-    } else {
-        return removeForGuest(userTokenOrSessionId, eventId, zoneId, selection);
-    }
-}
+    * Removes a line from the cart, automatically determining whether the user is a Member or Guest.
+    * The UI just calls this method, no need to handle InventorySelectionDTO or user type.
+    */
+    public ReservationResultDTO removeLine(String userTokenOrSessionId, int eventId, int zoneId,
+            InventorySelectionDTO selection) {
 
-/**
- * Determines if the given credential is a member JWT (vs a guest session ID).
- * JWTs have two dots; guest session IDs are UUIDs with none.
- * Only silences exceptions for the guest path — a credential that looks like
- * a JWT but fails validation throws so the caller sees the real failure.
- */
-private boolean isMember(String userTokenOrSessionId) {
-    if (userTokenOrSessionId == null || userTokenOrSessionId.isBlank()) {
-        throw new IllegalArgumentException("User token or session ID cannot be null or empty");
-    }
-    if (!looksLikeJwt(userTokenOrSessionId)) {
-        return false;
-    }
-    int userId = validateTokenAndGetUserId(userTokenOrSessionId);
-    return userId > 0;
-}
-
-private static boolean looksLikeJwt(String s) {
-    int dot1 = s.indexOf('.');
-    if (dot1 <= 0) return false;
-    return s.indexOf('.', dot1 + 1) > dot1;
-}
-
-
-
-public void expireActiveOrders() {
-    List<ActiveOrder> expiredOrders = activeOrderRepository.findExpired();
-    if (expiredOrders == null || expiredOrders.isEmpty()) return;
-    for (ActiveOrder order : expiredOrders) {
-        safelyReleaseAndDelete(order);
-    }
-}
-private void safelyReleaseAndDelete(ActiveOrder order) {
-    String lockKey = order.getUserId() != 0
-        ? "user:" + order.getUserId()
-        : "sess:" + order.getSessionId();
-
-    activeOrderRepository.lockForUpdate(lockKey);
-    try {
-        for (ActiveOrderDTO.CartLineDTO line : order.toDTO().lines()) {
-            try {
-                Event event = eventRepository.findById(line.eventId());
-                if (event != null) {
-                    eventRepository.lockForUpdate(line.eventId());
-                    try {
-                        InventorySelection selection = (line.seatNumber() != null)
-                            ? InventorySelection.seated(List.of(line.seatNumber()))
-                            : InventorySelection.standing(1);
-                        event.releaseInventory(line.zoneId(), selection);
-                        eventRepository.save(event);
-                    } finally {
-                        eventRepository.unlock(line.eventId());
-                    }
-                }
-            } catch (RuntimeException e) {
-                log.warn("Failed to release inventory for expired order ...", e.getMessage());
-            }
+        boolean isMember = isMember(userTokenOrSessionId);
+        if (isMember) {
+            return removeForMember(userTokenOrSessionId, eventId, zoneId, selection);
+        } else {
+            return removeForGuest(userTokenOrSessionId, eventId, zoneId, selection);
         }
-        activeOrderRepository.delete(order);
-    } catch (Exception e) {
-        log.error("Failed to expire order for userId={} sessionId={}",
-            order.getUserId(), order.getSessionId(), e);
-    } finally {
-        activeOrderRepository.unlock(lockKey);
     }
-}
+
+    /**
+     * Determines if the given credential is a member JWT (vs a guest session ID).
+     * JWTs have two dots; guest session IDs are UUIDs with none.
+     * Only silences exceptions for the guest path — a credential that looks like
+     * a JWT but fails validation throws so the caller sees the real failure.
+     */
+    private boolean isMember(String userTokenOrSessionId) {
+        if (userTokenOrSessionId == null || userTokenOrSessionId.isBlank()) {
+            throw new IllegalArgumentException("User token or session ID cannot be null or empty");
+        }
+        if (!looksLikeJwt(userTokenOrSessionId)) {
+            return false;
+        }
+        int userId = validateTokenAndGetUserId(userTokenOrSessionId);
+        return userId > 0;
+    }
+
+    private static boolean looksLikeJwt(String s) {
+        int dot1 = s.indexOf('.');
+        if (dot1 <= 0)
+            return false;
+        return s.indexOf('.', dot1 + 1) > dot1;
+    }
 
     // Helper method to view the current active order for a user (member or guest). For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we convert it to an ActiveOrderDTO and return it. If no active order is found, we return null. This allows the frontend to show the user their current reservations in the cart when they navigate to the cart page, etc.
     public ActiveOrderDTO viewMyActiveOrder(String userOrSessionId) {
-    if (userOrSessionId == null || userOrSessionId.isBlank()) {
-        return null;
+        if (userOrSessionId == null || userOrSessionId.isBlank()) {
+            return null;
+        }
+        try {
+            if (iSessionManager.validateToken(userOrSessionId)) {
+                int userId = iSessionManager.extractUserId(userOrSessionId);
+                return restoreActiveOrder(userId);
+            }
+        } catch (Exception ignored) {
+            // not a JWT token — fall through to guest path
+        }
+        return restoreActiveOrderForGuest(userOrSessionId);
     }
-    try {
-    if (iSessionManager.validateToken(userOrSessionId)) {
-        int userId = iSessionManager.extractUserId(userOrSessionId);
-        return restoreActiveOrder(userId);
-    }
-} catch (Exception ignored) {
-    // not a JWT token — fall through to guest path
-}
-return restoreActiveOrderForGuest(userOrSessionId);
-}
+
+    
+
+    // COMMENTED OUT: expireActiveOrders / safelyReleaseAndDelete are a second, orphaned cart-expiry
+    // path that duplicates the live @Scheduled SessionAndOrderSweeper. They have no callers anywhere
+    // in the codebase (dead code), and the live sweeper is the single source of truth for expiry-driven
+    // inventory release. Keeping a callable public duplicate is a foot-gun: wiring it up would
+    // reintroduce the "buyer loses seats mid-payment" bug the sweeper is careful to avoid. The
+    // in-checkout guard below is preserved so that if this is ever revived it already matches the
+    // sweeper's behavior. Left in (commented) rather than deleted for reference/history.
+    //
+    // public void expireActiveOrders() {
+    //     List<ActiveOrder> expiredOrders = activeOrderRepository.findExpired();
+    //     if (expiredOrders == null || expiredOrders.isEmpty()) return;
+    //     for (ActiveOrder order : expiredOrders) {
+    //         safelyReleaseAndDelete(order);
+    //     }
+    // }
+    // private void safelyReleaseAndDelete(ActiveOrder order) {
+    //     String lockKey = order.getUserId() != 0
+    //         ? "user:" + order.getUserId()
+    //         : "sess:" + order.getSessionId();
+    //
+    //     activeOrderRepository.lockForUpdate(lockKey);
+    //     try {
+    //         // Mirror SessionAndOrderSweeper: never release/delete an order that is mid-checkout.
+    //         // Checkout's own failure handling resets it to PRE_CHECKOUT, after which a later sweep
+    //         // can clean it up if still expired. Releasing inventory under an active checkout would
+    //         // break a buyer who is currently paying.
+    //         if (order.isCheckoutInProgress()) {
+    //             log.info("Skipping expired order for userId={} sessionId={} because checkout is in progress",
+    //                 order.getUserId(), order.getSessionId());
+    //             return;
+    //         }
+    //         for (ActiveOrderDTO.CartLineDTO line : order.toDTO().lines()) {
+    //             try {
+    //                 Event event = eventRepository.findById(line.eventId());
+    //                 if (event != null) {
+    //                     eventRepository.lockForUpdate(line.eventId());
+    //                     try {
+    //                         InventorySelection selection = (line.seatNumber() != null)
+    //                             ? InventorySelection.seated(List.of(line.seatNumber()))
+    //                             : InventorySelection.standing(1);
+    //                         event.releaseInventory(line.zoneId(), selection);
+    //                         eventRepository.save(event);
+    //                     } finally {
+    //                         eventRepository.unlock(line.eventId());
+    //                     }
+    //                 }
+    //             } catch (RuntimeException e) {
+    //                 log.warn("Failed to release inventory for expired order ...", e.getMessage());
+    //             }
+    //         }
+    //         activeOrderRepository.delete(order);
+    //     } catch (Exception e) {
+    //         log.error("Failed to expire order for userId={} sessionId={}",
+    //             order.getUserId(), order.getSessionId(), e);
+    //     } finally {
+    //         activeOrderRepository.unlock(lockKey);
+    //     }
+    // }
 
 
 

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
@@ -485,6 +485,16 @@ public class ActiveOrder implements InvariantChecked {
         return createdAt;
     }
 
+    /** Resets every line item's hold timer to a fresh full window starting at {@code now}. */
+    public void renewReservationTimers(LocalDateTime now) {
+        synchronized (itemsLock) {
+            ensureModifiable();              // refuses while CHECKOUT_IN_PROGRESS (existing guard)
+            for (CartLineItem item : items) {
+                item.renew(now);
+            }
+        }
+    }
+
     // returns the minimum remaining time among the items in the active order, which represents the time until the next item expires. If there are no items, returns Duration.ZERO.
     public Duration getRemainingTime() {
         synchronized (itemsLock) {

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
@@ -48,14 +48,12 @@ public class ActiveOrder implements InvariantChecked {
     private final String orderKey = UUID.randomUUID().toString();
 
     public ActiveOrder(Integer userId, String sessionId) {
-        if (userId == null && sessionId == null) {
-            throw new IllegalArgumentException("ActiveOrder must have at least a userId or a sessionId");
-        }
         this.userId = userId;
         this.sessionId = sessionId;
         this.status = ActiveOrderStatus.PRE_CHECKOUT;
         this.items = new ArrayList<>();
         this.createdAt = LocalDateTime.now();
+        checkInvariants();
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
@@ -1,11 +1,12 @@
 package com.ticketing.system.Core.Domain.ActiveOrder;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO.CartLineDTO;
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
 import java.time.LocalDateTime;
 import java.time.Duration;
 
-public class CartLineItem {
+public class CartLineItem implements InvariantChecked {
 
     private int eventId;
     private int zoneId;
@@ -20,6 +21,26 @@ public class CartLineItem {
         this.seatNumber = seatNumber;
         this.priceAtoneticketReservation = priceAtReservation;
         this.addedAt = addedAt;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (eventId <= 0) {
+            throw new IllegalStateException("CartLineItem invariant violated: eventId must be positive (was " + eventId + ")");
+        }
+        if (zoneId < 0) {
+            throw new IllegalStateException("CartLineItem invariant violated: zoneId must be non-negative (was " + zoneId + ")");
+        }
+        if (priceAtoneticketReservation < 0) {
+            throw new IllegalStateException("CartLineItem invariant violated: price must be >= 0 (was " + priceAtoneticketReservation + ")");
+        }
+        if (addedAt == null) {
+            throw new IllegalStateException("CartLineItem invariant violated: addedAt must not be null");
+        }
+        if (seatNumber != null && seatNumber.isBlank()) {
+            throw new IllegalStateException("CartLineItem invariant violated: seatNumber must not be blank if provided");
+        }
     }
 
     // Getters

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
@@ -60,6 +60,12 @@ public class CartLineItem implements InvariantChecked {
         return addedAt;
     }
 
+    /** Resets the reservation hold timer to a fresh window starting at {@code newAddedAt}. */
+    public void renew(LocalDateTime newAddedAt) {
+        this.addedAt = newAddedAt;
+        checkInvariants();   // re-runs the existing invariant guard (addedAt != null, etc.)
+    }
+
     public String getSeatNumber() {
         return seatNumber;
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/Admin/Admin.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/Admin/Admin.java
@@ -17,6 +17,7 @@ public class Admin implements InvariantChecked {
         this.username = username;
         this.passwordHash = passwordHash;
         this.isDefault = isDefault;
+        checkInvariants();
     }
 
     public int getId() { return id; }

--- a/src/main/java/com/ticketing/system/Core/Domain/Tickets/Ticket.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/Tickets/Ticket.java
@@ -32,13 +32,11 @@ public class Ticket implements InvariantChecked {
         this.seatNumber = seatLabel;    // nullable for standing zones, non-null for seated zones
         this.price = price;
         this.ticketId = ticketId;
-        if (orderReceiptId <= 0) {
-            throw new IllegalArgumentException("orderReceiptId must be positive");
-        }
         this.orderReceiptId = orderReceiptId;
         this.barcodeValue = barcodeValue;
         this.status = TicketStatus.PAID; // Default initial status, because tickets are created at payment time in the current design. Adjust as needed if creation timing changes.
         this.holderUserId = null;
+        checkInvariants();
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
@@ -42,6 +42,7 @@ public class ProductionCompany implements InvariantChecked {
         this.discountPolicies = new ArrayList<>();
         this.purchasePolicy = new NoPurchasePolicy();
         this.managers = new ArrayList<>();
+        checkInvariants();
     }
 
     public void addManager(int targetId) {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicy.java
@@ -2,18 +2,23 @@ package com.ticketing.system.Core.Domain.events;
 
 import java.time.LocalDateTime;
 
-public class DiscountPolicy { //? Note: but not in implementation plan  <------------   <-----------    <---------------
-    
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class DiscountPolicy implements InvariantChecked { //? Note: but not in implementation plan  <------------   <-----------    <---------------
+
     private final double discountPercentage;  // Discount percentage (0-100)
 
     public DiscountPolicy(double discountPercentage) {
-        if (discountPercentage < 0 || discountPercentage > 100) {
-            throw new IllegalArgumentException("Invalid discount percentage");
-        }
-        // if(discountPercentage == null) {
-        //     throw new IllegalArgumentException("Discount percentage cannot be null");
-        // }
         this.discountPercentage = discountPercentage;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (discountPercentage < 0 || discountPercentage > 100) {
+            throw new IllegalStateException(
+                    "DiscountPolicy invariant violated: discountPercentage must be between 0 and 100 (was " + discountPercentage + ")");
+        }
     }
 
     public double apply(double price) {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -30,56 +30,25 @@ public class Event implements InvariantChecked {
     public Event(int id, String name, Double rating, List<String> artistsNames, EventCategory category, int comapnyid,
             EventStatus status, VenueMap venueMap, List<ShowDate> showDates, PurchasePolicy PurchasePolicy,
          DiscountPolicy discountPolicy) {
+        // Invariants are enforced by checkInvariants() at the end of construction
+        // (single source of truth). Collection copies are null-safe so a null input
+        // reaches checkInvariants() as a clean IllegalStateException instead of an NPE here.
         this.id = id;
-
-        if (name == null || name.isBlank()) {
-            log.error("Attempted to create Event with invalid name: '{}'", name);
-            throw new IllegalArgumentException("Event name is required");
-        }
         this.name = name;
-
-        if(rating != null && (rating < 0 || rating > 5)) {
-            log.error("Attempted to create Event with invalid rating: '{}'", rating);
-            throw new IllegalArgumentException("Event rating must be between 0 and 5");
-        }
         this.rating = rating;
-
-        if(artistsNames == null || artistsNames.isEmpty()) {
-            log.error("Attempted to create Event with null/empty artistsNames list");
-            throw new IllegalArgumentException("Artists names list is required");
-        }
-        this.artistsNames = List.copyOf(artistsNames);
-
-        if (category == null) {
-            log.error("Attempted to create Event with null category");
-            throw new IllegalArgumentException("Event category is required");
-        }
+        this.artistsNames = artistsNames == null ? null : List.copyOf(artistsNames);
         this.category = category;
-
-        if (comapnyid <= 0) {
-            log.error("Attempted to create Event with invalid companyId: '{}'", comapnyid);
-            throw new IllegalArgumentException("Company ID must be positive");
-        }
-        
         this.comapnyid = comapnyid;
         this.status = status;
         this.venueMap = venueMap;
-
-        if(showDates == null || showDates.isEmpty()) {
-            log.error("Attempted to create Event with null/empty showDates list");
-            throw new IllegalArgumentException("Show dates list is required");
-         }
-         this.showDates = List.copyOf(showDates);
-        
-         if (PurchasePolicy == null) {
-            this.purchasePolicy = new NoPurchasePolicy();
-        } else {
-            this.purchasePolicy = PurchasePolicy;
-        }
-        // Discount Policies are not currently in the implementation plan so in the creation of the event we manually, 
+        this.showDates = showDates == null ? null : List.copyOf(showDates);
+        // purchasePolicy defaults to NoPurchasePolicy when not supplied.
+        this.purchasePolicy = PurchasePolicy == null ? new NoPurchasePolicy() : PurchasePolicy;
+        // Discount Policies are not currently in the implementation plan so in the creation of the event we manually,
         // without outside intervention, set the discount to 0, not doing any discount automatically without the ability to
         // change this from the outside right now.
         this.discountPolicy = discountPolicy;
+        checkInvariants();
     }
 
 
@@ -526,6 +495,10 @@ public class Event implements InvariantChecked {
         if (name == null || name.isBlank()) {
             throw new IllegalStateException("Event invariant violated: name must be non-blank");
         }
+        if (rating != null && (rating < 0 || rating > 5)) {
+            throw new IllegalStateException(
+                    "Event invariant violated: rating must be between 0 and 5 (was " + rating + ")");
+        }
         if (comapnyid <= 0) {
             throw new IllegalStateException(
                     "Event invariant violated: companyId must be positive (was " + comapnyid + ")");
@@ -536,11 +509,11 @@ public class Event implements InvariantChecked {
         if (category == null) {
             throw new IllegalStateException("Event invariant violated: category must not be null");
         }
-        if (artistsNames == null) {
-            throw new IllegalStateException("Event invariant violated: artistsNames list must not be null");
+        if (artistsNames == null || artistsNames.isEmpty()) {
+            throw new IllegalStateException("Event invariant violated: artistsNames list must be non-empty");
         }
-        if (showDates == null) {
-            throw new IllegalStateException("Event invariant violated: showDates list must not be null");
+        if (showDates == null || showDates.isEmpty()) {
+            throw new IllegalStateException("Event invariant violated: showDates list must be non-empty");
         }
         if (purchasePolicy == null) {
             throw new IllegalStateException("Event invariant violated: purchasePolicy must not be null");

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -187,6 +188,12 @@ public class Event implements InvariantChecked {
         }
 
         this.venueMap = venueMap;
+
+        // UC-20: binding a venue map with inventory advances a draft event to SCHEDULED.
+        // Reconfiguring an already-scheduled (or later) event leaves its status untouched.
+        if (status == EventStatus.DRAFT && !venueMap.getInventoryZones().isEmpty()) {
+            transitionToScheduled();
+        }
     }
 
 
@@ -309,26 +316,44 @@ public class Event implements InvariantChecked {
 
 
 
-    // UC-19 / UC-32 — DRAFT/SCHEDULED -> ON_SALE when admin opens or owner publishes.
+    // UC-20 — DRAFT -> SCHEDULED once a venue map with inventory is bound (tickets pre-generated).
+    // Auto-fired from configureVenueMap; safe to call directly (idempotent when already SCHEDULED).
+    public void transitionToScheduled() {
+        if (status == EventStatus.SCHEDULED) {
+            return;
+        }
+
+        if (venueMap == null || venueMap.getInventoryZones().isEmpty()) {
+            throw new InvalidStateTransitionException(
+                    "Event cannot be scheduled without a venue map and at least one inventory zone");
+        }
+
+        if (status != EventStatus.DRAFT) {
+            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.SCHEDULED.name());
+        }
+
+        this.status = EventStatus.SCHEDULED;
+    }
+
+
+    // UC-19 / UC-32 — SCHEDULED -> ON_SALE when admin opens or owner publishes.
     public void transitionToOnSale() {
         if (status == EventStatus.ON_SALE) {
             return;
         }
 
         if (venueMap == null || venueMap.getInventoryZones().isEmpty()) {
-            throw new IllegalStateException("Cannot publish event without venue map and inventory");
+            throw new InvalidStateTransitionException("Cannot publish event without venue map and inventory");
         }
 
         if (showDates.isEmpty()) {
-            throw new IllegalStateException("All show dates must be present before going on sale");
+            throw new InvalidStateTransitionException("All show dates must be present before going on sale");
         }
 
         checkInvariants(); // enforce all invariants before allowing sales to start
 
-        //TODO:   <<------------------  see what more checks are needed to be added here   <----------------
-
         if (status != EventStatus.SCHEDULED) {
-            throw new IllegalStateException("Only scheduled events can go on sale");
+            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.ON_SALE.name());
         }
 
         this.status = EventStatus.ON_SALE;

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -444,7 +444,12 @@ public class Event implements InvariantChecked {
         if (newLocation != null && this.venueMap != null) {
             this.venueMap.setLocation(newLocation);
         }
-        if (newShowDates != null && !newShowDates.isEmpty()) {
+        if (newShowDates != null) {
+            // null means "leave the schedule alone"; an explicitly empty list is rejected
+            // rather than silently ignored, since an event must always have >=1 show date.
+            if (newShowDates.isEmpty()) {
+                throw new IllegalArgumentException("showDates cannot be empty; an event must have at least one show date");
+            }
             this.showDates = List.copyOf(newShowDates);
         }
         checkInvariants();

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -17,24 +17,35 @@ import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
 public class Event implements InvariantChecked {
     private final int id;
     private String name;
+    private String description;
     private final Double rating;
     private final List<String> artistsNames;
     private EventCategory category;
     private final int comapnyid;
     private EventStatus status;
     private VenueMap venueMap;
-    private final List<ShowDate> showDates;
+    private List<ShowDate> showDates;
     private PurchasePolicy purchasePolicy;
     private final DiscountPolicy discountPolicy;
 
+    // Description-less constructor — kept for existing callers/tests. Delegates with a null
+    // description (description is optional and carries no invariant).
     public Event(int id, String name, Double rating, List<String> artistsNames, EventCategory category, int comapnyid,
             EventStatus status, VenueMap venueMap, List<ShowDate> showDates, PurchasePolicy PurchasePolicy,
          DiscountPolicy discountPolicy) {
+        this(id, name, null, rating, artistsNames, category, comapnyid, status, venueMap, showDates,
+                PurchasePolicy, discountPolicy);
+    }
+
+    public Event(int id, String name, String description, Double rating, List<String> artistsNames,
+            EventCategory category, int comapnyid, EventStatus status, VenueMap venueMap, List<ShowDate> showDates,
+            PurchasePolicy PurchasePolicy, DiscountPolicy discountPolicy) {
         // Invariants are enforced by checkInvariants() at the end of construction
         // (single source of truth). Collection copies are null-safe so a null input
         // reaches checkInvariants() as a clean IllegalStateException instead of an NPE here.
         this.id = id;
         this.name = name;
+        this.description = description;
         this.rating = rating;
         this.artistsNames = artistsNames == null ? null : List.copyOf(artistsNames);
         this.category = category;
@@ -413,24 +424,38 @@ public class Event implements InvariantChecked {
 
     // UC-19 — partial update of mutable metadata. Only allowed in DRAFT or SCHEDULED state.
     // Caller must hold the event lock (IEventRepository.lockForUpdate) before calling this method —
-    // name and category are non-final, so concurrent reads depend on the service's lock discipline.
-    // location and showDates are intentionally excluded: EventUpdateDTO carries location as a
-    // plain String (not a Location record) and showDates as List<LocalDateTime> (not List<ShowDate>),
-    // so neither can be safely mapped without a DTO redesign.
-    public void editDetails(String newName, EventCategory newCategory) {
+    // the mutated fields are non-final, so concurrent reads depend on the service's lock discipline.
+    // Each argument is null-coalesced: null means "leave this field alone". The service is
+    // responsible for converting LocationDTO/ShowDateDTO into the domain Location/ShowDate passed here.
+    public void editDetails(String newName, String newDescription, EventCategory newCategory,
+            Location newLocation, List<ShowDate> newShowDates) {
         if (status != EventStatus.DRAFT && status != EventStatus.SCHEDULED) {
             throw new IllegalStateException("Event details can only be edited while in DRAFT or SCHEDULED state");
         }
         if (newName != null && !newName.isBlank()) {
             this.name = newName;
         }
+        if (newDescription != null) {
+            this.description = newDescription;
+        }
         if (newCategory != null) {
             this.category = newCategory;
         }
+        if (newLocation != null && this.venueMap != null) {
+            this.venueMap.setLocation(newLocation);
+        }
+        if (newShowDates != null && !newShowDates.isEmpty()) {
+            this.showDates = List.copyOf(newShowDates);
+        }
+        checkInvariants();
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public Double getRating() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -63,12 +63,21 @@ public class Event implements InvariantChecked {
     public boolean reserveInventory(int zoneId, InventorySelection selection) {
         validateCanReserve(selection);
         this.venueMap.reserveInventory(zoneId, selection);
+        // When the last available place/seat is taken, the event sells out automatically.
+        if (status == EventStatus.ON_SALE && !venueMap.hasAvailableInventory()) {
+            markSoldOut();
+        }
         return true;
     }
 
     public boolean releaseInventory(int zoneId, InventorySelection selection) {
         validateInventoryAction(selection);
         this.venueMap.releaseInventory(zoneId, selection);
+        // Releasing inventory (manual removal, checkout rollback, or expiry sweep) re-opens
+        // a sold-out event for sale again.
+        if (status == EventStatus.SOLD_OUT && venueMap.hasAvailableInventory()) {
+            revertToOnSale();
+        }
         return true;
     }
 
@@ -99,7 +108,9 @@ public class Event implements InvariantChecked {
     private void validateCanConfirmSale(InventorySelection selection) {
         validateInventoryAction(selection);
 
-        if (status != EventStatus.ON_SALE) {
+        // SOLD_OUT is allowed: an event that sold out while tickets were reserved must still let
+        // the holders of those reservations complete their purchase (reserved -> sold).
+        if (status != EventStatus.ON_SALE && status != EventStatus.SOLD_OUT) {
             throw new IllegalStateException("Cannot confirm ticket sale for an event that is not on sale");
         }
     }
@@ -364,16 +375,32 @@ public class Event implements InvariantChecked {
 
 
     // ON_SALE -> SOLD_OUT when no AVAILABLE tickets remain.
+    // Auto-fired from reserveInventory; safe to call directly (idempotent when already SOLD_OUT).
     public void markSoldOut() {
         if (status == EventStatus.SOLD_OUT) {
             return;
         }
 
         if (status != EventStatus.ON_SALE) {
-            throw new IllegalStateException("Only on-sale events can be marked as sold out");
+            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.SOLD_OUT.name());
         }
 
         this.status = EventStatus.SOLD_OUT;
+    }
+
+
+    // SOLD_OUT -> ON_SALE when availability reappears (a reservation is released).
+    // Auto-fired from releaseInventory; safe to call directly (idempotent when already ON_SALE).
+    public void revertToOnSale() {
+        if (status == EventStatus.ON_SALE) {
+            return;
+        }
+
+        if (status != EventStatus.SOLD_OUT) {
+            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.ON_SALE.name());
+        }
+
+        this.status = EventStatus.ON_SALE;
     }
 
     

--- a/src/main/java/com/ticketing/system/Core/Domain/events/InventorySelection.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/InventorySelection.java
@@ -5,6 +5,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
 /**
  * Domain value object representing a buyer's inventory selection.
  *
@@ -17,7 +19,7 @@ import java.util.Set;
  * concept as part of business logic.
  */
 // This avoids passing random combinations of: quantity, ticketId, seatNumber and seatNumbers, all over the system.
-public final class InventorySelection {
+public final class InventorySelection implements InvariantChecked {
 
     private final int quantity;                // tickets quantity, For standing zones, this is the only relevant field.
     private final List<String> seatNumbers;    // only non-empty For seated zones, must contain no duplicates.
@@ -27,6 +29,36 @@ public final class InventorySelection {
         this.quantity = quantity;
         this.seatNumbers = seatNumbers == null ? List.of() : List.copyOf(seatNumbers);
         this.orderKey = orderKey;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (seatNumbers == null) {
+            throw new IllegalStateException("InventorySelection invariant violated: seatNumbers must not be null");
+        }
+        if (seatNumbers.isEmpty()) {
+            // standing selection
+            if (quantity <= 0) {
+                throw new IllegalStateException(
+                        "InventorySelection invariant violated: standing selection quantity must be positive (was " + quantity + ")");
+            }
+        } else {
+            // seated selection
+            if (quantity != seatNumbers.size()) {
+                throw new IllegalStateException("InventorySelection invariant violated: seated selection quantity ("
+                        + quantity + ") must equal seatNumbers size (" + seatNumbers.size() + ")");
+            }
+            Set<String> unique = new HashSet<>(seatNumbers);
+            if (unique.size() != seatNumbers.size()) {
+                throw new IllegalStateException("InventorySelection invariant violated: duplicate seat numbers are not allowed");
+            }
+            for (String seatNumber : seatNumbers) {
+                if (seatNumber == null || seatNumber.isBlank()) {
+                    throw new IllegalStateException("InventorySelection invariant violated: seat number must be non-blank");
+                }
+            }
+        }
     }
 
     public static InventorySelection standing(int quantity) {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/InventoryZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/InventoryZone.java
@@ -32,13 +32,10 @@ public abstract class InventoryZone implements InvariantChecked {
     protected double price;
 
     protected InventoryZone(int id, String name, double price) {
-        if (price < 0) {
-            throw new IllegalArgumentException("Price cannot be negative");
-        }
-        if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("Zone name must be non-blank");
-        }
-
+        // Invariants (name non-blank, price >= 0) are enforced by the concrete
+        // subclass's checkInvariants(), invoked at the end of its constructor.
+        // Calling the overridable checkInvariants() here would run before the
+        // subclass's own fields are initialized.
         this.id = id;
         this.name = name;
         this.price = price;

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Location.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Location.java
@@ -1,8 +1,31 @@
 package com.ticketing.system.Core.Domain.events;
 
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
 public record Location(
                 String country,
-                String city) {
+                String city) implements InvariantChecked {
+
+        // Compact constructor validates the canonical components before they are assigned;
+        // checkInvariants() restates the same rules for the InvariantChecked contract.
+        public Location {
+                if (country == null || country.isBlank()) {
+                        throw new IllegalStateException("Location invariant violated: country must be non-blank");
+                }
+                if (city == null || city.isBlank()) {
+                        throw new IllegalStateException("Location invariant violated: city must be non-blank");
+                }
+        }
+
+        @Override
+        public void checkInvariants() {
+                if (country == null || country.isBlank()) {
+                        throw new IllegalStateException("Location invariant violated: country must be non-blank");
+                }
+                if (city == null || city.isBlank()) {
+                        throw new IllegalStateException("Location invariant violated: city must be non-blank");
+                }
+        }
 
         @Override
         public String toString() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Seat.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Seat.java
@@ -29,13 +29,11 @@ public class Seat implements InvariantChecked {
     private LocalDateTime reservedUntil; //TODO: when going to checkout, this should be set to {time now} + {reservation timeout period}.
 
     public Seat(String label, double x, double y) {
-        if (label == null || label.isBlank()) {
-            throw new IllegalArgumentException("Seat label must be non-blank");
-        }
         this.label = label;
         this.x = x;
         this.y = y;
         this.status = SeatStatus.AVAILABLE;
+        checkInvariants();
     }
 
     public String getLabel() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/SeatedZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/SeatedZone.java
@@ -46,6 +46,7 @@ public class SeatedZone extends InventoryZone {
             this.seats.put(seat.getLabel(), seat);
             this.seatLocks.put(seat.getLabel(), new ReentrantLock());
         }
+        checkInvariants();
     }
 
     /** Snapshot of the seats — modifications to the returned list don't affect the zone. */

--- a/src/main/java/com/ticketing/system/Core/Domain/events/ShowDate.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/ShowDate.java
@@ -2,15 +2,34 @@ package com.ticketing.system.Core.Domain.events;
 
 import java.time.LocalDateTime;
 
-public class ShowDate {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class ShowDate implements InvariantChecked {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
     public ShowDate(LocalDateTime startTime, LocalDateTime endTime) {
+        // validateTimes enforces the construction-time "must be future-dated" precondition,
+        // which is NOT a perpetual invariant (a past show is still structurally valid later).
         validateTimes(startTime, endTime);
 
         this.startTime = startTime;
         this.endTime = endTime;
+        checkInvariants();
+    }
+
+    /** Perpetual structural invariants (non-null, ordering) — distinct from the future-dated precondition. */
+    @Override
+    public void checkInvariants() {
+        if (startTime == null) {
+            throw new IllegalStateException("ShowDate invariant violated: startTime must not be null");
+        }
+        if (endTime == null) {
+            throw new IllegalStateException("ShowDate invariant violated: endTime must not be null");
+        }
+        if (!endTime.isAfter(startTime)) {
+            throw new IllegalStateException("ShowDate invariant violated: endTime must be after startTime");
+        }
     }
 
     public LocalDateTime getStartTime() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/StandingZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/StandingZone.java
@@ -28,11 +28,9 @@ public class StandingZone extends InventoryZone {
 
     public StandingZone(int id, String name, int capacity, double price) {
         super(id, name, price);
-        if (capacity < 0) {
-            throw new IllegalArgumentException("Capacity cannot be negative");
-        }
         this.capacity = capacity;
         this.soldAmount = 0;
+        checkInvariants();
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
@@ -4,13 +4,17 @@ import java.util.List;
 
 import java.util.ArrayList;
 
-public class VenueMap {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class VenueMap implements InvariantChecked {
     private int id;
     private Location location;
     private final List<InventoryZone> inventoryZones;
     private int nextZoneId;
 
     public VenueMap(int id, Location location, List<InventoryZone> inventoryZones) {
+        // Null-guarded here because the list is copied before checkInvariants() runs;
+        // a null input would otherwise NPE in the copy rather than fail cleanly.
         if (inventoryZones == null) {
             throw new IllegalArgumentException("Inventory zones cannot be null");
         }
@@ -24,6 +28,17 @@ public class VenueMap {
                 .mapToInt(InventoryZone::getId)
                 .max()
                 .orElse(0) + 1;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (inventoryZones == null) {
+            throw new IllegalStateException("VenueMap invariant violated: inventoryZones must not be null");
+        }
+        if (nextZoneId < 1) {
+            throw new IllegalStateException("VenueMap invariant violated: nextZoneId must be >= 1 (was " + nextZoneId + ")");
+        }
     }
 
     public int getId() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
@@ -77,6 +77,11 @@ public class VenueMap implements InvariantChecked {
         return zone.checkAvailability(quantity);
     }
 
+    // True if any zone still has at least one AVAILABLE place/seat across the venue.
+    public boolean hasAvailableInventory() {
+        return inventoryZones.stream().anyMatch(zone -> zone.getAvailableAmount() > 0);
+    }
+
 
 
 

--- a/src/main/java/com/ticketing/system/Core/Domain/messaging/Conversation.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/messaging/Conversation.java
@@ -47,6 +47,7 @@ public class Conversation implements InvariantChecked {
         this.createdAt = createdAt;
         this.lastMessageAt = createdAt;
         this.messages = messages;
+        checkInvariants();
     }
 
     public String getConversationId() { return conversationId; }

--- a/src/main/java/com/ticketing/system/Core/Domain/messaging/Message.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/messaging/Message.java
@@ -2,10 +2,12 @@ package com.ticketing.system.Core.Domain.messaging;
 
 import java.time.LocalDateTime;
 
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
 // Sub-entity of the Conversation aggregate.
 // Identity is local to the conversation. Cross-aggregate refs by ID:
 //   senderId — User / ProductionCompany / Admin (resolved by senderType)
-public class Message {
+public class Message implements InvariantChecked {
 
     private final String messageId;
     private final int senderId;
@@ -22,6 +24,23 @@ public class Message {
         this.body = body;
         this.sentAt = sentAt;
         this.read = false;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (messageId == null || messageId.isBlank()) {
+            throw new IllegalStateException("Message invariant violated: messageId must be non-blank");
+        }
+        if (senderType == null) {
+            throw new IllegalStateException("Message invariant violated: senderType must not be null");
+        }
+        if (body == null || body.isBlank()) {
+            throw new IllegalStateException("Message invariant violated: body must be non-blank");
+        }
+        if (sentAt == null) {
+            throw new IllegalStateException("Message invariant violated: sentAt must not be null");
+        }
     }
 
     public String getMessageId() { return messageId; }

--- a/src/main/java/com/ticketing/system/Core/Domain/notifications/Notification.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/notifications/Notification.java
@@ -56,6 +56,7 @@ public class Notification implements InvariantChecked {
         this.message = message;
         this.createdAt = createdAt;
         this.data = data == null ? new HashMap<>() : new HashMap<>(data);
+        checkInvariants();
     }
 
     public String getId() {

--- a/src/main/java/com/ticketing/system/Core/Domain/orders/ReceiptLine.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/orders/ReceiptLine.java
@@ -20,6 +20,7 @@ public class ReceiptLine implements InvariantChecked {
         this.zoneId = zoneId;
         this.seatNumber = seatNumber;
         this.addedAt = addedAt;
+        checkInvariants();
     }
 
     public boolean isExpired() {

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/AgePurchasePolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/AgePurchasePolicy.java
@@ -1,15 +1,21 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class AgePurchasePolicy implements PurchasePolicy {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class AgePurchasePolicy implements PurchasePolicy, InvariantChecked {
 
     private final int minimumAge;
 
     public AgePurchasePolicy(int minimumAge) {
-        if (minimumAge < 0) {
-            throw new IllegalArgumentException("Minimum age cannot be negative");
-        }
-
         this.minimumAge = minimumAge;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (minimumAge < 0) {
+            throw new IllegalStateException("AgePurchasePolicy invariant violated: minimumAge cannot be negative (was " + minimumAge + ")");
+        }
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/AndPurchasePolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/AndPurchasePolicy.java
@@ -1,17 +1,23 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class AndPurchasePolicy implements PurchasePolicy {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class AndPurchasePolicy implements PurchasePolicy, InvariantChecked {
 
     private final PurchasePolicy leftPolicy;
     private final PurchasePolicy rightPolicy;
 
     public AndPurchasePolicy(PurchasePolicy leftPolicy, PurchasePolicy rightPolicy) {
-        if (leftPolicy == null || rightPolicy == null) {
-            throw new IllegalArgumentException("Purchase policies cannot be null");
-        }
-
         this.leftPolicy = leftPolicy;
         this.rightPolicy = rightPolicy;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (leftPolicy == null || rightPolicy == null) {
+            throw new IllegalStateException("AndPurchasePolicy invariant violated: both policies must be non-null");
+        }
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/MaxTicketsPurchasePolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/MaxTicketsPurchasePolicy.java
@@ -1,15 +1,21 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class MaxTicketsPurchasePolicy implements PurchasePolicy {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class MaxTicketsPurchasePolicy implements PurchasePolicy, InvariantChecked {
 
     private final int maximumTickets;
 
     public MaxTicketsPurchasePolicy(int maximumTickets) {
-        if (maximumTickets < 0) {
-            throw new IllegalArgumentException("Maximum tickets cannot be negative");
-        }
-
         this.maximumTickets = maximumTickets;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (maximumTickets < 0) {
+            throw new IllegalStateException("MaxTicketsPurchasePolicy invariant violated: maximumTickets cannot be negative (was " + maximumTickets + ")");
+        }
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/MinTicketsPurchasePolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/MinTicketsPurchasePolicy.java
@@ -1,15 +1,21 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class MinTicketsPurchasePolicy implements PurchasePolicy {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class MinTicketsPurchasePolicy implements PurchasePolicy, InvariantChecked {
 
     private final int minimumTickets;
 
     public MinTicketsPurchasePolicy(int minimumTickets) {
-        if (minimumTickets < 0) {
-            throw new IllegalArgumentException("Minimum tickets cannot be negative");
-        }
-
         this.minimumTickets = minimumTickets;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (minimumTickets < 0) {
+            throw new IllegalStateException("MinTicketsPurchasePolicy invariant violated: minimumTickets cannot be negative (was " + minimumTickets + ")");
+        }
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/OrPurchasePolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/OrPurchasePolicy.java
@@ -1,17 +1,23 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class OrPurchasePolicy implements PurchasePolicy {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class OrPurchasePolicy implements PurchasePolicy, InvariantChecked {
 
     private final PurchasePolicy leftPolicy;
     private final PurchasePolicy rightPolicy;
 
     public OrPurchasePolicy(PurchasePolicy leftPolicy, PurchasePolicy rightPolicy) {
-        if (leftPolicy == null || rightPolicy == null) {
-            throw new IllegalArgumentException("Purchase policies cannot be null");
-        }
-
         this.leftPolicy = leftPolicy;
         this.rightPolicy = rightPolicy;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (leftPolicy == null || rightPolicy == null) {
+            throw new IllegalStateException("OrPurchasePolicy invariant violated: both policies must be non-null");
+        }
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/PurchaseContext.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/PurchaseContext.java
@@ -1,6 +1,8 @@
 package com.ticketing.system.Core.Domain.policies.purchase;
 
-public class PurchaseContext {
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
+
+public class PurchaseContext implements InvariantChecked {
 
     private final int buyerId;
     private final Integer buyerAge;
@@ -9,15 +11,19 @@ public class PurchaseContext {
     private final int quantity;
 
     public PurchaseContext(int buyerId, Integer buyerAge, int eventId, int companyId, int quantity) {
-        if (quantity <= 0) {
-            throw new IllegalArgumentException("Quantity must be positive");
-        }
-
         this.buyerId = buyerId;
         this.buyerAge = buyerAge;
         this.eventId = eventId;
         this.companyId = companyId;
         this.quantity = quantity;
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (quantity <= 0) {
+            throw new IllegalStateException("PurchaseContext invariant violated: quantity must be positive (was " + quantity + ")");
+        }
     }
 
     public int getBuyerId() {

--- a/src/main/java/com/ticketing/system/Core/Domain/users/CompanyAppointment.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/CompanyAppointment.java
@@ -5,10 +5,11 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import com.ticketing.system.Core.Domain.exceptions.InvalidPermissionException;
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
 import java.util.List;
 
-public class CompanyAppointment {
+public class CompanyAppointment implements InvariantChecked {
     private final int appointmentId; // Unique identifier for the appointment (could be UUID or int)
     private final int companyId; // ID of the company this appointment belongs to
     private final int targetId; // ID of the user being appointed
@@ -26,23 +27,41 @@ public class CompanyAppointment {
             CompanyRole role,
             AppointmentStatus status,
             List<Permission> permissions) {
-        if (role == CompanyRole.Manager && (permissions == null || permissions.isEmpty())) {
-            throw new IllegalArgumentException("Manager role must have at least one permission.");
-        }
-        if (role == CompanyRole.Owner && permissions != null && !permissions.isEmpty()) {
-            throw new IllegalArgumentException("Owner role should not have explicit permissions.");
-        }
-
         this.appointmentId = appointmentId;
         this.companyId = companyId;
         this.targetId = targetId;
         this.inviterId = inviterId;
         this.role = role;
         this.status = status;
-        this.permissions = permissions != null
-                ? EnumSet.copyOf(permissions)
-                : EnumSet.noneOf(Permission.class);
+        // Empty/null-safe: EnumSet.copyOf throws on an empty non-EnumSet collection, and would
+        // run before checkInvariants(). The Manager/Owner permission rules are enforced below.
+        this.permissions = (permissions == null || permissions.isEmpty())
+                ? EnumSet.noneOf(Permission.class)
+                : EnumSet.copyOf(permissions);
         this.createdAt = LocalDateTime.now();
+        checkInvariants();
+    }
+
+    @Override
+    public void checkInvariants() {
+        if (role == null) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: role must not be null");
+        }
+        if (status == null) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: status must not be null");
+        }
+        if (permissions == null) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: permissions must not be null");
+        }
+        if (role == CompanyRole.Manager && permissions.isEmpty()) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: Manager role must have at least one permission");
+        }
+        if (role == CompanyRole.Owner && !permissions.isEmpty()) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: Owner role must not have explicit permissions");
+        }
+        if (createdAt == null) {
+            throw new IllegalStateException("CompanyAppointment invariant violated: createdAt must not be null");
+        }
     }
 
     // this constructor is specifically for the creation of the company founder

--- a/src/main/java/com/ticketing/system/Core/Domain/users/Session.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/Session.java
@@ -30,20 +30,12 @@ public class Session implements InvariantChecked {
     private Instant expiresAt;
 
     public Session(String sessionId, Integer userId, Instant createdAt, Instant expiresAt) {
-        if (sessionId == null || sessionId.isBlank()) {
-            throw new IllegalArgumentException("sessionId must be non-blank");
-        }
-        if (createdAt == null) {
-            throw new IllegalArgumentException("createdAt must not be null");
-        }
-        if (expiresAt == null) {
-            throw new IllegalArgumentException("expiresAt must not be null");
-        }
         this.sessionId = sessionId;
         this.userId = userId;
         this.createdAt = createdAt;
         this.lastSeenAt = createdAt;
         this.expiresAt = expiresAt;
+        checkInvariants();
     }
 
     public String getSessionId() {

--- a/src/main/java/com/ticketing/system/Core/Domain/users/User.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/User.java
@@ -24,11 +24,9 @@ public class User implements InvariantChecked {
         this.username = username;
         this.email = email;
         this.password = password;
-        if(age < 0){
-            throw new IllegalArgumentException("Age cannot be negative");
-        }
         this.age = age;
         this.companyAppointments = new ArrayList<>();
+        checkInvariants();
     }
 
     public CompanyAppointment acceptInvitation(int companyId) {

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
@@ -231,10 +231,8 @@ public final class DemoEvents {
         // so the event can now go ON_SALE through the legitimate domain transition.
         Event event = eventRepository.findById(Integer.parseInt(created.eventId()));
         event.transitionToOnSale();
-        eventRepository.save(event);
-        // forceStatusOnSale(event);
-        // Existing events must be locked before save (MemoryEventRepository contract); the
-        // reflection-forced status write is a direct repo save, so lock/unlock around it.
+        // Existing events must be locked before save (MemoryEventRepository contract):
+        // an unlocked save of an already-stored event throws IllegalStateException.
         int eventId = event.getId();
         eventRepository.lockForUpdate(eventId);
         try {

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
@@ -10,12 +10,10 @@ import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.ZoneConfigDTO
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.EventCategory;
-import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.Location;
 import com.ticketing.system.Core.Domain.events.ShowDate;
 
-import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -229,27 +227,12 @@ public final class DemoEvents {
         eventService.configureVenueMap(token, company.companyId(),
             new VenueMapConfigDTO(created.eventId(), city + " venue", zones));
 
+        // configureVenueMap binds inventory and auto-advances DRAFT -> SCHEDULED,
+        // so the event can now go ON_SALE through the legitimate domain transition.
         Event event = eventRepository.findById(Integer.parseInt(created.eventId()));
-        forceStatusOnSale(event);
+        event.transitionToOnSale();
         eventRepository.save(event);
         return created;
-    }
-
-    /**
-     * Reflection bypass: the domain has no DRAFT → SCHEDULED path, so
-     * {@code Event.transitionToOnSale()} can't be reached through the
-     * legitimate API. For a fixture this is fine — we're materialising
-     * a state the production flow will eventually produce once the
-     * missing transition lands.
-     */
-    private static void forceStatusOnSale(Event event) {
-        try {
-            Field f = Event.class.getDeclaredField("status");
-            f.setAccessible(true);
-            f.set(event, EventStatus.ON_SALE);
-        } catch (ReflectiveOperationException e) {
-            throw new IllegalStateException("could not set Event.status for demo seed", e);
-        }
     }
 
     // -- Zone helpers -----------------------------------------------------

--- a/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
@@ -6,8 +6,9 @@ import com.ticketing.system.Core.Domain.notifications.Notification;
 import org.springframework.stereotype.Component;
 
 // V1 stub for IPushNotificationService — push channel adapter.
-// V1: simulates a reachable channel by always returning true (no real delivery yet);
-//     the dispatcher persists notifications, so nothing is stored here.
+// V1: simulates a reachable channel by always returning true (no real delivery yet).
+//     Sent notifications are also collected in memory (see getSentNotifications) so tests
+//     can assert what was pushed; the dispatcher remains the durable store of record.
 // V2/V3: replace with WebSocket / SSE / email when real-time push is in scope.
 
 @Component
@@ -21,9 +22,9 @@ public class InMemoryNotificationService implements IPushNotificationService {
 
     @Override
     public boolean send(int recipientUserId, Notification notification) {
-        // For V1, we simulate success for testing, or return false to test PENDING
-        // flow.
-        // In a real stub, we might collect these in a list for assertions.
+        // V1: always report success (no real channel yet) and record the notification so
+        // tests can assert what was sent. Tests that need a failed/PENDING delivery should
+        // mock IPushNotificationService to return false rather than rely on this stub.
         sentNotifications.add(notification);
         return true;
     }

--- a/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
@@ -1,16 +1,14 @@
 package com.ticketing.system.Infrastructure.external;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-
 import com.ticketing.system.Core.Application.interfaces.IPushNotificationService;
 import com.ticketing.system.Core.Domain.notifications.Notification;
 
-// V1 stub for IPushNotificationService — push channel adapter.
-// V1: collects notifications in memory so tests can assert on them.
-// V2/V3: replace with WebSocket / SSE / email when real-time push is in scope.
 import org.springframework.stereotype.Component;
+
+// V1 stub for IPushNotificationService — push channel adapter.
+// V1: simulates a reachable channel by always returning true (no real delivery yet);
+//     the dispatcher persists notifications, so nothing is stored here.
+// V2/V3: replace with WebSocket / SSE / email when real-time push is in scope.
 
 @Component
 public class InMemoryNotificationService implements IPushNotificationService {
@@ -19,7 +17,7 @@ public class InMemoryNotificationService implements IPushNotificationService {
     public boolean send(int recipientUserId, Notification notification) {
         // For V1, we simulate success for testing, or return false to test PENDING flow.
         // In a real stub, we might collect these in a list for assertions.
-        return true; 
+        return true;
     }
 
     @Override

--- a/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/InMemoryNotificationService.java
@@ -13,13 +13,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class InMemoryNotificationService implements IPushNotificationService {
 
-    // V1 stub behaviour (as the class doc states): collect notifications in memory instead of
-    // throwing, so reservation/checkout flows complete. UC-35 replaces this with a real push channel.
+    // V1 stub behaviour (as the class doc states): collect notifications in memory
+    // instead of
+    // throwing, so reservation/checkout flows complete. UC-35 replaces this with a
+    // real push channel.
     private final java.util.List<Notification> sentNotifications = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     @Override
     public boolean send(int recipientUserId, Notification notification) {
-        // For V1, we simulate success for testing, or return false to test PENDING flow.
+        // For V1, we simulate success for testing, or return false to test PENDING
+        // flow.
         // In a real stub, we might collect these in a list for assertions.
         sentNotifications.add(notification);
         return true;
@@ -29,7 +32,7 @@ public class InMemoryNotificationService implements IPushNotificationService {
     public boolean isReachable(int recipientUserId) {
         return true;
     }
-}
+
     public java.util.List<Notification> getSentNotifications() {
         return java.util.List.copyOf(sentNotifications);
     }

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -122,7 +122,7 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         resolveIdentity();
-        refreshFromOrder(loadActiveOrder());
+        refreshFromOrder(renewAndLoadActiveOrder());
 
         if (getChildren().findAny().isEmpty()) {
             buildPage();
@@ -153,6 +153,35 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver {
             session.setAttribute("guestSessionId", guestId);
         }
         return guestId;
+    }
+
+    /**
+     * Like {@link #loadActiveOrder()}, but resets every reserved ticket's 10-minute hold
+     * timer to a fresh full window. Used only on checkout-page entry ({@link #beforeEnter})
+     * so the buyer gets the maximum time to pay; the pre-pay refresh keeps using the plain
+     * {@link #loadActiveOrder()} so its "cart expired while you were typing" guard stays intact.
+     */
+    private ActiveOrderDTO renewAndLoadActiveOrder() {
+        if (isMember) {
+            try {
+                this.resolvedUserId = sessionManager.extractUserId(memberToken);
+                return reservationService.renewReservationsForMemberCheckout(resolvedUserId);
+            } catch (Exception e) {
+                log.warn("Failed to renew/load active order for member", e);
+                Toasts.warn("Could not load your cart — please try again.");
+                return null;
+            }
+        }
+
+        if (sessionId != null) {
+            try {
+                return reservationService.renewReservationsForGuestCheckout(sessionId);
+            } catch (Exception e) {
+                log.warn("Failed to renew/load active order for guest", e);
+                return null;
+            }
+        }
+        return null;
     }
 
     private ActiveOrderDTO loadActiveOrder() {

--- a/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
@@ -13,6 +13,7 @@ import com.ticketing.system.Core.Domain.events.*;
 import com.ticketing.system.Core.Domain.orders.*;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
+import com.ticketing.system.Infrastructure.persistence.MemoryActiveOrderRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -892,6 +893,95 @@ public class CheckoutServiceAcceptanceTest {
         assertEquals(true, userNotified.get());
     }
 
+
+
+
+
+    // Regression tests for the "stuck order" bug: after a successful checkout the consumed cart must
+    // be deleted (not saved while still CHECKOUT_IN_PROGRESS), otherwise the buyer's next reservation
+    // hits ensureModifiable() and throws "Cannot modify active order while checkout is in progress".
+    // These use a REAL MemoryActiveOrderRepository so delete-vs-save is observable across lookups —
+    // the mock-based suites cannot catch this (their save/delete are no-ops).
+
+    private CheckoutService checkoutServiceWith(IActiveOrderRepository realRepo) {
+        return new CheckoutService(
+                realRepo,
+                eventRepository,
+                ticketRepository,
+                orderReceiptRepository,
+                ticketIssuer,
+                paymentGateway,
+                notificationService,
+                sessionManager,
+                userRepository
+        );
+    }
+
+    @Test
+    void GivenSuccessfulMemberCheckout_WhenBuyerChecksOutAgain_ThenSecondCheckoutSucceeds() {
+        validSession();
+        validPaymentAndIssuance(1);
+
+        MemoryActiveOrderRepository realRepo = new MemoryActiveOrderRepository();
+        CheckoutService service = checkoutServiceWith(realRepo);
+
+        ActiveOrder firstOrder = new ActiveOrder(USER_ID);
+        firstOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 10.0, LocalDateTime.now());
+        realRepo.save(firstOrder);
+
+        service.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY + "-1", CURRENCY, PAYMENT_METHOD_TOKEN);
+
+        // The consumed cart must be gone so the buyer's next reservation/checkout starts clean.
+        assertNull(realRepo.getByUserId(USER_ID));
+
+        // Buyer comes back and reserves again on the same account, then checks out a second time.
+        ActiveOrder secondOrder = new ActiveOrder(USER_ID);
+        secondOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 10.0, LocalDateTime.now());
+        realRepo.save(secondOrder);
+
+        CheckoutResultDTO secondResult = assertDoesNotThrow(() ->
+                service.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY + "-2", CURRENCY, PAYMENT_METHOD_TOKEN));
+
+        assertEquals(10.0, secondResult.totalCharged());
+    }
+
+    @Test
+    void GivenSuccessfulGuestCheckout_WhenGuestChecksOutAgain_ThenSecondCheckoutSucceeds() {
+        String guestSessionId = "guest-sess";
+        String guestEmail = "guest@test.com";
+        when(sessionManager.validateCredential(guestSessionId)).thenReturn(true);
+        validPaymentAndIssuance(1);
+
+        MemoryActiveOrderRepository realRepo = new MemoryActiveOrderRepository();
+        CheckoutService service = checkoutServiceWith(realRepo);
+
+        ActiveOrder firstOrder = ActiveOrder.forGuest(guestSessionId);
+        firstOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 10.0, LocalDateTime.now());
+        realRepo.save(firstOrder);
+
+        service.checkoutGuest(guestSessionId, guestEmail, IDEMPOTENCY_KEY + "-g1", CURRENCY, PAYMENT_METHOD_TOKEN, 30);
+
+        assertTrue(realRepo.getBySessionId(guestSessionId).isEmpty());
+
+        ActiveOrder secondOrder = ActiveOrder.forGuest(guestSessionId);
+        secondOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 10.0, LocalDateTime.now());
+        realRepo.save(secondOrder);
+
+        assertDoesNotThrow(() ->
+                service.checkoutGuest(guestSessionId, guestEmail, IDEMPOTENCY_KEY + "-g2", CURRENCY, PAYMENT_METHOD_TOKEN, 30));
+    }
+
+    @Test
+    void GivenCheckoutSucceeds_WhenCheckout_ThenConsumedOrderIsDeleted() {
+        validSession();
+        ActiveOrder order = order(List.of(item(EVENT_ID_1, ZONE_ID_1, 10.0)), true);
+        when(activeOrderRepository.getByUserId(USER_ID)).thenReturn(order);
+        validPaymentAndIssuance(1);
+
+        checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN);
+
+        verify(activeOrderRepository).delete(order);
+    }
 
 
 

--- a/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
@@ -624,6 +624,8 @@ public class CheckoutServiceAcceptanceTest {
                 checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN)
         );
 
+        // Ticket save fails BEFORE confirmInventorySale (the sale is committed last), so the inventory
+        // is still RESERVED and is cleanly returned to stock, and the payment is refunded.
         assertEquals(true, refundRequested.get());
         assertEquals(1, returnedTickets.get());
         assertEquals("Checkout failed, tickets returned to stock", exception.getMessage());
@@ -644,6 +646,8 @@ public class CheckoutServiceAcceptanceTest {
                 checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN)
         );
 
+        // Receipt save fails BEFORE confirmInventorySale (the sale is committed last), so the inventory
+        // is still RESERVED and is cleanly returned to stock, and the payment is refunded.
         assertEquals(true, refundRequested.get());
         assertEquals(1, returnedTickets.get());
         assertEquals("Checkout failed, tickets returned to stock", exception.getMessage());

--- a/src/test/java/com/ticketing/system/acceptance/CompanyAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CompanyAcceptanceTest.java
@@ -26,6 +26,8 @@ import com.ticketing.system.Core.Application.dto.PermissionEditDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
+import com.ticketing.system.Core.Application.dto.LocationDTO;
+import com.ticketing.system.Core.Application.dto.ShowDateDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
 import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
@@ -315,6 +317,7 @@ class CompanyAcceptanceTest {
                 assertEquals(EventCategory.FESTIVAL, result.category());
                 assertEquals(EventStatus.DRAFT, result.status());
                 assertEquals("DetailCo1", result.companyName());
+                assertEquals("desc", result.description());
         }
 
         @Test
@@ -447,5 +450,35 @@ class CompanyAcceptanceTest {
                 assertThrows(RuntimeException.class,
                                 () -> eventManagementService.editEventDetails(manager.token(),
                                                 new EventUpdateDTO(created.eventId(), "Blocked Edit", null, null, null, null)));
+        }
+
+        @Test
+        void GivenOwner_WhenEditAllFields_ThenDescriptionLocationAndShowDatesPersist() {
+                AuthTokenDTO owner = registerAndLoginMember("editOwner5");
+                int companyId = companyService.registerCompany(
+                                owner.token(), new CompanyRegistrationDTO("EditCo5", "desc")).companyId();
+
+                EventDetailDTO created = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                                companyId, "Full Edit Event", "original desc", List.of("Artist"),
+                                EventCategory.MUSIC, 4.0,
+                                new Location("Italy", "Rome"),
+                                List.of(new ShowDate(LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(3))),
+                                null));
+
+                LocalDateTime newStart = LocalDateTime.now().plusDays(20);
+                eventManagementService.editEventDetails(owner.token(), new EventUpdateDTO(
+                                created.eventId(), "Full Edit Renamed", "updated desc", "THEATER",
+                                new LocationDTO("France", "Paris"),
+                                List.of(new ShowDateDTO(newStart, newStart.plusHours(2)))));
+
+                EventDetailDTO result = eventManagementService.getEventDetail(owner.token(), created.eventId());
+                assertEquals("Full Edit Renamed", result.name());
+                assertEquals("updated desc", result.description());
+                assertEquals(EventCategory.THEATER, result.category());
+                assertEquals(new Location("France", "Paris"), result.location());
+
+                Event stored = eventRepository.findById(Integer.parseInt(created.eventId()));
+                assertEquals(1, stored.getShowDates().size());
+                assertEquals(newStart, stored.getShowDates().get(0).getStartTime());
         }
 }

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -1327,13 +1327,11 @@ void GivenMultipleTicketsFromDifferentZonesSameEvent_WhenCheckout_ThenBuyAllTick
 
         // new test
         @Test
-        void GivenReceiptSaveFailsAfterSeatConfirmation_WhenCheckout_ThenSystemDoesNotLoseSeatOrCart() {
-                // Arrange seated seat A1 RESERVED in cart
-                // Make payment and issuance succeed
-                // Make orderReceiptRepository.save(...) throw
-                // Assert checkout throws
-                // Assert seat is not left in an impossible state
-                // Assert active order is not silently lost
+        void GivenReceiptSaveFails_WhenCheckout_ThenSeatReturnedToStockAndCartCleared() {
+                // Receipt save fails. Because the sale is committed (confirmInventorySale) LAST — after
+                // ticket + receipt persistence — the seat is still RESERVED when the save fails, so the
+                // rollback returns it to stock (AVAILABLE) and clears the cart, rather than stranding a
+                // SOLD seat. (Payment is refunded too; not asserted here.)
                 ActiveOrder activeOrder = new ActiveOrder(USER_ID);
                 SeatedZone seatedZone = new SeatedZone(
                                 ZONE_ID_1,
@@ -1374,9 +1372,49 @@ void GivenMultipleTicketsFromDifferentZonesSameEvent_WhenCheckout_ThenBuyAllTick
                 assertThrows(RuntimeException.class, () -> checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY,
                                 CURRENCY, PAYMENT_METHOD_TOKEN));
                                 
-                assertEquals(SeatStatus.SOLD, seatedZone.getSeatStatus("A1"));
-                assertFalse(activeOrder.isEmpty());
+                assertEquals(SeatStatus.AVAILABLE, seatedZone.getSeatStatus("A1"));
+                assertTrue(activeOrder.isEmpty());
                 assertThrows(RuntimeException.class, () -> checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN));
+        }
+
+        // Fix #3: a Phase-2 failure rollback over a multi-event cart must release every event
+        // independently. If one event's release throws, the remaining events must still be released
+        // and the cart must still be cleared — the rollback loop no longer aborts on the first throw.
+        @Test
+        void GivenMultiEventRollbackWhereOneReleaseFails_WhenCheckout_ThenOtherEventsStillReleasedAndCartCleared() {
+                ActiveOrder activeOrder = new ActiveOrder(USER_ID);
+                String orderKey = activeOrder.getOrderKey();
+
+                // Event B is a real standing zone holding a live reservation under this order.
+                StandingZone zoneB = new StandingZone(ZONE_ID_3, "GA", 5, 200.0);
+                zoneB.reserve(InventorySelection.standing(1, orderKey));
+
+                activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
+                activeOrder.addStandingReservation(EVENT_ID_2, ZONE_ID_3, 1, 200.0, LocalDateTime.now());
+
+                when(mockActiveOrderRepo.getByUserId(USER_ID)).thenReturn(activeOrder);
+                when(mockEventRepo.findById(EVENT_ID_1)).thenReturn(event1);
+                when(mockEventRepo.findById(EVENT_ID_2)).thenReturn(event2);
+
+                // Event A's release fails; event B's release delegates to the real zone.
+                when(event1.releaseInventory(anyInt(), any(InventorySelection.class)))
+                        .thenThrow(new IllegalStateException("event A release failed"));
+                when(event2.releaseInventory(anyInt(), any(InventorySelection.class))).thenAnswer(invocation -> {
+                        zoneB.release(invocation.getArgument(1));
+                        return true;
+                });
+
+                // Force a Phase-2 failure (before any inventory is confirmed) so the rollback runs.
+                when(mockPaymentGateway.charge(any(PaymentRequestDTO.class))).thenReturn(null);
+
+                assertThrows(RuntimeException.class, () ->
+                        checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN));
+
+                // Event A throwing did not strand event B...
+                assertEquals(0, zoneB.getReservedAmount());
+                assertEquals(5, zoneB.getAvailableAmount());
+                // ...and the cart was still cleared.
+                assertTrue(activeOrder.isEmpty());
         }
 
         //////////////////////////// tests for policies

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -2246,7 +2246,7 @@ private AtomicBoolean trackReceiptSave() {
 
         StandingZone zone = new StandingZone(ZONE_ID_1, "VIP", 5, 100.0);
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now().minusMinutes(20));
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2273,7 +2273,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new AgePurchasePolicy(18));
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2299,7 +2299,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new AgePurchasePolicy(18));
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2327,7 +2327,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new NoPurchasePolicy());
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2352,7 +2352,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new NoPurchasePolicy());
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2389,7 +2389,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new NoPurchasePolicy());
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 
@@ -2417,7 +2417,7 @@ private AtomicBoolean trackReceiptSave() {
 
         Event event = createRealEventWithPolicyAndZone(EVENT_ID_1, zone, new NoPurchasePolicy());
 
-        ActiveOrder activeOrder = new ActiveOrder(-1);
+        ActiveOrder activeOrder = ActiveOrder.forGuest(VALID_GUEST_SID);
         activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
         zone.reserve(InventorySelection.standing(1, activeOrder.getOrderKey()));
 

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -1374,7 +1374,6 @@ void GivenMultipleTicketsFromDifferentZonesSameEvent_WhenCheckout_ThenBuyAllTick
                                 
                 assertEquals(SeatStatus.AVAILABLE, seatedZone.getSeatStatus("A1"));
                 assertTrue(activeOrder.isEmpty());
-                assertThrows(RuntimeException.class, () -> checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN));
         }
 
         // Fix #3: a Phase-2 failure rollback over a multi-event cart must release every event

--- a/src/test/java/com/ticketing/system/unit/application/CompanyManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CompanyManagementServiceTest.java
@@ -26,14 +26,11 @@ import com.ticketing.system.Core.Application.dto.AppointmentResponseDTO;
 import com.ticketing.system.Core.Application.dto.AppointmentRevokeDTO;
 import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
 import com.ticketing.system.Core.Application.dto.ManagerAppointmentRequestDTO;
-import com.ticketing.system.Core.Application.dto.OwnerAppointmentRequestDTO;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.Tickets.Ticket;
 import com.ticketing.system.Core.Domain.company.CompanyStatus;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
-import com.ticketing.system.Core.Domain.users.CompanyRole;
-import com.ticketing.system.Core.Domain.users.CompanyAppointment;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
@@ -42,7 +39,6 @@ import com.ticketing.system.Core.Domain.orders.ReceiptLine;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.Permission;
 import com.ticketing.system.Core.Domain.users.User;
-//import com.ticketing.system.Core.Domain.users.exceptions.UserNotFoundException;
 
 public class CompanyManagementServiceTest {
 

--- a/src/test/java/com/ticketing/system/unit/application/CompanyManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CompanyManagementServiceTest.java
@@ -89,9 +89,9 @@ public class CompanyManagementServiceTest {
         public void GivenOwnerAndTargetUser_WhenInviteManager_ThenTargetHasOneInvitation() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 19);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 19);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -110,9 +110,9 @@ public class CompanyManagementServiceTest {
         public void GivenPendingManagerInvitation_WhenTargetAccepts_ThenTargetIsCompanyManager() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -136,9 +136,9 @@ public class CompanyManagementServiceTest {
         public void GivenPendingManagerInvitation_WhenTargetRejects_ThenTargetHasNoInvitations() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 19);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 19);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -166,9 +166,9 @@ public class CompanyManagementServiceTest {
         public void GivenAcceptedManager_WhenOwnerModifiesPermissions_ThenCompanyPermissionsAreUpdated() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
                 when(mockUserRepo.getUserById(OWNER_ID)).thenReturn(ownerUser);
@@ -205,9 +205,9 @@ public class CompanyManagementServiceTest {
         public void GivenAcceptedManager_WhenOwnerRevokesManager_ThenCompanyDoesNotContainManager() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
                 when(mockUserRepo.getUserById(OWNER_ID)).thenReturn(ownerUser);
@@ -264,7 +264,7 @@ public class CompanyManagementServiceTest {
         public void GivenUserIsNotOwner_WhenInviteManager_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User nonOwnerUser = new User(3, "nonOwner", "", "password", 25);
+                User nonOwnerUser = new User(3, "nonOwner", "user@test.com", "password", 25);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(3);
@@ -283,7 +283,7 @@ public class CompanyManagementServiceTest {
         public void GivenTargetUserDoesNotExist_WhenInviteManager_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
@@ -304,9 +304,9 @@ public class CompanyManagementServiceTest {
         public void GivenEmptyPermissions_WhenInviteManager_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -344,7 +344,7 @@ public class CompanyManagementServiceTest {
 
     @Test
     public void GivenCompanyDoesNotExist_WhenAcceptManagerInvitation_ThenThrowException() {
-        User targetUser = new User(TARGET_USER_ID, "targetUser","", "password",20);
+        User targetUser = new User(TARGET_USER_ID, "targetUser","user@test.com", "password",20);
 
                 when(sessionManager.validateToken(TARGET_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(TARGET_TOKEN)).thenReturn(TARGET_USER_ID);
@@ -359,7 +359,7 @@ public class CompanyManagementServiceTest {
     @Test
     public void GivenNoPendingInvitation_WhenAcceptManagerInvitation_ThenThrowException() {
         ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-        User targetUser = new User(TARGET_USER_ID, "targetUser","", "password",20);
+        User targetUser = new User(TARGET_USER_ID, "targetUser","user@test.com", "password",20);
 
                 when(sessionManager.validateToken(TARGET_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(TARGET_TOKEN)).thenReturn(TARGET_USER_ID);
@@ -383,7 +383,7 @@ public class CompanyManagementServiceTest {
     @Test
     public void GivenNoPendingInvitation_WhenRejectManagerInvitation_ThenThrowException() {
         ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-        User targetUser = new User(TARGET_USER_ID, "targetUser","", "password",20       );
+        User targetUser = new User(TARGET_USER_ID, "targetUser","user@test.com", "password",20       );
 
                 when(sessionManager.validateToken(TARGET_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(TARGET_TOKEN)).thenReturn(TARGET_USER_ID);
@@ -408,8 +408,8 @@ public class CompanyManagementServiceTest {
         public void GivenUserIsNotOwner_WhenRevokeManager_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User nonOwnerUser = new User(3, "nonOwner", "", "password", 22);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 22);
+                User nonOwnerUser = new User(3, "nonOwner", "user@test.com", "password", 22);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 22);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(3);
@@ -426,9 +426,9 @@ public class CompanyManagementServiceTest {
         public void GivenTargetIsNotManager_WhenRevokeManager_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -454,7 +454,7 @@ public class CompanyManagementServiceTest {
         public void GivenUserIsNotOwner_WhenModifyManagerPermissions_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 25);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 25);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(3);
@@ -469,7 +469,7 @@ public class CompanyManagementServiceTest {
     @Test
     public void GivenTargetIsNotManager_WhenModifyManagerPermissions_ThenThrowException() {
         ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-        User targetUser = new User(TARGET_USER_ID, "targetUser","", "password",20);
+        User targetUser = new User(TARGET_USER_ID, "targetUser","user@test.com", "password",20);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -486,9 +486,9 @@ public class CompanyManagementServiceTest {
         public void GivenEmptyPermissions_WhenModifyManagerPermissions_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
                 when(mockUserRepo.getUserById(OWNER_ID)).thenReturn(ownerUser);
@@ -518,9 +518,9 @@ public class CompanyManagementServiceTest {
         public void GivenAlreadyPendingInvitation_WhenInviteManagerAgain_ThenThrowException() {
                 ProductionCompany company = new ProductionCompany(COMPANY_ID, OWNER_ID, COMPANY_1_NAME,
                                 CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 4.5);
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 22);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 22);
                 ownerUser.addFounderAppointment(COMPANY_ID);
-                User targetUser = new User(TARGET_USER_ID, "targetUser", "", "password", 20);
+                User targetUser = new User(TARGET_USER_ID, "targetUser", "user@test.com", "password", 20);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
@@ -548,7 +548,7 @@ public class CompanyManagementServiceTest {
                 when(mockCompanyRepo.existsByName("Epic Productions")).thenReturn(false);
                 when(mockCompanyRepo.nextId()).thenReturn(expectedCompanyId);
 
-                when(mockUserRepo.getUserById(userId)).thenReturn(new User(userId, "founder", "", "password", 30));
+                when(mockUserRepo.getUserById(userId)).thenReturn(new User(userId, "founder", "user@test.com", "password", 30));
 
                 // save() is void per IProductionCompanyRepository — no return-value mock
                 // needed.
@@ -837,7 +837,7 @@ public class CompanyManagementServiceTest {
                 when(company.getFounderId()).thenReturn(OWNER_ID);
                 when(company.getOwnersIds()).thenReturn(List.of(OWNER_ID));
 
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 30);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 30);
                 ownerUser.addFounderAppointment(COMPANY_ID);
 
                 when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
@@ -868,10 +868,10 @@ public class CompanyManagementServiceTest {
                 when(company.getFounderId()).thenReturn(OWNER_ID);
                 when(company.getOwnersIds()).thenReturn(List.of(OWNER_ID));
 
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 30);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 30);
                 ownerUser.addFounderAppointment(COMPANY_ID);
 
-                User managerUser = new User(TARGET_USER_ID, "managerUser", "", "password",85);
+                User managerUser = new User(TARGET_USER_ID, "managerUser", "user@test.com", "password",85);
                 managerUser.receiveManagerAppointment(COMPANY_ID, OWNER_ID, defaultPermissions);
                 managerUser.acceptInvitation(COMPANY_ID);
 
@@ -910,14 +910,14 @@ public class CompanyManagementServiceTest {
                 when(company.getFounderId()).thenReturn(OWNER_ID);
                 when(company.getOwnersIds()).thenReturn(List.of(OWNER_ID));
 
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 30);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 30);
                 ownerUser.addFounderAppointment(COMPANY_ID);
 
-                User manager1 = new User(MANAGER1_ID, "manager1", "", "password",101);
+                User manager1 = new User(MANAGER1_ID, "manager1", "user@test.com", "password",101);
                 manager1.receiveManagerAppointment(COMPANY_ID, OWNER_ID, defaultPermissions);
                 manager1.acceptInvitation(COMPANY_ID);
 
-                User manager2 = new User(MANAGER2_ID, "manager2", "", "password",102);
+                User manager2 = new User(MANAGER2_ID, "manager2", "user@test.com", "password",102);
                 manager2.receiveManagerAppointment(COMPANY_ID, OWNER_ID, List.of(Permission.VIEW_SALES));
                 manager2.acceptInvitation(COMPANY_ID);
 
@@ -960,16 +960,16 @@ public class CompanyManagementServiceTest {
                 when(company.getFounderId()).thenReturn(OWNER_ID);
                 when(company.getOwnersIds()).thenReturn(List.of(OWNER_ID));
 
-                User ownerUser = new User(OWNER_ID, "ownerUser", "", "password", 30);
+                User ownerUser = new User(OWNER_ID, "ownerUser", "user@test.com", "password", 30);
                 ownerUser.addFounderAppointment(COMPANY_ID);
 
                 // manager1 was appointed by the owner
-                User manager1 = new User(MANAGER1_ID, "manager1", "", "password",101);
+                User manager1 = new User(MANAGER1_ID, "manager1", "user@test.com", "password",101);
                 manager1.receiveManagerAppointment(COMPANY_ID, OWNER_ID, defaultPermissions);
                 manager1.acceptInvitation(COMPANY_ID);
 
                 // manager2 was appointed by manager1, not by the owner
-                User manager2 = new User(MANAGER2_ID, "manager2", "", "password",152);
+                User manager2 = new User(MANAGER2_ID, "manager2", "user@test.com", "password",152);
                 manager2.receiveManagerAppointment(COMPANY_ID, MANAGER1_ID, List.of(Permission.MANAGE_INVENTORY));
                 manager2.acceptInvitation(COMPANY_ID);
 

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -29,6 +30,7 @@ import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.InventorySelection;
@@ -262,6 +264,71 @@ class EventManagementServiceTest {
         eventService.cancelEventAndRefund(OWNER_TOKEN, EVENT_ID);
 
         assertEquals(TicketStatus.VOIDED, availableTicket.getStatus());
+    }
+
+    // -- UC-19: owner publishes event (SCHEDULED -> ON_SALE) -------------
+
+    @Test
+    public void GivenScheduledEvent_WhenPublishEvent_ThenStatusOnSaleAndSaved() {
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+
+        eventService.publishEvent(OWNER_TOKEN, COMPANY_ID, EVENT_ID);
+
+        assertEquals(EventStatus.ON_SALE, event.getStatus());
+        verify(mockEventRepo).save(event);
+    }
+
+    @Test
+    public void GivenInvalidToken_WhenPublishEvent_ThenThrows() {
+        when(sessionManager.validateToken(INVALID_TOKEN)).thenReturn(false);
+
+        assertThrows(RuntimeException.class,
+                () -> eventService.publishEvent(INVALID_TOKEN, COMPANY_ID, EVENT_ID));
+    }
+
+    @Test
+    public void GivenEventNotOwnedByCompany_WhenPublishEvent_ThenThrows() {
+        int otherCompanyId = 999;
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event); // event.companyId == COMPANY_ID
+
+        assertThrows(RuntimeException.class,
+                () -> eventService.publishEvent(OWNER_TOKEN, otherCompanyId, EVENT_ID));
+        assertEquals(EventStatus.SCHEDULED, event.getStatus());
+    }
+
+    @Test
+    public void GivenUserWithoutPermission_WhenPublishEvent_ThenThrows() {
+        User noPermissionUser = new User(MANAGER_ID, "No Perm", "noperm@example.com", "hashedpassword", 30);
+        when(sessionManager.validateToken(MANAGER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(MANAGER_TOKEN)).thenReturn(MANAGER_ID);
+        when(userRepository.getUserById(MANAGER_ID)).thenReturn(noPermissionUser);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+
+        assertThrows(RuntimeException.class,
+                () -> eventService.publishEvent(MANAGER_TOKEN, COMPANY_ID, EVENT_ID));
+        assertEquals(EventStatus.SCHEDULED, event.getStatus());
+    }
+
+    @Test
+    public void GivenDraftEvent_WhenPublishEvent_ThenThrowsInvalidStateTransition() {
+        Event draftEvent = new Event(
+                EVENT_ID, "Concert", 4.5, List.of("Artist1"), EventCategory.CONCERT, COMPANY_ID,
+                EventStatus.DRAFT, venueMap,
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(2))),
+                null, new DiscountPolicy(0));
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(draftEvent);
+
+        assertThrows(InvalidStateTransitionException.class,
+                () -> eventService.publishEvent(OWNER_TOKEN, COMPANY_ID, EVENT_ID));
+        assertEquals(EventStatus.DRAFT, draftEvent.getStatus());
     }
 
     // new test

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -46,6 +46,8 @@ import com.ticketing.system.Core.Domain.orders.TransactionRecord;
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
+import com.ticketing.system.Core.Application.dto.LocationDTO;
+import com.ticketing.system.Core.Application.dto.ShowDateDTO;
 import com.ticketing.system.Core.Domain.events.DiscountPolicy;
 import com.ticketing.system.Core.Domain.events.EventCategory;
 import com.ticketing.system.Core.Domain.users.Permission;
@@ -599,5 +601,68 @@ class EventManagementServiceTest {
                 new EventUpdateDTO(String.valueOf(EVENT_ID), "Updated Draft Name", null, null, null, null));
 
         assertEquals("Updated Draft Name", draftEvent.getName());
+    }
+
+    @Test
+    void GivenOwnerAndNewDescription_WhenEditEventDetails_ThenDescriptionIsUpdated() {
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+
+        eventService.editEventDetails(OWNER_TOKEN,
+                new EventUpdateDTO(String.valueOf(EVENT_ID), null, "A brand new description", null, null, null));
+
+        assertEquals("A brand new description", event.getDescription());
+    }
+
+    @Test
+    void GivenOwnerAndNewLocation_WhenEditEventDetails_ThenVenueMapLocationIsUpdated() {
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+
+        eventService.editEventDetails(OWNER_TOKEN,
+                new EventUpdateDTO(String.valueOf(EVENT_ID), null, null, null,
+                        new LocationDTO("France", "Paris"), null));
+
+        assertEquals(new Location("France", "Paris"), event.getVenueMap().getLocation());
+    }
+
+    @Test
+    void GivenOwnerAndNewShowDates_WhenEditEventDetails_ThenShowDatesAreReplaced() {
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+
+        LocalDateTime newStart = LocalDateTime.now().plusDays(30);
+        LocalDateTime newEnd = newStart.plusHours(3);
+        eventService.editEventDetails(OWNER_TOKEN,
+                new EventUpdateDTO(String.valueOf(EVENT_ID), null, null, null, null,
+                        List.of(new ShowDateDTO(newStart, newEnd))));
+
+        assertEquals(1, event.getShowDates().size());
+        assertEquals(newStart, event.getShowDates().get(0).getStartTime());
+        assertEquals(newEnd, event.getShowDates().get(0).getEndTime());
+    }
+
+    @Test
+    void GivenDescribedEvent_WhenGetEventDetail_ThenReturnsDescription() {
+        Event describedEvent = new Event(
+                EVENT_ID, "Concert", "The headline show of the year", 4.5, List.of("Artist1"),
+                EventCategory.CONCERT, COMPANY_ID, EventStatus.SCHEDULED, venueMap,
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(2))),
+                null, new DiscountPolicy(0));
+        when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
+        when(mockEventRepo.findById(EVENT_ID)).thenReturn(describedEvent);
+        when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
+        when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
+
+        EventDetailDTO result = eventService.getEventDetail(OWNER_TOKEN, String.valueOf(EVENT_ID));
+
+        assertEquals("The headline show of the year", result.description());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -115,7 +115,7 @@ class EventManagementServiceTest {
                 venueMap,
                 List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(2))),
                 null,
-                null);
+                new DiscountPolicy(0));
         ownerUser = new User(OWNER_ID, "Owner Name", "owner@example.com", "hashedpassword",50);
         ownerUser.addFounderAppointment(COMPANY_ID);
         managerUser = new User(MANAGER_ID, "Manager Name", "manager@example.com", "hashedpassword",40);
@@ -381,7 +381,7 @@ class EventManagementServiceTest {
                 EVENT_ID, "Draft Concert", 4.5, List.of("Artist1"),
                 EventCategory.MUSIC, COMPANY_ID, EventStatus.DRAFT, null,
                 List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(2))),
-                null, null);
+                null, new DiscountPolicy(0));
         when(sessionManager.validateToken(OWNER_TOKEN)).thenReturn(true);
         when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
         when(mockEventRepo.findById(EVENT_ID)).thenReturn(draftNoVenue);

--- a/src/test/java/com/ticketing/system/unit/application/NotificationDispatchServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/NotificationDispatchServiceTest.java
@@ -1,6 +1,7 @@
 package com.ticketing.system.unit.application;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -15,9 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import com.ticketing.system.Core.Application.dto.NotificationDTO;
 import com.ticketing.system.Core.Application.interfaces.IPushNotificationService;
@@ -62,7 +61,7 @@ class NotificationDispatchServiceTest {
         // Verify it was saved twice: once as PENDING, once as DELIVERED
         verify(mockRepo, times(2)).save(notification);
         verify(mockPushService, times(1)).send(eq(userId), any(Notification.class));
-        assert notification.getStatus() == NotificationStatus.DELIVERED;
+        assertEquals(NotificationStatus.DELIVERED, notification.getStatus());
     }
 
     @Test
@@ -83,7 +82,7 @@ class NotificationDispatchServiceTest {
 
         // Verify it was saved once (at the start of dispatch)
         verify(mockRepo, times(1)).save(notification);
-        assert notification.getStatus() == NotificationStatus.PENDING;
+        assertEquals(NotificationStatus.PENDING, notification.getStatus());
     }
 
     // UC-36: offline recipient → PENDING storage
@@ -149,9 +148,9 @@ class NotificationDispatchServiceTest {
         verify(mockRepo, times(1)).save(notif2);
 
         // Verify all returned DTOs have DELIVERED status
-        assert result.size() == 2;
-        assert result.get(0).status().equals("DELIVERED");
-        assert result.get(1).status().equals("DELIVERED");
+        assertEquals(2, result.size());
+        assertEquals("DELIVERED", result.get(0).status());
+        assertEquals("DELIVERED", result.get(1).status());
     }
 
     /* UC-37: no pending notifications is no-op */
@@ -176,6 +175,6 @@ class NotificationDispatchServiceTest {
         verify(mockRepo, never()).save(any());
 
         // Verify empty list is returned
-        assert result.isEmpty();
+        assertTrue(result.isEmpty());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.mockito.ArgumentCaptor;
 
+import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
 import com.ticketing.system.Core.Domain.events.DiscountPolicy;
@@ -869,6 +870,83 @@ void GivenManyMembersReserveSameZoneConcurrently_WhenreserveStandingTicketsForMe
 
 
 
+
+    // ---------------------------------------------------------------------
+    // Checkout-entry timer renewal (reset every reserved ticket to the full window)
+    // ---------------------------------------------------------------------
+
+    @Test
+    void GivenValidCartNearExpiry_WhenRenewReservationsForMemberCheckout_ThenTimersResetToFullWindow() {
+        ActiveOrder realOrder = new ActiveOrder(USER_ID);
+        realOrder.addStandingReservation(EVENT_ID, ZONE_ID, 2, 50.0, LocalDateTime.now().minusMinutes(9));
+        when(activeOrderRepository.getByUserId(USER_ID)).thenReturn(realOrder);
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+
+        ActiveOrderDTO dto = reservationService.renewReservationsForMemberCheckout(USER_ID);
+
+        assertNotNull(dto);
+        assertTrue(dto.remainingSecondsBeforeExpiry() > 590,
+                "timers should be reset close to the full 10-minute window");
+        verify(activeOrderRepository).lockForUpdate("user:" + USER_ID);
+        verify(activeOrderRepository).unlock("user:" + USER_ID);
+        verify(activeOrderRepository).save(realOrder);
+    }
+
+    @Test
+    void GivenExpiredItem_WhenRenewReservationsForMemberCheckout_ThenTimersNotResetAndNotSaved() {
+        ActiveOrder realOrder = new ActiveOrder(USER_ID);
+        realOrder.addStandingReservation(EVENT_ID, ZONE_ID, 1, 50.0, LocalDateTime.now().minusMinutes(20));
+        when(activeOrderRepository.getByUserId(USER_ID)).thenReturn(realOrder);
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+
+        ActiveOrderDTO dto = reservationService.renewReservationsForMemberCheckout(USER_ID);
+
+        assertEquals(0, dto.remainingSecondsBeforeExpiry(), "already-expired cart must not be revived");
+        verify(activeOrderRepository, never()).save(any());
+        verify(activeOrderRepository).unlock("user:" + USER_ID);
+    }
+
+    @Test
+    void GivenCheckoutInProgress_WhenRenewReservationsForMemberCheckout_ThenTimersNotResetAndNotSaved() {
+        ActiveOrder realOrder = new ActiveOrder(USER_ID);
+        realOrder.addStandingReservation(EVENT_ID, ZONE_ID, 1, 50.0, LocalDateTime.now().minusMinutes(9));
+        realOrder.markCheckoutInProgress();
+        when(activeOrderRepository.getByUserId(USER_ID)).thenReturn(realOrder);
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+
+        ActiveOrderDTO dto = reservationService.renewReservationsForMemberCheckout(USER_ID);
+
+        assertTrue(dto.remainingSecondsBeforeExpiry() < 120, "in-checkout cart timers must be left untouched");
+        verify(activeOrderRepository, never()).save(any());
+    }
+
+    @Test
+    void GivenNoOrder_WhenRenewReservationsForMemberCheckout_ThenReturnsNullAndDoesNotSave() {
+        when(activeOrderRepository.getByUserId(USER_ID)).thenReturn(null);
+
+        ActiveOrderDTO dto = reservationService.renewReservationsForMemberCheckout(USER_ID);
+
+        assertNull(dto);
+        verify(activeOrderRepository, never()).save(any());
+        verify(activeOrderRepository).unlock("user:" + USER_ID);
+    }
+
+    @Test
+    void GivenValidGuestCartNearExpiry_WhenRenewReservationsForGuestCheckout_ThenTimersResetToFullWindow() {
+        String sessionId = "guest-session";
+        ActiveOrder realOrder = ActiveOrder.forGuest(sessionId);
+        realOrder.addStandingReservation(EVENT_ID, ZONE_ID, 1, 50.0, LocalDateTime.now().minusMinutes(9));
+        when(activeOrderRepository.getBySessionId(sessionId)).thenReturn(Optional.of(realOrder));
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+
+        ActiveOrderDTO dto = reservationService.renewReservationsForGuestCheckout(sessionId);
+
+        assertNotNull(dto);
+        assertTrue(dto.remainingSecondsBeforeExpiry() > 590);
+        verify(activeOrderRepository).lockForUpdate("sess:" + sessionId);
+        verify(activeOrderRepository).unlock("sess:" + sessionId);
+        verify(activeOrderRepository).save(realOrder);
+    }
 
     // helper test methods:
 

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -611,33 +611,6 @@ void GivenManyMembersReserveSameZoneConcurrently_WhenreserveStandingTicketsForMe
     }
 
 
-    // COMMENTED OUT: this test exercises ReservationService.expireActiveOrders(), which is now
-    // commented out (an orphaned duplicate of the live SessionAndOrderSweeper expiry path). With the
-    // method gone the test no longer compiles and has nothing to verify, so it is parked here
-    // alongside its subject. The equivalent in-checkout guard is already covered for the live path by
-    // SessionAndOrderSweeperTest.GivenExpiredCartInCheckoutProgress_WhenSweepExpiredOrders_ThenDoNotReleaseOrDelete.
-    // Restore this together with expireActiveOrders/safelyReleaseAndDelete if that path is ever revived.
-    //
-    // @Test
-    // void GivenExpiredOrderInCheckoutProgress_WhenExpireActiveOrders_ThenDoNotReleaseOrDelete() {
-    //     ActiveOrder cart = new ActiveOrder(USER_ID);
-    //     cart.addStandingReservation(EVENT_ID, ZONE_ID, QUANTITY, 100.0, LocalDateTime.now().minusMinutes(30));
-    //     cart.markCheckoutInProgress();
-    //
-    //     when(activeOrderRepository.findExpired()).thenReturn(List.of(cart));
-    //
-    //     reservationService.expireActiveOrders();
-    //
-    //     verify(activeOrderRepository).lockForUpdate("user:" + USER_ID);
-    //     verify(activeOrderRepository).unlock("user:" + USER_ID);
-    //     verify(activeOrderRepository, never()).delete(any());
-    //     verify(eventRepository, never()).lockForUpdate(anyInt());
-    //     verify(eventRepository, never()).save(any());
-    // }
-
-
-
-
 
 
 

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -610,6 +610,31 @@ void GivenManyMembersReserveSameZoneConcurrently_WhenreserveStandingTicketsForMe
     }
 
 
+    // COMMENTED OUT: this test exercises ReservationService.expireActiveOrders(), which is now
+    // commented out (an orphaned duplicate of the live SessionAndOrderSweeper expiry path). With the
+    // method gone the test no longer compiles and has nothing to verify, so it is parked here
+    // alongside its subject. The equivalent in-checkout guard is already covered for the live path by
+    // SessionAndOrderSweeperTest.GivenExpiredCartInCheckoutProgress_WhenSweepExpiredOrders_ThenDoNotReleaseOrDelete.
+    // Restore this together with expireActiveOrders/safelyReleaseAndDelete if that path is ever revived.
+    //
+    // @Test
+    // void GivenExpiredOrderInCheckoutProgress_WhenExpireActiveOrders_ThenDoNotReleaseOrDelete() {
+    //     ActiveOrder cart = new ActiveOrder(USER_ID);
+    //     cart.addStandingReservation(EVENT_ID, ZONE_ID, QUANTITY, 100.0, LocalDateTime.now().minusMinutes(30));
+    //     cart.markCheckoutInProgress();
+    //
+    //     when(activeOrderRepository.findExpired()).thenReturn(List.of(cart));
+    //
+    //     reservationService.expireActiveOrders();
+    //
+    //     verify(activeOrderRepository).lockForUpdate("user:" + USER_ID);
+    //     verify(activeOrderRepository).unlock("user:" + USER_ID);
+    //     verify(activeOrderRepository, never()).delete(any());
+    //     verify(eventRepository, never()).lockForUpdate(anyInt());
+    //     verify(eventRepository, never()).save(any());
+    // }
+
+
 
 
 

--- a/src/test/java/com/ticketing/system/unit/domain/ActiveOrderTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/ActiveOrderTest.java
@@ -244,7 +244,51 @@ class ActiveOrderTest extends BaseDomainTest {
                 order.getItems().stream().map(CartLineItem::getSeatNumber).toList());
     }
 
+    @Test
+    void GivenItemsNearExpiry_WhenRenewReservationTimers_ThenAllTimersResetToFullWindow() {
+        ActiveOrder order = track(new ActiveOrder(USER_ID));
 
+        // Added 9 minutes ago -> ~1 minute left on the 10-minute window.
+        LocalDateTime nineMinutesAgo = LocalDateTime.now().minusMinutes(9);
+        order.addStandingReservation(EVENT_ID, ZONE_ID, 2, 50.0, nineMinutesAgo);
+        order.addSeatedReservation(EVENT_ID, ZONE_ID + 1, List.of("A1"), 120.0, nineMinutesAgo);
 
+        assertTrue(order.getRemainingTime().getSeconds() < 120,
+                "precondition: cart should be near expiry before renewal");
+
+        order.renewReservationTimers(LocalDateTime.now());
+
+        // Every line item now has a fresh ~10-minute window.
+        assertTrue(order.getRemainingTime().getSeconds() > 590,
+                "all timers should be reset close to the full 10-minute window");
+        for (CartLineItem item : order.getItems()) {
+            assertTrue(item.getRemainingTime().getSeconds() > 590);
+            assertFalse(item.isExpired());
+        }
+    }
+
+    @Test
+    void GivenCheckoutInProgress_WhenRenewReservationTimers_ThenThrows() {
+        ActiveOrder order = track(new ActiveOrder(USER_ID));
+        order.addStandingReservation(EVENT_ID, ZONE_ID, 1, 50.0, LocalDateTime.now());
+        order.markCheckoutInProgress();
+
+        assertThrows(IllegalStateException.class,
+                () -> order.renewReservationTimers(LocalDateTime.now()));
+    }
+
+    @Test
+    void GivenLineItem_WhenRenew_ThenAddedAtUpdatedAndTimerFresh() {
+        LocalDateTime nineMinutesAgo = LocalDateTime.now().minusMinutes(9);
+        CartLineItem item = new CartLineItem(EVENT_ID, ZONE_ID, "A7", 120.0, nineMinutesAgo);
+
+        assertTrue(item.getRemainingTime().getSeconds() < 120);
+
+        LocalDateTime now = LocalDateTime.now();
+        item.renew(now);
+
+        assertEquals(now, item.getAddedAt());
+        assertTrue(item.getRemainingTime().getSeconds() > 590);
+    }
 
 }

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -529,6 +529,76 @@ class EventTest extends BaseDomainTest {
         assertEquals(EventStatus.ON_SALE, event.getStatus());
     }
 
+    // -- ON_SALE <-> SOLD_OUT transition --------------------------------
+
+    @Test
+    void GivenOnSaleEvent_WhenAllInventoryReserved_ThenSoldOut() {
+        StandingZone zone = track(new StandingZone(1, "General", 5, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+        event.transitionToOnSale();
+
+        event.reserveInventory(1, InventorySelection.standing(5));
+
+        assertEquals(EventStatus.SOLD_OUT, event.getStatus());
+    }
+
+    @Test
+    void GivenOnSaleEvent_WhenPartiallyReserved_ThenStaysOnSale() {
+        StandingZone zone = track(new StandingZone(1, "General", 5, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+        event.transitionToOnSale();
+
+        event.reserveInventory(1, InventorySelection.standing(3));
+
+        assertEquals(EventStatus.ON_SALE, event.getStatus());
+    }
+
+    @Test
+    void GivenSoldOutEvent_WhenReservationReleased_ThenBackOnSale() {
+        StandingZone zone = track(new StandingZone(1, "General", 5, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+        event.transitionToOnSale();
+        event.reserveInventory(1, InventorySelection.standing(5, "order-1"));
+        assertEquals(EventStatus.SOLD_OUT, event.getStatus());
+
+        event.releaseInventory(1, InventorySelection.standing(1, "order-1"));
+
+        assertEquals(EventStatus.ON_SALE, event.getStatus());
+    }
+
+    @Test
+    void GivenMultiZone_WhenOneZoneFullButAnotherHasAvailability_ThenStaysOnSale() {
+        StandingZone full = track(new StandingZone(1, "General", 5, 50.0));
+        StandingZone other = track(new StandingZone(2, "VIP", 5, 120.0));
+        Event event = createEventWithZones(List.of(full, other));
+        event.transitionToOnSale();
+
+        event.reserveInventory(1, InventorySelection.standing(5));
+
+        assertEquals(EventStatus.ON_SALE, event.getStatus());
+    }
+
+    @Test
+    void GivenSoldOutEvent_WhenSaleConfirmed_ThenStaysSoldOut() {
+        StandingZone zone = track(new StandingZone(1, "General", 5, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+        event.transitionToOnSale();
+        event.reserveInventory(1, InventorySelection.standing(5, "order-1"));
+        assertEquals(EventStatus.SOLD_OUT, event.getStatus());
+
+        event.confirmInventorySale(1, InventorySelection.standing(5, "order-1"));
+
+        assertEquals(EventStatus.SOLD_OUT, event.getStatus());
+    }
+
+    @Test
+    void GivenScheduledEvent_WhenRevertToOnSaleCalledDirectly_ThenThrows() {
+        StandingZone zone = track(new StandingZone(1, "General", 5, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+
+        assertThrows(InvalidStateTransitionException.class, event::revertToOnSale);
+    }
+
     private Event createDraftEvent() {
         return track(new Event(
                 EVENT_ID,

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -18,6 +18,7 @@ import com.ticketing.system.Core.Domain.events.Location;
 import com.ticketing.system.Core.Domain.events.VenueMap;
 import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
 import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.support.BaseDomainTest;
 
 import java.time.LocalDateTime;
@@ -443,6 +444,73 @@ class EventTest extends BaseDomainTest {
                 return priceAtOneTicketReservation;
             }
         };
+    }
+
+    // -- DRAFT -> SCHEDULED transition (issue #305) -----------------------
+
+    @Test
+    void GivenDraftEventWithInventory_WhenConfigureVenueMap_ThenStatusScheduled() {
+        Event event = createDraftEvent();
+        StandingZone zone = track(new StandingZone(1, "General", 50, 80.0));
+
+        event.configureVenueMap(new VenueMap(1, LOCATION, List.of(zone)), COMPANY_ID);
+
+        assertEquals(EventStatus.SCHEDULED, event.getStatus());
+    }
+
+    @Test
+    void GivenDraftEventNoInventory_WhenConfigureVenueMap_ThenStaysDraft() {
+        Event event = createDraftEvent();
+
+        event.configureVenueMap(new VenueMap(1, LOCATION, List.of()), COMPANY_ID);
+
+        assertEquals(EventStatus.DRAFT, event.getStatus());
+    }
+
+    @Test
+    void GivenScheduledEvent_WhenTransitionToScheduledAgain_ThenIdempotent() {
+        StandingZone zone = track(new StandingZone(1, "General", 50, 80.0));
+        Event event = createEventWithZones(List.of(zone));
+
+        event.transitionToScheduled();
+
+        assertEquals(EventStatus.SCHEDULED, event.getStatus());
+    }
+
+    @Test
+    void GivenDraftEvent_WhenTransitionToOnSale_ThenThrowsInvalidStateTransition() {
+        Event event = createDraftEvent();
+        // addStandingZone gives inventory without triggering the auto-transition, so the
+        // event still has DRAFT status when transitionToOnSale is called directly.
+        event.addStandingZone("General", 50, 80.0, COMPANY_ID);
+
+        assertThrows(InvalidStateTransitionException.class, event::transitionToOnSale);
+    }
+
+    @Test
+    void GivenDraftEventWithInventory_WhenScheduledThenOnSale_ThenOnSale() {
+        Event event = createDraftEvent();
+        StandingZone zone = track(new StandingZone(1, "General", 50, 80.0));
+
+        event.configureVenueMap(new VenueMap(1, LOCATION, List.of(zone)), COMPANY_ID); // -> SCHEDULED
+        event.transitionToOnSale(); // -> ON_SALE
+
+        assertEquals(EventStatus.ON_SALE, event.getStatus());
+    }
+
+    private Event createDraftEvent() {
+        return track(new Event(
+                EVENT_ID,
+                "Concert",
+                4.5,
+                ARTISTS,
+                EventCategory.CONCERT,
+                COMPANY_ID,
+                EventStatus.DRAFT,
+                new VenueMap(1, LOCATION, List.of()),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(30), LocalDateTime.now().plusDays(30).plusHours(2))),
+                acceptingPurchasePolicy(),
+                noDiscountPolicy()));
     }
 
     private Event createEventWithZones(List<InventoryZone> zones) {

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -96,6 +96,41 @@ class EventTest extends BaseDomainTest {
                 null, new DiscountPolicy(0)));
     }
 
+    // UC-19 — editDetails applies all five updatable fields while DRAFT or SCHEDULED.
+    @Test
+    void GivenScheduledEvent_WhenEditDetailsAllFields_ThenAllApplied() {
+        ShowDate newShow = new ShowDate(LocalDateTime.now().plusDays(40), LocalDateTime.now().plusDays(40).plusHours(2));
+
+        event.editDetails("New Name", "New Description", EventCategory.THEATER,
+                new Location("France", "Paris"), List.of(newShow));
+
+        assertEquals("New Name", event.getName());
+        assertEquals("New Description", event.getDescription());
+        assertEquals(EventCategory.THEATER, event.getCategory());
+        assertEquals(new Location("France", "Paris"), event.getVenueMap().getLocation());
+        assertEquals(1, event.getShowDates().size());
+        assertEquals(newShow.getStartTime(), event.getShowDates().get(0).getStartTime());
+    }
+
+    // Null arguments mean "leave this field alone".
+    @Test
+    void GivenNullArguments_WhenEditDetails_ThenNothingChanges() {
+        event.editDetails(null, null, null, null, null);
+
+        assertEquals("Concert", event.getName());
+        assertEquals(EventCategory.CONCERT, event.getCategory());
+        assertEquals(LOCATION, event.getVenueMap().getLocation());
+        assertEquals(1, event.getShowDates().size());
+    }
+
+    @Test
+    void GivenOnSaleEvent_WhenEditDetails_ThenThrowsIllegalState() {
+        event.transitionToOnSale();
+
+        assertThrows(IllegalStateException.class, () -> event.editDetails(
+                "New Name", null, null, null, null));
+    }
+
     @Test
     void GivenStandingZone_WhenReserveInventoryStandingSelection_ThenQuantityReserved() {
         StandingZone standingZone = track(new StandingZone(1, "General Admission", 10, 50.0));

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -65,6 +65,37 @@ class EventTest extends BaseDomainTest {
 
 
 
+    // Construction-time invariant enforcement (issue #303): a freshly-constructed Event
+    // must satisfy its invariants, so invalid args fail at construction with IllegalStateException.
+    @Test
+    void GivenRatingOutOfRange_WhenConstructed_ThenThrowsIllegalState() {
+        VenueMap venueMap = new VenueMap(1, LOCATION, List.of(new StandingZone(ZONE_ID, "VIP", 10, 100)));
+        assertThrows(IllegalStateException.class, () -> new Event(
+                EVENT_ID, "Concert", 9.0, ARTISTS, EventCategory.CONCERT, COMPANY_ID,
+                EventStatus.SCHEDULED, venueMap,
+                List.of(new ShowDate(LocalDateTime.now().plusDays(30), LocalDateTime.now().plusDays(30).plusHours(2))),
+                null, new DiscountPolicy(0)));
+    }
+
+    @Test
+    void GivenEmptyArtists_WhenConstructed_ThenThrowsIllegalState() {
+        VenueMap venueMap = new VenueMap(1, LOCATION, List.of(new StandingZone(ZONE_ID, "VIP", 10, 100)));
+        assertThrows(IllegalStateException.class, () -> new Event(
+                EVENT_ID, "Concert", 4.5, List.of(), EventCategory.CONCERT, COMPANY_ID,
+                EventStatus.SCHEDULED, venueMap,
+                List.of(new ShowDate(LocalDateTime.now().plusDays(30), LocalDateTime.now().plusDays(30).plusHours(2))),
+                null, new DiscountPolicy(0)));
+    }
+
+    @Test
+    void GivenEmptyShowDates_WhenConstructed_ThenThrowsIllegalState() {
+        VenueMap venueMap = new VenueMap(1, LOCATION, List.of(new StandingZone(ZONE_ID, "VIP", 10, 100)));
+        assertThrows(IllegalStateException.class, () -> new Event(
+                EVENT_ID, "Concert", 4.5, ARTISTS, EventCategory.CONCERT, COMPANY_ID,
+                EventStatus.SCHEDULED, venueMap, List.of(),
+                null, new DiscountPolicy(0)));
+    }
+
     @Test
     void GivenStandingZone_WhenReserveInventoryStandingSelection_ThenQuantityReserved() {
         StandingZone standingZone = track(new StandingZone(1, "General Admission", 10, 50.0));

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -123,6 +123,13 @@ class EventTest extends BaseDomainTest {
         assertEquals(1, event.getShowDates().size());
     }
 
+    // An explicitly empty showDates list is rejected (vs null, which leaves the schedule alone).
+    @Test
+    void GivenEmptyShowDates_WhenEditDetails_ThenThrowsIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> event.editDetails(
+                null, null, null, null, List.of()));
+    }
+
     @Test
     void GivenOnSaleEvent_WhenEditDetails_ThenThrowsIllegalState() {
         event.transitionToOnSale();

--- a/src/test/java/com/ticketing/system/unit/domain/ReceiptLineTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/ReceiptLineTest.java
@@ -72,17 +72,15 @@ class ReceiptLineTest extends BaseDomainTest {
     }
 
     @Test
-    void GivenBlankSeatNumber_WhenCheckInvariants_ThenThrowsException() {
-        ReceiptLine line = new ReceiptLine(
+    void GivenBlankSeatNumber_WhenConstructed_ThenThrowsException() {
+        assertThrows(IllegalStateException.class, () -> new ReceiptLine(
                 101,
                 120.0,
                 10,
                 7,
                 "   ",
                 LocalDateTime.now()
-        );
-
-        assertThrows(IllegalStateException.class, line::checkInvariants);
+        ));
     }
 
 

--- a/src/test/java/com/ticketing/system/unit/domain/SessionTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/SessionTest.java
@@ -47,19 +47,19 @@ class SessionTest extends BaseDomainTest {
 
     @Test
     void constructor_rejectsBlankSessionId() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalStateException.class,
                 () -> new Session("", null, T0, T_EXPIRES));
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalStateException.class,
                 () -> new Session("   ", null, T0, T_EXPIRES));
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalStateException.class,
                 () -> new Session(null, null, T0, T_EXPIRES));
     }
 
     @Test
     void constructor_rejectsNullTimestamps() {
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalStateException.class,
                 () -> new Session("sid", null, null, T_EXPIRES));
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalStateException.class,
                 () -> new Session("sid", null, T0, null));
     }
 

--- a/src/test/java/com/ticketing/system/unit/domain/TicketTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/TicketTest.java
@@ -90,10 +90,9 @@ class TicketTest extends BaseDomainTest {
     }
 
     @Test
-    void GivenBlankSeatNumber_WhenCheckInvariants_ThenThrowsException() {
-        Ticket ticket = new Ticket(1, 10, 11, "   ", 75.0, 101, "barcode-Y");
-
-        assertThrows(IllegalStateException.class, ticket::checkInvariants);
+    void GivenBlankSeatNumber_WhenConstructed_ThenThrowsException() {
+        assertThrows(IllegalStateException.class,
+                () -> new Ticket(1, 10, 11, "   ", 75.0, 101, "barcode-Y"));
     }
 
 


### PR DESCRIPTION
## Summary

This PR bundles the event-lifecycle / domain work done on this branch together with the
**fixed** version of the notification refactor (#314, authored by @moshe2432). #314 was
merged into `dev` first; this branch then merged `dev` and applies the review-feedback fixes
on top, so `dev` ends up with my work **and** Moshe's notification work in a corrected state.

Verified end-to-end: `mvn -B verify -Pno-vaadin` → **756 tests, 0 failures, 0 errors** (97 skipped), jar packaged.

---

## Event lifecycle & domain

- **`fix(events)`: implement DRAFT → SCHEDULED transition (#305)** — `transitionToOnSale`
  required `SCHEDULED` but nothing produced it, leaving the transition unreachable. Adds
  `Event.transitionToScheduled()` (requires venue map + ≥1 inventory zone, only legal from
  DRAFT, idempotent), auto-fires it from `configureVenueMap`, converts raw
  `IllegalStateException` to the domain `InvalidStateTransitionException` convention, and
  removes the `DemoEvents` reflection workaround.
- **`feat(domain)`: enforce invariants at construction (#303)** — every domain object now
  calls `checkInvariants()` as the final constructor statement (single validator, throws
  `IllegalStateException`); redundant inline guards dropped; 15 aggregates/entities + all
  value objects (incl. purchase policies) made `InvariantChecked`. A few non-perpetual
  checks kept as explicit guards.
- **`feat(events)`: auto-transition ON_SALE ↔ SOLD_OUT with inventory** — adds
  `VenueMap.hasAvailableInventory()`; `reserveInventory` flips ON_SALE → SOLD_OUT on the
  last place, `releaseInventory` reverts SOLD_OUT → ON_SALE when availability reappears
  (covers manual removal, checkout rollback, and the expiry sweeper); `confirmInventorySale`
  still allowed while SOLD_OUT so last-reservation holders can finish checkout.
- **`feat(events)`: owner `publishEvent` to open sales (UC-19)** — adds
  `EventManagementService.publishEvent(token, companyId, eventId)` (lock → ownership +
  `CONFIGURE_VENUE` → `transitionToOnSale` → save), the missing application-layer caller for
  SCHEDULED → ON_SALE.
- **`feat(events)`: persist description + edit all event fields (UC-19)** — real `Event`
  `description` field that actually persists and is returned by `getEventDetail`;
  `editEventDetails` now applies all five `EventUpdateDTO` fields (name, description,
  category, location, showDates) while DRAFT/SCHEDULED.

## Checkout

- **Harden checkout failure flow** — commit the sale **last** (move the irreversible
  RESERVED → SOLD `confirmInventorySale` + `order.buy()` to the end of Phase 3) so a
  ticket/receipt save failure rolls back cleanly to stock + refund instead of stranding SOLD
  inventory; resilient per-event rollback; `safelyClearCart` always runs.
- **`feat(checkout)`: reset cart hold timers to full window on checkout entry** — buyers get
  a fresh 10-minute window on entering checkout; already-expired carts are not revived.

## Notification refactor fixes (follow-up to #314)

Addresses the 10 GitHub Copilot review comments (+1 suppressed) on #314 plus a couple of
issues found in review:

- `INotificationService` — rewrite the stale header (now the app-facing facade, not the push
  channel) and drop the now-unused `Notification` import.
- `InMemoryNotificationService` — drop unused imports (`LocalDateTime`/`List`/`UUID`) and the
  duplicate `Component` import; comment now matches actual stub behavior; trailing newline.
- `NotificationDispatchService.dispatch()` — enforce a **PENDING precondition** before any
  persist/push, so an unexpected status can never be stored or make `markDelivered()` throw.
- `CompanyManagementService` / `EventManagementService` — pass the exception to `log.warn` in
  the notification-failure catch blocks so stack traces survive.
- `NotificationService` — carry the previously-unused `eventId`/`companyId` (plus
  names/role) in the `Notification` structured `data` payload.
- Tests — `NotificationDispatchServiceTest` drops unused imports and uses JUnit assertions
  instead of Java `assert`; `CompanyManagementServiceTest` drops unused/commented imports.

Merge-conflict note: resolved `CompanyManagementServiceTest` in favour of this branch's
`"user@test.com"` fixtures — required because #303 makes `User` reject a blank email, which
would have failed the `dev` side's `""` test data.

---

## Issues closed

- Closes #306 
- Closes #305
- Closes #303
- Follow-up fixes for the review feedback on #314 (merged separately into `dev`).
