### PR TITLE
Wire admin sign-in to real authentication + brute-force lockout (#290)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/AuthTokenDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/AuthTokenDTO.java
@@ -1,10 +1,18 @@
 package com.ticketing.system.Core.Application.dto;
 
-// Returned by AuthenticationService.login() (UC-12).
+// Returned by AuthenticationService.login() (UC-12) and signInAsAdmin() (#290).
 // 'expiresAt' is epoch millis to keep the DTO primitive-only.
+// 'isAdmin' lets the presentation layer know the pool the token was issued for without
+// consulting a hardcoded username set; member tokens default it to false.
 public record AuthTokenDTO(
     String token,
     long expiresAtEpochMillis,
     int userId,
-    String username
-) {}
+    String username,
+    boolean isAdmin
+) {
+    /** Member token — isAdmin defaults to false. */
+    public AuthTokenDTO(String token, long expiresAtEpochMillis, int userId, String username) {
+        this(token, expiresAtEpochMillis, userId, username, false);
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Application/interfaces/ISessionManager.java
+++ b/src/main/java/com/ticketing/system/Core/Application/interfaces/ISessionManager.java
@@ -25,6 +25,16 @@ public interface ISessionManager {
     String generateTokenForSession(Session session, String username);
 
     /**
+     * Admin sign-in (#290): issue a JWT for an admin that carries the ADMIN role claim, so the
+     * admin-authorization gate cannot be satisfied by a member token even when admin ids and
+     * member ids share an id space.
+     */
+    String generateAdminToken(int adminId, String username);
+
+    /** True iff the (valid) token carries the ADMIN role claim. Never throws. */
+    boolean isAdminToken(String token);
+
+    /**
      * Validates a token's signature and expiry. UC-12.
      *
      * @return {@code true} for a well-formed, signed, unexpired token; {@code false}

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -26,6 +28,9 @@ import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
+import com.ticketing.system.Core.Domain.Admin.Admin;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
 import com.ticketing.system.Core.Domain.exceptions.DuplicateEmailException;
 import com.ticketing.system.Core.Domain.exceptions.DuplicateUsernameException;
 import com.ticketing.system.Core.Domain.exceptions.GuestSessionRequiredException;
@@ -66,6 +71,15 @@ public class AuthenticationService {
     private final long guestIdleMinutes;
     private final long memberTtlMinutes;
 
+    // Admin sign-in (#290).
+    private final IAdminRepository adminRepository;
+    // Brute-force lockout (SLR.2 / #148) — shared by member AND admin sign-in. In-memory for
+    // V1/V2 (a restart clears it). Keys are namespaced by pool ("m:"/"a:") so the two forms are
+    // rate-limited independently.
+    private final int lockoutMaxAttempts;    // 0 disables the lockout entirely
+    private final long lockoutLockMinutes;
+    private final ConcurrentMap<String, LoginAttempts> loginAttempts = new ConcurrentHashMap<>();
+
     public AuthenticationService(
             IUserRepository userRepository,
             IPasswordHasher passwordHasher,
@@ -75,8 +89,11 @@ public class AuthenticationService {
             ISessionRepository sessionRepository,
             IActiveOrderRepository activeOrderRepository,
             Clock clock,
+            IAdminRepository adminRepository,
             @Value("${session.guest-idle-timeout-minutes}") long guestIdleMinutes,
-            @Value("${session.member-ttl-minutes}") long memberTtlMinutes) {
+            @Value("${session.member-ttl-minutes}") long memberTtlMinutes,
+            @Value("${auth.lockout.max-attempts:5}") int lockoutMaxAttempts,
+            @Value("${auth.lockout.lock-minutes:15}") long lockoutLockMinutes) {
         this.userRepository = userRepository;
         this.passwordHasher = passwordHasher;
         this.sessionManager = sessionManager;
@@ -85,8 +102,11 @@ public class AuthenticationService {
         this.sessionRepository = sessionRepository;
         this.activeOrderRepository = activeOrderRepository;
         this.clock = clock;
+        this.adminRepository = adminRepository;
         this.guestIdleMinutes = guestIdleMinutes;
         this.memberTtlMinutes = memberTtlMinutes;
+        this.lockoutMaxAttempts = lockoutMaxAttempts;
+        this.lockoutLockMinutes = lockoutLockMinutes;
     }
 
     /** Delegates to {@link ISessionManager#extractUserId}. */
@@ -236,6 +256,15 @@ public class AuthenticationService {
         // 1. Guest session must exist.
         Session session = requireActiveGuestSession(request.guestSessionId());
 
+        // 1b. Brute-force lockout (SLR.2 #148) — same policy as admin sign-in.
+        String lockKey = lockoutKey("m", request.username());
+        if (isLockedOut(lockKey)) {
+            log.warn("MEMBER AUTH BLOCKED · username={} · reason=locked-out · at={}",
+                    request.username(), clock.instant());
+            throw new AccountLockedException(
+                    "Too many failed attempts. Try again in about " + lockoutLockMinutes + " minutes.");
+        }
+
         // 2. Authenticate (same exception for both unknown-user and wrong-password).
         User user;
         try {
@@ -245,9 +274,11 @@ public class AuthenticationService {
                 throw new AuthenticationFailedException();
             }
         } catch (AuthenticationFailedException e) {
-            log.warn("login failed for username={}", request.username());
+            int failures = recordFailure(lockKey);
+            log.warn("MEMBER AUTH FAILED · username={} · failures={}", request.username(), failures);
             throw e;
         }
+        clearFailures(lockKey);
 
         // 3. Promote — same sessionId, userId set, expiry bumped to Member TTL.
         Instant memberExpiry = clock.instant().plus(memberTtlMinutes, ChronoUnit.MINUTES);
@@ -269,6 +300,78 @@ public class AuthenticationService {
         List<NotificationDTO> notifications = notificationDispatchService.deliverPending(user.getUserId());
         return new LoginDTO(authTokenDTO, activeOrderDTO, notifications);
     }
+
+    /**
+     * Admin sign-in (#290). Authenticates against the persisted admin pool (never the member pool
+     * — disjoint-pool rule), applies the shared lock-after-N policy, audit-logs every failure, and
+     * issues an ADMIN-role JWT so the backend admin gate can authorize it.
+     */
+    public AuthTokenDTO signInAsAdmin(String username, String rawPassword) {
+        String lockKey = lockoutKey("a", username);
+
+        if (isLockedOut(lockKey)) {
+            log.warn("ADMIN AUTH BLOCKED · username={} · reason=locked-out · at={}", username, clock.instant());
+            throw new AccountLockedException(
+                    "Too many failed attempts. Try again in about " + lockoutLockMinutes + " minutes.");
+        }
+
+        Admin admin = adminRepository.findByUsername(username == null ? "" : username.trim());
+        if (admin == null || !passwordHasher.matches(rawPassword, admin.getPasswordHash())) {
+            int failures = recordFailure(lockKey);
+            log.warn("ADMIN AUTH FAILED · username={} · reason={} · failures={} · at={}",
+                    username, admin == null ? "unknown-admin" : "bad-password", failures, clock.instant());
+            throw new AuthenticationFailedException();
+        }
+
+        clearFailures(lockKey);
+        String token = sessionManager.generateAdminToken(admin.getId(), admin.getUsername());
+        long expiresAt = sessionManager.extractExpiration(token);
+        log.info("ADMIN AUTH OK · username={} · id={}", admin.getUsername(), admin.getId());
+        return new AuthTokenDTO(token, expiresAt, admin.getId(), admin.getUsername(), true);
+    }
+
+    // ---- shared brute-force lockout (SLR.2 #148) — member + admin sign-in ----
+
+    private static String lockoutKey(String pool, String username) {
+        return pool + ":" + (username == null ? "" : username.trim().toLowerCase());
+    }
+
+    /** True while the key is inside an active lock window; clears an expired lock for a fresh start. */
+    private boolean isLockedOut(String key) {
+        if (lockoutMaxAttempts <= 0) {
+            return false;
+        }
+        LoginAttempts a = loginAttempts.get(key);
+        if (a == null || a.lockedUntil() == null) {
+            return false;
+        }
+        if (clock.instant().isBefore(a.lockedUntil())) {
+            return true;
+        }
+        loginAttempts.remove(key); // lock expired — fresh window
+        return false;
+    }
+
+    /** Records a failed attempt; locks the key once it reaches the configured threshold. */
+    private int recordFailure(String key) {
+        if (lockoutMaxAttempts <= 0) {
+            return 0;
+        }
+        LoginAttempts updated = loginAttempts.compute(key, (k, prev) -> {
+            int failures = (prev == null ? 0 : prev.failures()) + 1;
+            Instant lockedUntil = failures >= lockoutMaxAttempts
+                    ? clock.instant().plus(lockoutLockMinutes, ChronoUnit.MINUTES)
+                    : null;
+            return new LoginAttempts(failures, lockedUntil);
+        });
+        return updated.failures();
+    }
+
+    private void clearFailures(String key) {
+        loginAttempts.remove(key);
+    }
+
+    private record LoginAttempts(int failures, Instant lockedUntil) { }
 
     /**
      * D9a cart wiring at promotion time. Two cases:

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -311,6 +311,13 @@ public class SystemAdminService {
             throw new UnauthorizedActionException("Invalid or non-admin token.");
         }
 
+        // The token must carry the ADMIN role. Without this, a member whose id happens to equal an
+        // admin's id (both pools start at 1) would pass the adminRepository lookup below.
+        if (!sessionManager.isAdminToken(token)) {
+            log.warn("Unauthorized access attempt (non-admin token) with id: {}", sessionManager.extractUserId(token));
+            throw new UnauthorizedActionException("Invalid or non-admin token.");
+        }
+
         int userId = sessionManager.extractUserId(token);
         if (adminRepository.findById(userId) == null) {
             log.warn("Unauthorized access attempt with id: {}", userId);

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/AccountLockedException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/AccountLockedException.java
@@ -1,0 +1,11 @@
+package com.ticketing.system.Core.Domain.exceptions;
+
+// Thrown by member and admin sign-in (#290 / SLR.2 #148) when an account is temporarily locked
+// after too many failed attempts. Distinct from AuthenticationFailedException so the view can show
+// a "locked, try again later" message rather than "invalid credentials".
+public class AccountLockedException extends DomainException {
+
+    public AccountLockedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/security/JwtSessionManager.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/security/JwtSessionManager.java
@@ -47,6 +47,9 @@ public class JwtSessionManager implements ISessionManager {
 
     private static final String CLAIM_USERNAME = "username";
     private static final String CLAIM_SID = "sid";
+    private static final String CLAIM_ROLE = "role";
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_MEMBER = "MEMBER";
 
     private final SecretKey signingKey;
     private final long expirationMillis;
@@ -72,7 +75,27 @@ public class JwtSessionManager implements ISessionManager {
         Instant expiry = now.plusMillis(expirationMillis);
         String sid = UUID.randomUUID().toString();
         sessions.save(new Session(sid, userId, now, expiry));
-        return buildJwt(userId, username, sid, now, expiry);
+        return buildJwt(userId, username, sid, ROLE_MEMBER, now, expiry);
+    }
+
+    // Admin sign-in (#290): issue a JWT carrying the ADMIN role so the admin-authorization gate
+    // can never be satisfied by a member token (admin ids and member ids share an id space).
+    @Override
+    public String generateAdminToken(int adminId, String username) {
+        Instant now = clock.instant();
+        Instant expiry = now.plusMillis(expirationMillis);
+        String sid = UUID.randomUUID().toString();
+        sessions.save(new Session(sid, adminId, now, expiry));
+        return buildJwt(adminId, username, sid, ROLE_ADMIN, now, expiry);
+    }
+
+    @Override
+    public boolean isAdminToken(String token) {
+        try {
+            return ROLE_ADMIN.equals(parseClaims(token).get(CLAIM_ROLE, String.class));
+        } catch (RuntimeException e) {
+            return false;
+        }
     }
 
     // UC-12: issue a new JWT for an existing session (e.g. after password login to a guest session).
@@ -86,7 +109,7 @@ public class JwtSessionManager implements ISessionManager {
             throw new IllegalStateException("cannot issue JWT for a guest session");
         }
         Instant now = clock.instant();
-        return buildJwt(session.getUserId(), username, session.getSessionId(), now, session.getExpiresAt());
+        return buildJwt(session.getUserId(), username, session.getSessionId(), ROLE_MEMBER, now, session.getExpiresAt());
     }
 
     // UC-12: validate a JWT's signature, expiry, and revocation status. Revocation is checked by verifying that the Session row still exists.
@@ -239,11 +262,13 @@ public class JwtSessionManager implements ISessionManager {
         }
     }
 
-    private String buildJwt(int userId, String username, String sid, Instant issuedAt, Instant expiresAt) {
+    private String buildJwt(int userId, String username, String sid, String role,
+            Instant issuedAt, Instant expiresAt) {
         return Jwts.builder()
                 .subject(String.valueOf(userId))
                 .claim(CLAIM_USERNAME, username)
                 .claim(CLAIM_SID, sid)
+                .claim(CLAIM_ROLE, role)
                 .issuedAt(Date.from(issuedAt))
                 .expiration(Date.from(expiresAt))
                 .signWith(signingKey)

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
@@ -1,0 +1,44 @@
+package com.ticketing.system.Presentation.presenters.auth;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
+import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * MVP presenter for {@code AdminLoginView} (#290). Holds no Vaadin imports; the
+ * view switches over the typed {@link Outcome}. Mirrors {@link LoginPresenter}.
+ */
+@Component
+public class AdminLoginPresenter {
+
+    private final AuthenticationService authenticationService;
+
+    @Autowired
+    public AdminLoginPresenter(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    /** Authenticates against the admin pool; translates domain exceptions into a typed outcome. */
+    public Outcome attemptAdminLogin(String username, String rawPassword) {
+        try {
+            AuthTokenDTO token = authenticationService.signInAsAdmin(username, rawPassword);
+            return new Outcome.Success(token);
+        } catch (AccountLockedException e) {
+            return new Outcome.Locked(e.getMessage());
+        } catch (AuthenticationFailedException e) {
+            return new Outcome.InvalidCredentials();
+        } catch (RuntimeException e) {
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+
+    public sealed interface Outcome {
+        record Success(AuthTokenDTO authToken) implements Outcome { }
+        record InvalidCredentials() implements Outcome { }
+        record Locked(String reason) implements Outcome { }
+        record Failure(String reason) implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/session/AuthSession.java
+++ b/src/main/java/com/ticketing/system/Presentation/session/AuthSession.java
@@ -67,7 +67,9 @@ public final class AuthSession {
         s.setAttribute(EXPIRES_KEY, dto.expiresAtEpochMillis());
         s.setAttribute(NAME_KEY, dto.username());
         s.setAttribute(SIGNED_IN_KEY, Boolean.TRUE);
-        s.setAttribute(ADMIN_KEY, isAdminUsername(dto.username()));
+        // Admin-ness comes from the token the backend issued (admin sign-in sets it), not from a
+        // hardcoded username set — the dedicated /admin/sign-in flow is the only way to become admin.
+        s.setAttribute(ADMIN_KEY, dto.isAdmin());
     }
 
     // -- Dev-only flag toggles -------------------------------------------

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
@@ -1,0 +1,76 @@
+package com.ticketing.system.Presentation.views.auth;
+
+import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.components.kit.LkAuthCard;
+import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Presentation.presenters.auth.AdminLoginPresenter;
+import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.textfield.PasswordField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+/**
+ * Dedicated platform-admin sign-in (#290) at {@code /admin/sign-in}. Authenticates against the
+ * persisted admin pool through {@link AdminLoginPresenter} (real JWT, lockout, audit) — never the
+ * member pool. Members reach their own form at {@code /login}.
+ */
+@Route(value = "admin/sign-in", layout = MainLayout.class)
+@PageTitle("Admin sign in · TicketHub")
+@AnonymousAllowed
+public class AdminLoginView extends LkAuthCard {
+
+    private final AdminLoginPresenter presenter;
+
+    public AdminLoginView(AdminLoginPresenter presenter) {
+        super("Admin sign-in", "Restricted — platform administrators only.");
+        this.presenter = presenter;
+
+        TextField username = new TextField("Admin username");
+        username.setRequired(true);
+        username.setAutofocus(true);
+        username.setWidthFull();
+
+        PasswordField password = new PasswordField("Password");
+        password.setRequired(true);
+        password.setWidthFull();
+
+        Button signIn = new Button("Sign in", e -> attempt(username, password));
+        signIn.addThemeVariants(ButtonVariant.LUMO_PRIMARY, ButtonVariant.LUMO_LARGE);
+        signIn.setWidthFull();
+        signIn.addClickShortcut(Key.ENTER);
+
+        col(14, username, password, signIn);
+        foot("Not an administrator?", "Member sign in →", LoginView.class);
+    }
+
+    private void attempt(TextField username, PasswordField password) {
+        if (username.isEmpty() || password.isEmpty()) {
+            Toasts.failure("Please enter both username and password.");
+            return;
+        }
+
+        AdminLoginPresenter.Outcome outcome =
+            presenter.attemptAdminLogin(username.getValue(), password.getValue());
+
+        switch (outcome) {
+            case AdminLoginPresenter.Outcome.Success ok -> {
+                AuthSession.storeAuth(ok.authToken());
+                Toasts.success("Signed in as admin · " + ok.authToken().username());
+                UI.getCurrent().navigate(AdminDashboardView.class);
+            }
+            case AdminLoginPresenter.Outcome.InvalidCredentials ignored ->
+                Toasts.failure("Invalid admin username or password.");
+            case AdminLoginPresenter.Outcome.Locked locked ->
+                Toasts.failure(locked.reason());
+            case AdminLoginPresenter.Outcome.Failure fail ->
+                Toasts.failure("Sign-in failed: " + fail.reason());
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
@@ -68,6 +68,14 @@ public class LoginView extends LkAuthCard {
         add(social);
 
         foot("Don't have an account?", "Create one →", RegisterView.class);
+
+        // TEMP (dev, #290): discreet path to the dedicated admin sign-in during development.
+        // Drop this link for a real deployment — admins just bookmark /admin/sign-in.
+        Anchor adminLink = new Anchor("admin/sign-in", "Admin sign-in →");
+        adminLink.addClassName("bz-link");
+        adminLink.getStyle().set("display", "block").set("margin-top", "10px")
+            .set("text-align", "center").set("font-size", "12.5px");
+        add(adminLink);
     }
 
     private Anchor forgotPasswordLink() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,13 @@ session:
   member-ttl-minutes: ${SESSION_MEMBER_TTL_MINUTES:1440}
   guest-idle-timeout-minutes: ${SESSION_GUEST_IDLE_TIMEOUT_MINUTES:30}
 
+# Brute-force lock-after-N policy (SLR.2 #148) for member + admin sign-in.
+# max-attempts: 0 disables the lockout entirely.
+auth:
+  lockout:
+    max-attempts: ${AUTH_LOCKOUT_MAX_ATTEMPTS:5}
+    lock-minutes: ${AUTH_LOCKOUT_LOCK_MINUTES:15}
+
 
 constants:
   # System-wide constant

--- a/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
@@ -37,6 +37,10 @@ import com.ticketing.system.Core.Application.services.NotificationDispatchServic
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
+import com.ticketing.system.Core.Domain.Admin.Admin;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
 import com.ticketing.system.Core.Domain.exceptions.DuplicateEmailException;
 import com.ticketing.system.Core.Domain.exceptions.DuplicateUsernameException;
@@ -59,6 +63,7 @@ class AuthenticationServiceTest {
     private ISessionManager mockSessionManager;
     private ISessionRepository mockSessionRepo;
     private IActiveOrderRepository mockActiveOrderRepo;
+    private IAdminRepository mockAdminRepo;
     private Clock fixedClock;
     private AuthenticationService service;
     private NotificationDispatchService mockNotification;
@@ -73,11 +78,12 @@ class AuthenticationServiceTest {
         mockReservation = mock(ReservationService.class);
         mockSessionRepo = mock(ISessionRepository.class);
         mockActiveOrderRepo = mock(IActiveOrderRepository.class);
+        mockAdminRepo = mock(IAdminRepository.class);
         fixedClock = Clock.fixed(T0, ZoneOffset.UTC);
         service = new AuthenticationService(
                 mockUserRepo, mockHasher, mockSessionManager, mockReservation, mockNotification,
                 mockSessionRepo, mockActiveOrderRepo,
-                fixedClock, GUEST_IDLE_MINUTES, MEMBER_TTL_MINUTES);
+                fixedClock, mockAdminRepo, GUEST_IDLE_MINUTES, MEMBER_TTL_MINUTES, 5, 15L);
         // Default mocks: no cart for anyone. Individual D9a tests override.
         when(mockActiveOrderRepo.getBySessionId(any())).thenReturn(Optional.empty());
         when(mockActiveOrderRepo.getByUserId(anyInt())).thenReturn(null);
@@ -524,5 +530,47 @@ class AuthenticationServiceTest {
         service.logout(new LogoutRequestDTO("SOME_TOKEN"));
         verify(mockActiveOrderRepo, never()).delete(any());
         verify(mockActiveOrderRepo, never()).save(any());
+    }
+
+    // ---- admin sign-in (#290) ----
+
+    @Test
+    void signInAsAdmin_validCredentials_returnsAdminFlaggedToken() {
+        when(mockAdminRepo.findByUsername("admin")).thenReturn(new Admin(1, "admin", "hashed", true));
+        when(mockHasher.matches("pw", "hashed")).thenReturn(true);
+        when(mockSessionManager.generateAdminToken(1, "admin")).thenReturn("admin-jwt");
+        when(mockSessionManager.extractExpiration("admin-jwt")).thenReturn(999L);
+
+        AuthTokenDTO token = service.signInAsAdmin("admin", "pw");
+
+        assertTrue(token.isAdmin());
+        assertEquals("admin", token.username());
+        assertEquals("admin-jwt", token.token());
+    }
+
+    @Test
+    void signInAsAdmin_unknownUsername_throwsAuthenticationFailed() {
+        when(mockAdminRepo.findByUsername("ghost")).thenReturn(null);
+        assertThrows(AuthenticationFailedException.class, () -> service.signInAsAdmin("ghost", "pw"));
+    }
+
+    @Test
+    void signInAsAdmin_wrongPassword_throwsAuthenticationFailed() {
+        when(mockAdminRepo.findByUsername("admin")).thenReturn(new Admin(1, "admin", "hashed", true));
+        when(mockHasher.matches("wrong", "hashed")).thenReturn(false);
+        assertThrows(AuthenticationFailedException.class, () -> service.signInAsAdmin("admin", "wrong"));
+    }
+
+    @Test
+    void signInAsAdmin_locksAfterFiveFailures() {
+        when(mockAdminRepo.findByUsername("admin")).thenReturn(new Admin(1, "admin", "hashed", true));
+        when(mockHasher.matches(any(), any())).thenReturn(false);
+
+        for (int i = 0; i < 5; i++) {
+            assertThrows(AuthenticationFailedException.class, () -> service.signInAsAdmin("admin", "wrong"));
+        }
+        // 6th attempt is blocked even with the correct password.
+        when(mockHasher.matches("pw", "hashed")).thenReturn(true);
+        assertThrows(AccountLockedException.class, () -> service.signInAsAdmin("admin", "pw"));
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
@@ -78,6 +78,7 @@ class SystemAdminServiceTest {
                 "admin"
         );
         when(sessionManager.validateToken(ADMIN_TOKEN)).thenReturn(true);
+        when(sessionManager.isAdminToken(ADMIN_TOKEN)).thenReturn(true);
         when(sessionManager.extractUserId(ADMIN_TOKEN)).thenReturn(ADMIN_USER_ID);
         when(adminRepository.findById(ADMIN_USER_ID)).thenReturn(new Admin(ADMIN_USER_ID, "admin", "hash", true));
     }


### PR DESCRIPTION
## Summary
Wires the platform-admin sign-in to real authentication and closes a privilege-escalation hole found along the way.

Full suite: **764 tests, 0 failures, 0 errors** (`mvn -Pno-vaadin test`).

**Closes #290**

## 🔒 Security fix (the notable find)
The default admin is id `1` and `MemoryUserRepository` hands the **first member id `1`** too, while `requireSystemAdmin` only did `adminRepository.findById(userId)` — so the **first registered member could pass the admin gate**. Fixed by giving the JWT a **MEMBER/ADMIN role claim**; `requireSystemAdmin` now rejects any non-admin token regardless of id.

## What's built
- **`/admin/sign-in`** — dedicated `AdminLoginView` + `AdminLoginPresenter` (Outcome pattern); a temporary dev link sits on the member login.
- **`AuthenticationService.signInAsAdmin`** — authenticates against the persisted admin pool (`IAdminRepository.findByUsername` + bcrypt), never the member pool (disjoint-pool rule), issues an ADMIN-role JWT.
- **`AuthTokenDTO.isAdmin`** (+ `AuthSession.storeAuth`) — admin-ness now comes from the token, **replacing the hardcoded `ADMIN_USERNAMES`** set.
- **Brute-force lockout (SLR.2 #148)** — a **shared** lock-after-N policy used by *both* member `login` and admin sign-in (not a parallel one), configurable via `application.yml` (`auth.lockout.max-attempts` — `0` disables — and `lock-minutes`).
- **Audit** — structured `log.warn` on every failed/blocked attempt.

## Reuse, not rebuild
Most of the admin backend already existed (Admin aggregate, `IAdminRepository`, bcrypt hasher, #8 default-admin provisioning, JWT session manager, the real `requireSystemAdmin` check). This PR adds the sign-in method + view + role claim + lockout on top — it does **not** require full Spring Security (#209); the app's auth is JWT and route gating is already capability-based.

## Tests
`signInAsAdmin` success / unknown-user / wrong-password / lock-after-5; `SystemAdminServiceTest` updated for the new role check.

## Note
The branch was reset onto current `dev` (it had been forked off `main`, 108 commits behind).