### PR TITLE
fix(v1): multi-letter seat rows, remove() checkout guard, seated concurrency tests

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -261,6 +261,16 @@ public class ReservationService {
             removedPricePerTicket = zone.getprice();
             activeOrder = getActiveOrderOrThrow(buyer);
 
+            // CheckoutService marks orders CHECKOUT_IN_PROGRESS and releases the order lock during Phase 2.
+            // Reject remove attempts in that state so a concurrent removal can't mutate the cart snapshot
+            // checkout is pricing/charging against. Fails fast here (before releasing inventory) instead of
+            // letting the domain throw mid-flow and forcing a rollback — mirrors the guard in reserve(...).
+            if (activeOrder.isCheckoutInProgress()) {
+                log.warn("Request rejected: cannot modify active order during checkout. eventId={}, zoneId={}, userId={}, sessionId={}",
+                        eventId, zoneId, buyer.isMember() ? buyer.userId() : null, buyer.isMember() ? null : buyer.sessionId());
+                throw new IllegalStateException("Cannot modify active order during checkout");
+            }
+
             // Validate first so we do not release inventory for tickets that are not in the active order.
             activeOrder.validateContainsReservation(eventId, zoneId, selection);
             // Bind the selection to this order's key so the zone can verify ownership when releasing.

--- a/src/main/java/com/ticketing/system/Core/Domain/events/SeatLabels.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/SeatLabels.java
@@ -1,0 +1,34 @@
+package com.ticketing.system.Core.Domain.events;
+
+/**
+ * Canonical seat-row label helpers.
+ *
+ * <p>Row labels use bijective base-26 (spreadsheet-column) encoding so that venues with more than
+ * 26 rows still get clean, letter-only labels: index {@code 0 -> "A"}, {@code 25 -> "Z"},
+ * {@code 26 -> "AA"}, {@code 27 -> "AB"}, ... This matches the label contract the backend already
+ * relies on — {@code EventManagementService} parses the leading non-digit run of a seat label as its
+ * row, explicitly anticipating multi-character rows like {@code "AA12"}.
+ */
+public final class SeatLabels {
+
+    private SeatLabels() {
+    }
+
+    /**
+     * Returns the bijective base-26 row label for a 0-based row index.
+     *
+     * @param zeroBasedRowIndex the row index (0 == first row)
+     * @return the row label (e.g. 0 -> "A", 26 -> "AA")
+     * @throws IllegalArgumentException if the index is negative
+     */
+    public static String rowLabel(int zeroBasedRowIndex) {
+        if (zeroBasedRowIndex < 0) {
+            throw new IllegalArgumentException("row index must be >= 0: " + zeroBasedRowIndex);
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int n = zeroBasedRowIndex; n >= 0; n = n / 26 - 1) {
+            sb.insert(0, (char) ('A' + n % 26));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
@@ -12,6 +12,7 @@ import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.EventCategory;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.SeatLabels;
 import com.ticketing.system.Core.Domain.events.ShowDate;
 
 import java.time.LocalDateTime;
@@ -248,7 +249,7 @@ public final class DemoEvents {
     private ZoneConfigDTO seatedZone(String name, int rows, int cols, double price) {
         List<SeatConfigDTO> seats = new ArrayList<>(rows * cols);
         for (int r = 0; r < rows; r++) {
-            char rowLetter = (char) ('A' + r);
+            String rowLetter = SeatLabels.rowLabel(r);
             for (int c = 0; c < cols; c++) {
                 seats.add(new SeatConfigDTO(rowLetter + "-" + (c + 1), c * 60.0, r * 60.0));
             }

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoEvents.java
@@ -251,7 +251,9 @@ public final class DemoEvents {
         for (int r = 0; r < rows; r++) {
             String rowLetter = SeatLabels.rowLabel(r);
             for (int c = 0; c < cols; c++) {
-                seats.add(new SeatConfigDTO(rowLetter + "-" + (c + 1), c * 60.0, r * 60.0));
+                // Canonical "<row><num>" label (e.g. "A1") — matches generateSeats() and the
+                // leading-non-digit-run parsing in EventManagementService/SeatPickerPresenter.
+                seats.add(new SeatConfigDTO(rowLetter + "" + (c + 1), c * 60.0, r * 60.0));
             }
         }
         return new ZoneConfigDTO(name, true, null, seats, price, null);

--- a/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatBlock.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatBlock.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Presentation.components.venue;
 
+import com.ticketing.system.Core.Domain.events.SeatLabels;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 
@@ -27,7 +28,7 @@ public class VkSeatBlock extends Div {
         for (int ri = 0; ri < rows.length; ri++) {
             Div row = new Div();
             row.addClassName("vk-seatrow");
-            Span rl = new Span(String.valueOf((char) (startRowChar + ri)));
+            Span rl = new Span(SeatLabels.rowLabel((startRowChar - 'A') + ri));
             rl.addClassName("vk-rowlabel");
             row.add(rl);
             String r = rows[ri];

--- a/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
@@ -3,6 +3,7 @@ package com.ticketing.system.Presentation.views.company;
 import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
 import com.ticketing.system.Core.Application.dto.ZoneDetailDTO;
+import com.ticketing.system.Core.Domain.events.SeatLabels;
 import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
@@ -456,9 +457,9 @@ public class VenueMapEditorView extends LkPage implements BeforeEnterObserver {
     private List<VenueMapConfigDTO.SeatConfigDTO> generateSeats(int rows, int seatsPerRow) {
         List<VenueMapConfigDTO.SeatConfigDTO> seats = new ArrayList<>();
         for (int r = 0; r < rows; r++) {
-            char rowLabel = (char) ('A' + r);
+            String rowLabel = SeatLabels.rowLabel(r);
             for (int c = 1; c <= seatsPerRow; c++) {
-                seats.add(new VenueMapConfigDTO.SeatConfigDTO(rowLabel + "" + c, c, r));
+                seats.add(new VenueMapConfigDTO.SeatConfigDTO(rowLabel + c, c, r));
             }
         }
         return seats;

--- a/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
+++ b/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
@@ -6,17 +6,24 @@ import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.InventorySelection;
 import com.ticketing.system.Core.Domain.events.InventoryZone;
+import com.ticketing.system.Core.Domain.events.Seat;
+import com.ticketing.system.Core.Domain.events.SeatStatus;
+import com.ticketing.system.Core.Domain.events.SeatedZone;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -24,7 +31,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -367,23 +375,121 @@ void GivenNotEnoughTickets_WhenreserveStandingTicketsForMember_ThenThrowExceptio
 
 
 
-    // more acceptance tests:
+    // more acceptance tests: seated venue maps
+
+    // A real SeatedZone wired into the deep-stub event lets these exercise the actual per-seat
+    // locking; no dedicated test-data builder is required.
 
     @Test
-    @Disabled("Enable after test-data builder supports seated venue maps")
     void GivenMemberSelectsAvailableSeats_WhenReserveSeats_ThenSeatsAreLockedAndCartShowsSeatNumbers() {
-        
+        SeatedZone seatedZone = new SeatedZone(1, "Orchestra", 120.0,
+                List.of(new Seat("A1", 0, 0), new Seat("A2", 1, 0), new Seat("A3", 2, 0)));
+        when(event.getVenueMap().getZone(1)).thenReturn(seatedZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            seatedZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(1), any(InventorySelection.class));
+
+        ReservationResultDTO result = reservationService.reserveForMember(
+                "validToken", 100, 1, InventorySelectionDTO.seated(List.of("A1", "A2")));
+
+        assertEquals(List.of("A1", "A2"), result.getSeatNumbers());
+        assertEquals(SeatStatus.RESERVED, seatedZone.getSeatStatus("A1"));
+        assertEquals(SeatStatus.RESERVED, seatedZone.getSeatStatus("A2"));
+        assertEquals(SeatStatus.AVAILABLE, seatedZone.getSeatStatus("A3"));
+
+        assertEquals(List.of("A1", "A2"),
+                activeOrder.getItems().stream().map(CartLineItem::getSeatNumber).toList());
     }
 
     @Test
-    @Disabled("Enable after test-data builder supports seated venue maps")
-    void GivenTwoMembersSelectSameSeat_WhenReserveConcurrently_ThenOnlyOneReservationSucceeds() {
-        
+    void GivenTwoMembersSelectSameSeat_WhenReserveConcurrently_ThenOnlyOneReservationSucceeds()
+            throws InterruptedException {
+
+        int numberOfThreads = 2;
+        String contestedSeat = "A1";
+
+        SeatedZone seatedZone = new SeatedZone(1, "Orchestra", 120.0,
+                List.of(new Seat("A1", 0, 0), new Seat("A2", 1, 0)));
+        when(event.getVenueMap().getZone(1)).thenReturn(seatedZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            seatedZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(1), any(InventorySelection.class));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch readyLatch = new CountDownLatch(numberOfThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i = i + 1) {
+            final String token = "member-token-" + i;
+            final int userId = i + 1;
+
+            when(sessionManager.validateToken(token)).thenReturn(true);
+            when(sessionManager.extractUserId(token)).thenReturn(userId);
+            when(activeOrderRepository.getByUserId(userId)).thenReturn(null);
+
+            executorService.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    reservationService.reserveForMember(token, 100, 1, InventorySelectionDTO.seated(List.of(contestedSeat)));
+
+                    successCount.incrementAndGet();
+
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(true, finished);
+        assertEquals(1, successCount.get());
+        assertEquals(numberOfThreads - 1, failureCount.get());
+        assertEquals(SeatStatus.RESERVED, seatedZone.getSeatStatus(contestedSeat));
+        assertEquals(1, seatedZone.getReservedAmount());
     }
 
     @Test
-    @Disabled("Enable after test-data builder supports seated venue maps")
     void GivenGuestSelectsSeats_WhenReserveSeats_ThenGuestCartContainsSeatNumbers() {
-        
+        SeatedZone seatedZone = new SeatedZone(1, "Balcony", 80.0,
+                List.of(new Seat("C1", 0, 0), new Seat("C2", 1, 0)));
+        when(event.getVenueMap().getZone(1)).thenReturn(seatedZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            seatedZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(1), any(InventorySelection.class));
+        when(activeOrderRepository.getBySessionId("guest-session")).thenReturn(Optional.empty());
+
+        ReservationResultDTO result = reservationService.reserveForGuest(
+                "guest-session", 100, 1, InventorySelectionDTO.seated(List.of("C1", "C2")));
+
+        assertEquals(List.of("C1", "C2"), result.getSeatNumbers());
+        assertEquals(SeatStatus.RESERVED, seatedZone.getSeatStatus("C1"));
+        assertEquals(SeatStatus.RESERVED, seatedZone.getSeatStatus("C2"));
+
+        ArgumentCaptor<ActiveOrder> orderCaptor = ArgumentCaptor.forClass(ActiveOrder.class);
+        verify(activeOrderRepository).save(orderCaptor.capture());
+        ActiveOrder savedGuestOrder = orderCaptor.getValue();
+        assertTrue(savedGuestOrder.isGuest());
+        assertEquals(List.of("C1", "C2"),
+                savedGuestOrder.getItems().stream().map(CartLineItem::getSeatNumber).toList());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.mockito.ArgumentCaptor;
@@ -612,6 +613,209 @@ void GivenManyMembersReserveSameZoneConcurrently_WhenreserveStandingTicketsForMe
         assertEquals(0, realActiveOrder.countTickets(EVENT_ID, ZONE_ID));
         assertEquals(0, realZone.getReservedAmount());
         assertEquals(capacity, realZone.getAvailableAmount());
+    }
+
+
+    // ---- Seated-zone concurrency ----------------------------------------
+    // These isolate SeatedZone's per-seat ReentrantLock (the real guarantee against
+    // double-booking) by reserving against a real SeatedZone while the event is a deep-stub
+    // whose reserveInventory delegates to the zone — same approach as the standing tests above.
+
+    @Test
+    void GivenManyMembersSelectSameSeatConcurrently_WhenReserveSeatsForMember_ThenOnlyOneSucceeds()
+            throws InterruptedException {
+
+        int numberOfThreads = 20;
+        String contestedSeat = "A1";
+
+        SeatedZone realZone = new SeatedZone(
+                ZONE_ID, "Orchestra", 120.0,
+                List.of(new Seat("A1", 0, 0), new Seat("A2", 1, 0), new Seat("A3", 2, 0)));
+
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(event.getVenueMap().getZone(ZONE_ID)).thenReturn(realZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            realZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(ZONE_ID), any(InventorySelection.class));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch readyLatch = new CountDownLatch(numberOfThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i = i + 1) {
+            final String token = "valid-token-" + i;
+            final int userId = i + 1;
+
+            when(sessionManager.validateToken(token)).thenReturn(true);
+            when(sessionManager.extractUserId(token)).thenReturn(userId);
+            when(activeOrderRepository.getByUserId(userId)).thenReturn(null);
+
+            executorService.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    reservationService.reserveForMember(token, EVENT_ID, ZONE_ID, InventorySelectionDTO.seated(List.of(contestedSeat)));
+
+                    successCount.incrementAndGet();
+
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(true, finished);
+        assertEquals(1, successCount.get());
+        assertEquals(numberOfThreads - 1, failureCount.get());
+        assertEquals(SeatStatus.RESERVED, realZone.getSeatStatus(contestedSeat));
+        assertEquals(1, realZone.getReservedAmount());
+    }
+
+    @Test
+    void GivenManyGuestsSelectSameSeatConcurrently_WhenReserveSeatsForGuest_ThenOnlyOneSucceeds()
+            throws InterruptedException {
+
+        int numberOfThreads = 20;
+        String contestedSeat = "A1";
+
+        SeatedZone realZone = new SeatedZone(
+                ZONE_ID, "Orchestra", 120.0,
+                List.of(new Seat("A1", 0, 0), new Seat("A2", 1, 0), new Seat("A3", 2, 0)));
+
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(event.getVenueMap().getZone(ZONE_ID)).thenReturn(realZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            realZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(ZONE_ID), any(InventorySelection.class));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch readyLatch = new CountDownLatch(numberOfThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i = i + 1) {
+            final String sessionId = "guest-session-" + i;
+
+            when(activeOrderRepository.getBySessionId(sessionId)).thenReturn(Optional.empty());
+
+            executorService.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    reservationService.reserveForGuest(sessionId, EVENT_ID, ZONE_ID, InventorySelectionDTO.seated(List.of(contestedSeat)));
+
+                    successCount.incrementAndGet();
+
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(true, finished);
+        assertEquals(1, successCount.get());
+        assertEquals(numberOfThreads - 1, failureCount.get());
+        assertEquals(SeatStatus.RESERVED, realZone.getSeatStatus(contestedSeat));
+        assertEquals(1, realZone.getReservedAmount());
+    }
+
+    @Test
+    void GivenManyThreadsReserveDistinctSeatsConcurrently_WhenReserveSeatsForMember_ThenAllSucceed()
+            throws InterruptedException {
+
+        int numberOfThreads = 20;
+
+        List<Seat> seats = new ArrayList<>();
+        for (int i = 0; i < numberOfThreads; i = i + 1) {
+            seats.add(new Seat("A" + (i + 1), i, 0));
+        }
+        SeatedZone realZone = new SeatedZone(ZONE_ID, "Orchestra", 120.0, seats);
+
+        when(eventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(event.getVenueMap().getZone(ZONE_ID)).thenReturn(realZone);
+        doAnswer(inv -> {
+            InventorySelection selection = inv.getArgument(1);
+            realZone.reserve(selection);
+            return null;
+        }).when(event).reserveInventory(eq(ZONE_ID), any(InventorySelection.class));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch readyLatch = new CountDownLatch(numberOfThreads);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(numberOfThreads);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        for (int i = 0; i < numberOfThreads; i = i + 1) {
+            final String token = "valid-token-" + i;
+            final int userId = i + 1;
+            final String seatLabel = "A" + (i + 1);
+
+            when(sessionManager.validateToken(token)).thenReturn(true);
+            when(sessionManager.extractUserId(token)).thenReturn(userId);
+            when(activeOrderRepository.getByUserId(userId)).thenReturn(null);
+
+            executorService.submit(() -> {
+                try {
+                    readyLatch.countDown();
+                    startLatch.await();
+
+                    reservationService.reserveForMember(token, EVENT_ID, ZONE_ID, InventorySelectionDTO.seated(List.of(seatLabel)));
+
+                    successCount.incrementAndGet();
+
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        readyLatch.await();
+        startLatch.countDown();
+
+        boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        assertEquals(true, finished);
+        assertEquals(numberOfThreads, successCount.get());
+        assertEquals(0, failureCount.get());
+        assertEquals(numberOfThreads, realZone.getReservedAmount());
+        assertEquals(0, realZone.getAvailableAmount());
     }
 
 

--- a/src/test/java/com/ticketing/system/unit/domain/SeatLabelsTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/SeatLabelsTest.java
@@ -1,0 +1,32 @@
+package com.ticketing.system.unit.domain;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.events.SeatLabels;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SeatLabelsTest {
+
+    @Test
+    void GivenSingleLetterRange_WhenRowLabel_ThenReturnsAToZ() {
+        assertEquals("A", SeatLabels.rowLabel(0));
+        assertEquals("B", SeatLabels.rowLabel(1));
+        assertEquals("Z", SeatLabels.rowLabel(25));
+    }
+
+    @Test
+    void GivenIndexPastZ_WhenRowLabel_ThenRollsOverToDoubleLetters() {
+        assertEquals("AA", SeatLabels.rowLabel(26));
+        assertEquals("AB", SeatLabels.rowLabel(27));
+        assertEquals("AZ", SeatLabels.rowLabel(51));
+        assertEquals("BA", SeatLabels.rowLabel(52));
+        assertEquals("ZZ", SeatLabels.rowLabel(701));
+        assertEquals("AAA", SeatLabels.rowLabel(702));
+    }
+
+    @Test
+    void GivenNegativeIndex_WhenRowLabel_ThenThrows() {
+        assertThrows(IllegalArgumentException.class, () -> SeatLabels.rowLabel(-1));
+    }
+}


### PR DESCRIPTION
## Summary

Three small, independent V1 sharpenings (from a Copilot PR review and a `ReservationService` self-review). Branched off `dev`; touches only reservation / venue-map / test files — no overlap with the in-flight messaging work.

## 1. Multi-letter seat-row labels (row-label overflow fix)

`generateSeats()` labelled rows with `(char)('A' + r)`, so the venue-map editor's 99-row limit produced **non-letter labels** (`'['`, `'\'`, `']'`, …) past row 26, corrupting seat identity. The backend already parses multi-letter labels (`EventManagementService` groups seats by the leading non-digit run, explicitly anticipating `"AA12"` and `>26` rows) — only the UI/seed generators lagged.

- Added `Core/Domain/events/SeatLabels.java` → `rowLabel(int)` with bijective base-26 encoding: `0→A`, `25→Z`, `26→AA`, `27→AB`, …
- Routed all three generators through it: `VenueMapEditorView.generateSeats`, `DemoEvents.seatedZone`, `VkSeatBlock`.
- `rowsField` keeps `setMax(99)`; `VkSeatBlock`'s `char`-based constructor signature is unchanged (no callers affected).

## 2. Symmetric in-checkout guard in `ReservationService.remove()`

`reserve()` already rejects carts in `CHECKOUT_IN_PROGRESS` (checkout releases the per-order lock during its pricing/charging phase, so a concurrent cart mutation could corrupt the snapshot). `remove()` lacked the equivalent **service-level** guard — it relied on the domain throwing only *after* inventory had already been released, forcing a rollback.

- Added the same fail-fast guard right after the order is loaded, before any inventory work.
- `reserve` / `remove` / `abandon` are now consistent (fail fast at the service boundary with structured logging).

## 3. Seated-zone reservation concurrency tests

Standing-zone concurrency was already covered; seated zones had only `@Disabled` placeholders.

- Added 3 unit tests (`ReservationServiceTest`) exercising the real `SeatedZone` per-seat `ReentrantLock`: same-seat (members) and same-seat (guests) admit **exactly one winner**; distinct seats all succeed with no deadlock.
- Implemented the 3 formerly-`@Disabled` acceptance tests (`ReservationAcceptanceTests`).
- Added `SeatLabelsTest` for the new helper.

## Verification

`mvn -B -Pno-vaadin verify` → **983 tests, 0 failures, 0 errors**.
Targeted (`ReservationServiceTest`, `ReservationAcceptanceTests`, `SeatLabelsTest`) → **63 pass, 0 skipped**.

## Files changed

`SeatLabels.java` (new), `VenueMapEditorView.java`, `DemoEvents.java`, `VkSeatBlock.java`, `ReservationService.java`, `ReservationServiceTest.java`, `ReservationAcceptanceTests.java`, `SeatLabelsTest.java` (new).
