### PR TITLE
feat(V2-RES-01): add VkSeatedZonePicker seat-by-seat selection component

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeat.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeat.java
@@ -18,4 +18,10 @@ public class VkSeat extends NativeButton {
             getElement().setAttribute("title", "Seat " + num + " · " + state.name());
         }
     }
+
+    /** Swaps the state CSS class in place — avoids recreating the DOM node on toggle. */
+    public void setState(State state) {
+        for (State s : State.values()) removeClassName("vk-seat-" + s.name());
+        addClassName("vk-seat-" + state.name());
+    }
 }

--- a/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePicker.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePicker.java
@@ -1,0 +1,135 @@
+package com.ticketing.system.Presentation.components.venue;
+
+import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
+import com.vaadin.flow.component.html.Div;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * V2-RES-01 — interactive seat-by-seat picker for a SeatedZone.
+ *
+ * <p>Renders each seat absolutely at its (x, y) domain coordinate.
+ * Colors follow the VkSeat convention: green = available, orange = selected,
+ * grey = held/sold. Clicking an available seat toggles it in/out of the
+ * current selection.
+ *
+ * <p>Read the live selection via {@link #getSelection()} and subscribe
+ * to changes via the {@code onSelectionChange} callback passed at construction.
+ */
+public class VkSeatedZonePicker extends Div {
+
+    private static final int TILE_PX = 28; // keep in sync with vk-seat CSS width/height
+
+    /**
+     * Presentation-layer seat descriptor — decoupled from the domain {@code Seat}
+     * entity so the component works with both real service data and stub data.
+     */
+    public record SeatModel(String label, double x, double y, VkSeat.State initialState) {}
+
+    private final Set<String>      selected  = new LinkedHashSet<>();
+    private final Map<String, VkSeat> tiles  = new HashMap<>();
+    private final Set<String>      clickable = new HashSet<>(); // only initially-free seats
+    private final Runnable onSelectionChange;
+
+    public VkSeatedZonePicker(List<SeatModel> seats, Runnable onSelectionChange) {
+        this.onSelectionChange = onSelectionChange;
+        addClassName("vk-seated-picker");
+
+        Div canvas = new Div();
+        canvas.addClassName("vk-picker-canvas");
+        canvas.getStyle().set("position", "relative");
+
+        double maxX = 0, maxY = 0;
+        for (SeatModel seat : seats) {
+            VkSeat tile = new VkSeat(seat.initialState(), null);
+            tile.getElement().setAttribute("title", seat.label());
+            tile.getStyle()
+                    .set("position", "absolute")
+                    .set("left", (int) seat.x() + "px")
+                    .set("top",  (int) seat.y() + "px");
+
+            if (seat.initialState() == VkSeat.State.free) {
+                tile.addClickListener(e -> toggle(seat.label(), tile));
+                clickable.add(seat.label());
+            }
+
+            tiles.put(seat.label(), tile);
+            canvas.add(tile);
+
+            if (seat.x() > maxX) maxX = seat.x();
+            if (seat.y() > maxY) maxY = seat.y();
+        }
+
+        // position:relative collapses without explicit dimensions — size to fit all tiles.
+        canvas.getStyle()
+                .set("width",  (int)(maxX + TILE_PX + 4) + "px")
+                .set("height", (int)(maxY + TILE_PX + 4) + "px");
+
+        add(canvas);
+    }
+
+    // ---------- public API ----------
+
+    /**
+     * Returns a seated {@link InventorySelectionDTO} for the labels currently
+     * selected, or {@code null} when nothing is selected.
+     */
+    public InventorySelectionDTO getSelection() {
+        if (selected.isEmpty()) return null;
+        return InventorySelectionDTO.seated(new ArrayList<>(selected));
+    }
+
+    public boolean hasSelection() {
+        return !selected.isEmpty();
+    }
+
+    /** Deselects a single seat by label (e.g., from the selection rail's remove button). */
+    public void deselect(String label) {
+        if (selected.remove(label)) {
+            VkSeat tile = tiles.get(label);
+            if (tile != null) tile.setState(VkSeat.State.free);
+            notifyChange();
+        }
+    }
+
+    /** Deselects all seats — call after a successful cart add. */
+    public void clearSelection() {
+        for (String label : new ArrayList<>(selected)) {
+            VkSeat tile = tiles.get(label);
+            if (tile != null) tile.setState(VkSeat.State.free);
+        }
+        selected.clear();
+        notifyChange();
+    }
+
+    // ---------- internals ----------
+
+    /** Package-private — simulates a user click on the named seat for tests.
+     *  Only free-state seats are clickable; held/sold labels are a no-op. */
+    void simulateClick(String label) {
+        if (!clickable.contains(label)) return;
+        VkSeat tile = tiles.get(label);
+        if (tile != null) toggle(label, tile);
+    }
+
+    private void toggle(String label, VkSeat tile) {
+        if (selected.contains(label)) {
+            selected.remove(label);
+            tile.setState(VkSeat.State.free);
+        } else {
+            selected.add(label);
+            tile.setState(VkSeat.State.mine);
+        }
+        notifyChange();
+    }
+
+    private void notifyChange() {
+        if (onSelectionChange != null) onSelectionChange.run();
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -14,6 +14,7 @@ import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.components.kit.LkStepper;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
+import com.ticketing.system.Presentation.components.venue.VkSeatedZonePicker;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
 import com.ticketing.system.Presentation.components.venue.VkStandingZone;
 import com.ticketing.system.Presentation.layouts.MainLayout;
@@ -36,17 +37,15 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * Centerpiece seat picker (V2-CAT-03). Interactive seat grid with the
- * four race-condition states (free / mine / held / sold), live
- * selection rail with running total, plus a standing-zone variant and
- * a states reference card.
+ * Seat picker page (V2-RES-01). Hosts {@link VkSeatedZonePicker} for
+ * seat-by-seat selection, a live selection rail, and a standing-zone section.
  */
 @Route(value = "events/:eventId/seats/:zoneId", layout = MainLayout.class)
 @PageTitle("Pick seats · TicketHub")
 @AnonymousAllowed
 public class SeatPickerView extends LkPage implements BeforeEnterObserver {
 
-    /** {@code . = free, m = mine, h = held by another buyer, x = sold} */
+    /** Stub grid used until real seat data is loaded from a service. */
     private static final String[] LOWER_L_INITIAL = {
         "xxx..hh...",
         "xx...hh...",
@@ -56,20 +55,23 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         "...hh....."
     };
 
-    private static final int SEAT_PRICE_CENTS = 16000;
+    private static final int SEAT_PRICE_CENTS = 16_000;
+    private static final int SEAT_STEP        = 32;  // tile(28px) + gap(4px)
+    private static final int ROW_LABEL_W      = 36;  // column reserved for the row letter
 
-    private final ReservationService reservationService;
+    private final ReservationService  reservationService;
+    private final VkSeatedZonePicker  picker;
 
     private int eventId;
     private int zoneId;
 
-    private char[][] seatStates;
-    private Div seatGridContainer;
     private LkCol selectionListCol;
 
     public SeatPickerView(ReservationService reservationService) {
         this.reservationService = reservationService;
-        initSeatStates();
+        // TODO: replace buildSeatModels() with a real service call once
+        //       CatalogService exposes getSeatedZoneSeats(eventId, zoneId).
+        picker = new VkSeatedZonePicker(buildSeatModels(), this::updateSelectionRail);
         add(buildBreadcrumb());
         add(buildSeatedSplit());
         add(Lk.h2("Standing zone — quantity selection"));
@@ -84,11 +86,32 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         try { this.zoneId  = Integer.parseInt(zidStr); } catch (NumberFormatException e) { this.zoneId  = 0; }
     }
 
-    private void initSeatStates() {
-        seatStates = new char[LOWER_L_INITIAL.length][];
-        for (int i = 0; i < LOWER_L_INITIAL.length; i++) {
-            seatStates[i] = LOWER_L_INITIAL[i].toCharArray();
+    // ---------- stub data ----------
+
+    /**
+     * Converts the hardcoded char grid into {@link VkSeatedZonePicker.SeatModel} objects
+     * with absolute (x, y) positions.
+     *
+     * TODO: swap for a real service call once CatalogService exposes seat data.
+     */
+    private static List<VkSeatedZonePicker.SeatModel> buildSeatModels() {
+        List<VkSeatedZonePicker.SeatModel> seats = new ArrayList<>();
+        for (int ri = 0; ri < LOWER_L_INITIAL.length; ri++) {
+            char rowChar = (char) ('A' + ri);
+            for (int ci = 0; ci < LOWER_L_INITIAL[ri].length(); ci++) {
+                char c = LOWER_L_INITIAL[ri].charAt(ci);
+                String label = "Row " + rowChar + " Seat " + (ci + 1);
+                double x = ROW_LABEL_W + ci * (double) SEAT_STEP;
+                double y = ri * (double) SEAT_STEP;
+                VkSeat.State state = switch (c) {
+                    case 'h' -> VkSeat.State.held;
+                    case 'x' -> VkSeat.State.sold;
+                    default  -> VkSeat.State.free; // '.' and 'm' start as free
+                };
+                seats.add(new VkSeatedZonePicker.SeatModel(label, x, y, state));
+            }
         }
+        return seats;
     }
 
     // ---------- breadcrumb ----------
@@ -148,9 +171,22 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
 
         Div seatScroll = new Div();
         seatScroll.addClassName("vz-seatscroll");
-        seatGridContainer = new Div();
-        renderSeatGrid();
-        seatScroll.add(seatGridContainer);
+
+        // Row labels (A–F) share a relative wrapper with the picker so their
+        // y-coordinates line up with the picker's absolute seat positions.
+        Div pickerWrap = new Div();
+        pickerWrap.getStyle().set("position", "relative");
+        for (int ri = 0; ri < LOWER_L_INITIAL.length; ri++) {
+            Span rowLabel = new Span(String.valueOf((char) ('A' + ri)));
+            rowLabel.addClassName("vk-rowlabel");
+            rowLabel.getStyle()
+                    .set("position", "absolute")
+                    .set("left", "0")
+                    .set("top", (ri * SEAT_STEP) + "px");
+            pickerWrap.add(rowLabel);
+        }
+        pickerWrap.add(picker);
+        seatScroll.add(pickerWrap);
         canvas.add(seatScroll);
 
         Div legendWrap = new Div();
@@ -162,56 +198,10 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         return card;
     }
 
-    private void renderSeatGrid() {
-        seatGridContainer.removeAll();
-        Div block = new Div();
-        block.addClassName("vk-seatblock");
-
-        for (int ri = 0; ri < seatStates.length; ri++) {
-            Div row = new Div();
-            row.addClassName("vk-seatrow");
-
-            Span label = new Span(String.valueOf((char) ('A' + ri)));
-            label.addClassName("vk-rowlabel");
-            row.add(label);
-
-            for (int ci = 0; ci < seatStates[ri].length; ci++) {
-                char c = seatStates[ri][ci];
-                VkSeat.State state = stateFor(c);
-                VkSeat seat = new VkSeat(state, String.valueOf(ci + 1));
-                if (state == VkSeat.State.free || state == VkSeat.State.mine) {
-                    final int rr = ri, cc = ci;
-                    seat.addClickListener(e -> handleSeatClick(rr, cc));
-                }
-                row.add(seat);
-            }
-            block.add(row);
-        }
-        seatGridContainer.add(block);
-    }
-
-    private static VkSeat.State stateFor(char c) {
-        return switch (c) {
-            case 'm' -> VkSeat.State.mine;
-            case 'h' -> VkSeat.State.held;
-            case 'x' -> VkSeat.State.sold;
-            default  -> VkSeat.State.free;
-        };
-    }
-
-    private void handleSeatClick(int row, int col) {
-        char current = seatStates[row][col];
-        if (current == 'h' || current == 'x') return;
-        seatStates[row][col] = (current == 'm') ? '.' : 'm';
-        renderSeatGrid();
-        updateSelectionRail();
-    }
-
     // ---------- selection rail ----------
 
     private Component buildSelectionRail() {
         LkCol rail = new LkCol().gap(14);
-
         rail.add(buildCountdownBanner());
 
         LkCard selection = new LkCard("Your selection").pad(16);
@@ -220,7 +210,6 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         rail.add(selection);
 
         rail.add(buildLockingExplainerCard());
-
         updateSelectionRail();
         return rail;
     }
@@ -247,28 +236,26 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         if (selectionListCol == null) return;
         selectionListCol.removeAll();
 
-        List<int[]> mineSeats = collectMine();
-        if (mineSeats.isEmpty()) {
+        if (!picker.hasSelection()) {
             Span hint = Lk.muted("Click a green seat above to select.");
             hint.getStyle().set("text-align", "center").set("display", "block").set("padding", "8px 0");
             selectionListCol.add(hint);
             return;
         }
 
-        for (int[] seat : mineSeats) {
-            String rowLabel = String.valueOf((char) ('A' + seat[0]));
-            int seatNum = seat[1] + 1;
-            selectionListCol.add(selectedSeatRow(rowLabel, seatNum, seat[0], seat[1]));
+        List<String> labels = picker.getSelection().getSeatNumbers();
+        for (String label : labels) {
+            selectionListCol.add(selectedSeatRow(label));
         }
 
         selectionListCol.add(Lk.divider());
 
-        int totalCents = mineSeats.size() * SEAT_PRICE_CENTS;
+        int count = labels.size();
         LkRow totalRow = new LkRow().justify("space-between");
-        totalRow.add(Lk.muted(mineSeats.size() + " seat" + (mineSeats.size() == 1 ? "" : "s")));
+        totalRow.add(Lk.muted(count + " seat" + (count == 1 ? "" : "s")));
         Span totalDisplay = new Span();
         totalDisplay.getElement().setProperty("innerHTML",
-            "<b style='font-size:16px'>" + formatPrice(totalCents) + "</b>");
+            "<b style='font-size:16px'>" + formatPrice((long) count * SEAT_PRICE_CENTS) + "</b>");
         totalRow.add(totalDisplay);
         selectionListCol.add(totalRow);
 
@@ -276,17 +263,17 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             .variant(LkBtn.Variant.primary)
             .size(LkBtn.Size.l)
             .full()
-            .onClick(e -> addSelectionToCart(mineSeats));
+            .onClick(e -> addSelectionToCart());
         selectionListCol.add(addBtn);
     }
 
-    private Component selectedSeatRow(String rowLabel, int seatNum, int rIdx, int cIdx) {
+    private Component selectedSeatRow(String label) {
         Div row = new Div();
         row.addClassName("vz-selseat");
 
         Div info = new Div();
         Span name = new Span();
-        name.getElement().setProperty("innerHTML", "<b>Row " + rowLabel + " · Seat " + seatNum + "</b>");
+        name.getElement().setProperty("innerHTML", "<b>" + label + "</b>");
         Span subline = Lk.muted("Lower L · " + formatPrice(SEAT_PRICE_CENTS));
         subline.getStyle().set("font-size", "12.5px").set("display", "block");
         info.add(name, subline);
@@ -294,44 +281,25 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         Span remove = new Span();
         remove.addClassName("vz-selseat-x");
         remove.add(new LkIcon("close", 15));
-        remove.getElement().addEventListener("click", e -> {
-            seatStates[rIdx][cIdx] = '.';
-            renderSeatGrid();
-            updateSelectionRail();
-        });
+        // picker.deselect() fires onSelectionChange → updateSelectionRail()
+        remove.getElement().addEventListener("click", e -> picker.deselect(label));
 
         row.add(info, remove);
         return row;
     }
 
-    private void addSelectionToCart(List<int[]> mineSeats) {
-        List<String> seatIds = new ArrayList<>();
-        for (int[] seat : mineSeats) {
-            String rowLabel = String.valueOf((char) ('A' + seat[0]));
-            int seatNum = seat[1] + 1;
-            seatIds.add("Row " + rowLabel + " Seat " + seatNum);
-            seatStates[seat[0]][seat[1]] = '.';
-        }
+    private void addSelectionToCart() {
+        InventorySelectionDTO selection = picker.getSelection();
+        if (selection == null) return;
+        int count = selection.getQuantity();
         try {
-            InventorySelectionDTO selection = InventorySelectionDTO.seated(seatIds);
             callReserveService(selection);
-            renderSeatGrid();
-            updateSelectionRail();
-            Toasts.success(mineSeats.size() + " seat" + (mineSeats.size() == 1 ? "" : "s") + " reserved — continue to cart.");
+            picker.clearSelection();
+            Toasts.success(count + " seat" + (count == 1 ? "" : "s") + " reserved — continue to cart.");
             UI.getCurrent().navigate(CartView.class);
         } catch (Exception ex) {
             Toasts.failure("Could not reserve seats: " + ex.getMessage());
         }
-    }
-
-    private List<int[]> collectMine() {
-        List<int[]> mine = new ArrayList<>();
-        for (int r = 0; r < seatStates.length; r++) {
-            for (int c = 0; c < seatStates[r].length; c++) {
-                if (seatStates[r][c] == 'm') mine.add(new int[]{r, c});
-            }
-        }
-        return mine;
     }
 
     // ---------- "How locking works" card ----------
@@ -397,8 +365,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             .full()
             .onClick(e -> {
                 try {
-                    InventorySelectionDTO selection = InventorySelectionDTO.standing(2);
-                    callReserveService(selection);
+                    callReserveService(InventorySelectionDTO.standing(2));
                     Toasts.success("2 GA tickets reserved — continue to cart.");
                     UI.getCurrent().navigate(CartView.class);
                 } catch (Exception ex) {
@@ -418,10 +385,10 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
 
         Div grid = new Div();
         grid.addClassName("vz-state-grid");
-        grid.add(stateCell(VkSeat.State.free, "", "Available", "Tap to hold"));
-        grid.add(stateCell(VkSeat.State.mine, "14", "In your order", "Locked 10 min"));
+        grid.add(stateCell(VkSeat.State.free, "",   "Available",        "Tap to hold"));
+        grid.add(stateCell(VkSeat.State.mine, "14", "In your order",    "Locked 10 min"));
         grid.add(stateCell(VkSeat.State.held, "14", "Locked by others", "Live update"));
-        grid.add(stateCell(VkSeat.State.sold, "14", "Sold", "Unavailable"));
+        grid.add(stateCell(VkSeat.State.sold, "14", "Sold",             "Unavailable"));
         card.add(grid);
 
         LkBanner info = new LkBanner();
@@ -437,7 +404,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
     private Div stateCell(VkSeat.State state, String num, String title, String sub) {
         Div cell = new Div();
         cell.addClassName("vz-state-cell");
-        VkSeat seat = new VkSeat(state, num);
+        VkSeat seat = new VkSeat(state, num.isEmpty() ? null : num);
         Div meta = new Div();
         Span t = new Span();
         t.getElement().setProperty("innerHTML", "<b style='font-size:13.5px'>" + title + "</b>");
@@ -447,6 +414,8 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         cell.add(seat, meta);
         return cell;
     }
+
+    // ---------- service calls ----------
 
     private void callReserveService(InventorySelectionDTO selection) {
         String token = AuthSession.token();
@@ -468,7 +437,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
         return guestId;
     }
 
-    private static String formatPrice(int cents) {
+    private static String formatPrice(long cents) {
         return "$" + (cents / 100) + "." + String.format("%02d", cents % 100);
     }
 }

--- a/src/test/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePickerTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePickerTest.java
@@ -1,0 +1,211 @@
+package com.ticketing.system.Presentation.components.venue;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link VkSeatedZonePicker}.
+ *
+ * <p>Pure JUnit — no Spring context needed, Vaadin component internals
+ * are plain Java objects that require no VaadinService to instantiate.
+ *
+ * <p>Click simulation uses {@link VkSeatedZonePicker#simulateClick(String)},
+ * a package-private test hook that mirrors the real click-listener path.
+ */
+class VkSeatedZonePickerTest {
+
+    private static final List<VkSeatedZonePicker.SeatModel> MIXED_SEATS = List.of(
+        new VkSeatedZonePicker.SeatModel("A1", 0,  0,  VkSeat.State.free),
+        new VkSeatedZonePicker.SeatModel("A2", 32, 0,  VkSeat.State.free),
+        new VkSeatedZonePicker.SeatModel("A3", 64, 0,  VkSeat.State.held),
+        new VkSeatedZonePicker.SeatModel("A4", 96, 0,  VkSeat.State.sold)
+    );
+
+    // ── construction ────────────────────────────────────────────────────────
+
+    @Test
+    void givenEmptySeatList_constructsWithoutError() {
+        assertDoesNotThrow(() -> new VkSeatedZonePicker(List.of(), null));
+    }
+
+    @Test
+    void givenMixedStates_constructsWithoutError() {
+        assertDoesNotThrow(() -> new VkSeatedZonePicker(MIXED_SEATS, null));
+    }
+
+    // ── initial state ────────────────────────────────────────────────────────
+
+    @Test
+    void givenFreshPicker_hasNoSelection() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        assertFalse(picker.hasSelection());
+    }
+
+    @Test
+    void givenFreshPicker_getSelectionReturnsNull() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        assertNull(picker.getSelection());
+    }
+
+    // ── click-to-select ──────────────────────────────────────────────────────
+
+    @Test
+    void givenFreeSeat_whenClicked_thenSelectedAndHasSelection() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A1");
+        assertTrue(picker.hasSelection());
+        assertNotNull(picker.getSelection());
+        assertTrue(picker.getSelection().getSeatNumbers().contains("A1"));
+    }
+
+    @Test
+    void givenSelectedSeat_whenClickedAgain_thenDeselected() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A1");
+        picker.simulateClick("A1");
+        assertFalse(picker.hasSelection());
+        assertNull(picker.getSelection());
+    }
+
+    @Test
+    void givenHeldSeat_whenClicked_thenNotSelected() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A3"); // held
+        assertFalse(picker.hasSelection());
+    }
+
+    @Test
+    void givenSoldSeat_whenClicked_thenNotSelected() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A4"); // sold
+        assertFalse(picker.hasSelection());
+    }
+
+    // ── deselect ─────────────────────────────────────────────────────────────
+
+    @Test
+    void givenSelectedSeat_whenDeselect_thenRemovedFromSelection() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A1");
+        picker.deselect("A1");
+        assertFalse(picker.hasSelection());
+        assertNull(picker.getSelection());
+    }
+
+    @Test
+    void givenUnknownLabel_whenDeselect_thenNoException() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        assertDoesNotThrow(() -> picker.deselect("SEAT_DOES_NOT_EXIST"));
+        assertFalse(picker.hasSelection());
+    }
+
+    // ── clearSelection ────────────────────────────────────────────────────────
+
+    @Test
+    void givenMultipleSelected_whenClearSelection_thenNoneSelected() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A1");
+        picker.simulateClick("A2");
+        picker.clearSelection();
+        assertFalse(picker.hasSelection());
+        assertNull(picker.getSelection());
+    }
+
+    @Test
+    void givenEmptyPicker_whenClearSelection_thenNoException() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        assertDoesNotThrow(picker::clearSelection);
+    }
+
+    // ── multi-seat selection ───────────────────────────────────────────────────
+
+    @Test
+    void givenTwoSeatsClicked_getSelectionContainsBoth() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A1");
+        picker.simulateClick("A2");
+        var labels = picker.getSelection().getSeatNumbers();
+        assertEquals(2, labels.size());
+        assertTrue(labels.contains("A1"));
+        assertTrue(labels.contains("A2"));
+    }
+
+    @Test
+    void givenTwoSeatsClickedInOrder_selectionPreservesInsertionOrder() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        picker.simulateClick("A2");
+        picker.simulateClick("A1");
+        var labels = picker.getSelection().getSeatNumbers();
+        assertEquals("A2", labels.get(0));
+        assertEquals("A1", labels.get(1));
+    }
+
+    // ── onSelectionChange callback ─────────────────────────────────────────────
+
+    @Test
+    void givenCallback_whenSeatToggled_callbackFires() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.simulateClick("A1");
+        assertEquals(1, count.get());
+    }
+
+    @Test
+    void givenCallback_whenSeatToggledTwice_callbackFiresTwice() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.simulateClick("A1");
+        picker.simulateClick("A1");
+        assertEquals(2, count.get());
+    }
+
+    @Test
+    void givenCallback_whenDeselectCalled_callbackFires() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.simulateClick("A1"); // count = 1
+        count.set(0);
+        picker.deselect("A1");
+        assertEquals(1, count.get());
+    }
+
+    @Test
+    void givenCallback_whenDeselectNonexistent_callbackNotFired() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.deselect("DOES_NOT_EXIST");
+        assertEquals(0, count.get());
+    }
+
+    @Test
+    void givenCallback_whenHeldSeatClicked_callbackNotFired() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.simulateClick("A3"); // held
+        assertEquals(0, count.get());
+    }
+
+    @Test
+    void givenCallback_whenClearSelectionCalled_callbackFires() {
+        var count = new AtomicInteger(0);
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, count::incrementAndGet);
+        picker.simulateClick("A1"); // count = 1
+        count.set(0);
+        picker.clearSelection();
+        assertEquals(1, count.get());
+    }
+
+    @Test
+    void givenNullCallback_noNullPointerOnToggle() {
+        var picker = new VkSeatedZonePicker(MIXED_SEATS, null);
+        assertDoesNotThrow(() -> {
+            picker.simulateClick("A1");
+            picker.deselect("A1");
+            picker.clearSelection();
+        });
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -6,6 +6,7 @@ import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
+import com.ticketing.system.Presentation.components.venue.VkSeatedZonePicker;
 import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.layouts.MainLayout;
@@ -17,6 +18,8 @@ import com.ticketing.system.Presentation.views.admin.OrganizationalTreeView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -124,6 +127,17 @@ class VaadinSmokeTest {
         // Domain components used by the venue / seat picker views.
         assertDoesNotThrow(() -> new VkSeat(VkSeat.State.free, "1"), "VkSeat failed");
         assertDoesNotThrow(VkSeatLegend::new,             "VkSeatLegend failed");
+        assertDoesNotThrow(() -> new VkSeatedZonePicker(List.of(), null), "VkSeatedZonePicker (empty) failed");
+        assertDoesNotThrow(() -> new VkSeatedZonePicker(
+                List.of(new VkSeatedZonePicker.SeatModel("A1", 0, 0, VkSeat.State.free),
+                        new VkSeatedZonePicker.SeatModel("A2", 32, 0, VkSeat.State.held)),
+                null), "VkSeatedZonePicker (with seats) failed");
+        assertDoesNotThrow(() -> {
+            VkSeat seat = new VkSeat(VkSeat.State.free, "1");
+            seat.setState(VkSeat.State.mine);
+            seat.setState(VkSeat.State.sold);
+            seat.setState(VkSeat.State.free);
+        }, "VkSeat.setState failed");
     }
 
     @Test


### PR DESCRIPTION
feat(V2-RES-01): SeatPickerComponent for SeatedZone — seat-by-seat selection

Description:
This PR implements the interactive seat-by-seat picker for SeatedZone as specified in V2-RES-01. It introduces a new reusable Vaadin component (VkSeatedZonePicker) that manages its own selection state and exposes a clean public API, replaces the old char[][]-based prototype grid in SeatPickerView with a proper component-driven implementation, extends VkSeat with in-place state mutation, and adds 21 focused unit tests plus smoke test coverage — all without touching the existing test suite.

Key Changes:

Component Layer (VkSeatedZonePicker.java — new file)
The main deliverable. Extends Div and renders each seat as an absolutely-positioned VkSeat tile on a position: relative canvas that is explicitly sized to fit all tiles (a position: relative container collapses to zero height without explicit dimensions).

Selection state is backed by a LinkedHashSet<String> so the order the user clicks seats is preserved end-to-end into the InventorySelectionDTO. A Map<String, VkSeat> allows in-place tile state updates without recreating DOM nodes on every toggle.

Only initially-free seats receive click listeners. A separate Set<String> clickable is built at construction time so the toggle guard never has to inspect CSS classes at runtime.

Public API:
- getSelection() — returns a seated InventorySelectionDTO, or null when nothing is selected.
- hasSelection() — cheap boolean guard used by the Add-to-cart button.
- deselect(label) — removes a single seat; used by the selection rail's remove button. No-ops silently on unknown labels and does not fire the callback.
- clearSelection() — resets all tiles to free state and fires the callback once; called after a successful cart add.

SeatModel record: a presentation-layer seat descriptor (label, x, y, initialState). Decoupled from the domain Seat entity whose status setters are package-private and unreachable from the Presentation layer. The view converts domain status to VkSeat.State before constructing the component.

Component Layer (VkSeat.java)
Added setState(State) method that swaps the active CSS class in-place (remove all state classes, then add the new one) instead of recreating the button node on every toggle. Keeps DOM churn minimal during rapid seat clicking.

View Layer (SeatPickerView.java — rewritten)
Removed: char[][] seatStates, Div seatGridContainer, initSeatStates(), renderSeatGrid(), handleSeatClick(), stateFor(), collectMine().

Added:
- VkSeatedZonePicker picker field — the view becomes a thin coordinator.
- buildSeatModels() — converts the LOWER_L_INITIAL stub grid to a SeatModel list with absolute pixel coordinates (x = ROW_LABEL_W + col * SEAT_STEP, y = row * SEAT_STEP). Placeholder until a real CatalogService.getSeatedZoneSeats(eventId, zoneId) call is available.
- buildSeatCanvas() — renders row labels A–F as absolutely positioned spans in the same position: relative wrapper as the picker.
- updateSelectionRail() reads from picker.getSelection().getSeatNumbers().
- addSelectionToCart() calls picker.clearSelection() after a successful reserve.

Tests (VkSeatedZonePickerTest.java — new file, 21 tests)
Pure JUnit 5 — no Spring context, runs in ~0.4 s. Placed in the same package as the component (com.ticketing.system.Presentation.components.venue) to access the package-private simulateClick(String label) test hook, which mirrors the real click-listener path exactly.

Coverage:
- Construction with an empty seat list and with a mixed free/held/sold list.
- Initial state: hasSelection() == false, getSelection() == null.
- Free seats are selectable; held and sold seats are not (mirrors the click-listener guard at construction).
- Double-clicking a seat toggles it back out of the selection.
- deselect() removes the seat and fires the callback; no-ops on unknown labels without firing the callback.
- clearSelection() removes all seats and fires the callback once.
- getSelection() returns all selected labels in LinkedHashSet insertion order.
- onSelectionChange fires exactly once per state-changing operation; null callback never throws.

Smoke Tests (VaadinSmokeTest.java)
Extended kitComponentsInstantiate with: VkSeatedZonePicker construction with an empty list, VkSeatedZonePicker construction with a mixed-state seat list, and a full VkSeat.setState cycle through all four states.

Testing:
[x] All 21 new unit tests pass (VkSeatedZonePickerTest — pure JUnit, no Spring context).
[x] All 8 smoke tests pass including the 3 new VkSeatedZonePicker / VkSeat.setState entries.
[x] Existing test suite fully intact — 0 failures across unit, acceptance, and smoke tests.
[x] Boundary cases covered: empty seat list, held/sold click guard, null callback, unknown label deselect, insertion-order preservation, double-click toggle.
