### PR TITLE
fix: remove #330 regressions (keep validateZone + date fix)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -232,17 +232,6 @@ public class CompanyManagementService {
                 edit.companyId());
     }
 
-    public List<Permission> getManagerPermissions(String token, int companyId, int managerId) {
-        int requesterId = authenticate(token);
-        User requester = userRepository.getUserById(requesterId);
-        requester.requireOwnerInCompany(companyId);
-        User manager = userRepository.getUserById(managerId);
-        CompanyAppointment appt = manager.getActiveCompanyAppointment(companyId);
-        if (appt == null || appt.getRole() != CompanyRole.Manager) {
-            throw new RuntimeException("No active manager appointment found for user " + managerId);
-        }
-        return new ArrayList<>(appt.getPermissions());
-    }
 
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -186,9 +186,7 @@ public class EventManagementService {
         User user = userRepository.getUserById(userId);
         user.requirePermissionInCompany(companyId, Permission.MANAGE_INVENTORY);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
-        if (company == null) {
-            throw new RuntimeException("Company not found");
-        }
+
         return eventRepository.findByCompanyId(companyId).stream()
             .map(e -> new EventDetailDTO(
                 String.valueOf(e.getId()),
@@ -205,41 +203,12 @@ public class EventManagementService {
             .toList();
     }
 
-      public EventDetailDTO getEvent(String token, int eventId) {
-        int userId = validateTokenAndGetUserId(token);
-        Event event = eventRepository.findById(eventId);
-        if (event == null) {
-            throw new EventNotFoundException(eventId);
-        }
-        User user = userRepository.getUserById(userId);
-        user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
-        ProductionCompany company = companyRepository.getCompanyById(event.getCompanyId());
-        if (company == null) {
-            throw new RuntimeException("Company not found");
-        }
-        return new EventDetailDTO(
-            String.valueOf(event.getId()),
-            event.getName(),
-            event.getRating(),
-            null,
-            event.getCategory(),
-            event.getVenueMap() != null ? event.getVenueMap().getLocation() : null,
-            String.valueOf(event.getCompanyId()),
-            company.getName(),
-            event.getStatus(),
-            event.getShowDates()
-        );
-    }
-
     // II.4.2.3 — Read back the current zone states from the domain so the
     // editor reflects real-time inventory (capacity consumed by sales, etc.).
     public VenueLayoutDTO getEventZones(String token, int eventId) {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
         Event event = eventRepository.findById(eventId);
-        if (event == null) {
-            throw new EventNotFoundException(eventId);
-        }
         user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
 
         VenueMap map = event.getVenueMap();

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -607,9 +607,6 @@ public class Event implements InvariantChecked {
 
 
 
-    private void setVenueMap(VenueMap venueMap) {
-        this.venueMap = venueMap;
-    }
 
 
 


### PR DESCRIPTION
#330 was merged at an earlier commit than the corrected branch, so it re-introduced dead code our cleanup had already removed on dev:

- `getEvent` — a duplicate of `getEventDetail` (the double-pass)
- `getManagerPermissions` — unwired; the manager roster already carries `grantedPermissions()` (used by `EditPermissionsDialog`)
- private `Event.setVenueMap` — no caller; `configureVenueMap` is the real path
- unreachable `== null` checks (the repos throw)

This resets those 3 files (`EventManagementService`, `CompanyManagementService`, `Event.java`) to their pre-#330 state — removing **only** the regressions. The two useful parts of #330 stay: `VenueMapPresenter.validateZone` + the `CompanyEventListView` date fix.

Full suite green: 903 tests, 0 failures.