### PR TITLE
255 v2 error 01 structured failure payload toastsfailureerrorpayload retrofit

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/components/ErrorCode.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.ticketing.system.Presentation.components;
+
+public enum ErrorCode {
+    AUTH_FAILED,
+    GUEST_SESSION_EXPIRED,
+    USERNAME_TAKEN,
+    EMAIL_TAKEN,
+    WEAK_PASSWORD,
+    INVALID_EMAIL,
+    EVENT_NOT_ON_SALE,
+    POLICY_VIOLATION,
+    INVALID_STATE,
+    PAYMENT_FAILED,
+    IDEMPOTENCY_CONFLICT,
+    UNKNOWN
+}

--- a/src/main/java/com/ticketing/system/Presentation/components/ErrorPayload.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/ErrorPayload.java
@@ -1,0 +1,73 @@
+package com.ticketing.system.Presentation.components;
+
+/**
+ * Structured failure payload carried by presenter Failure outcomes and
+ * rendered by {@link Toasts#failure(ErrorPayload)}.
+ *
+ * <p>{@code code} is a stable enum value safe for telemetry / logging.
+ * {@code retryable} drives toast colour (amber vs red) and the optional
+ * Retry action. {@code helpHref} — when non-null — adds a "Learn more"
+ * anchor to the toast.
+ *
+ * <p>Use the static factory methods rather than the canonical constructor
+ * so call sites read as intent, not as field-list noise.
+ */
+public record ErrorPayload(ErrorCode code, String message, boolean retryable, String helpHref) {
+
+    // --- factories ---
+
+    public static ErrorPayload authFailed() {
+        return new ErrorPayload(ErrorCode.AUTH_FAILED, "Invalid username or password.", false, null);
+    }
+
+    public static ErrorPayload guestSessionExpired() {
+        return new ErrorPayload(ErrorCode.GUEST_SESSION_EXPIRED,
+                "Your session has expired. Please refresh the page.", false, null);
+    }
+
+    public static ErrorPayload usernameTaken() {
+        return new ErrorPayload(ErrorCode.USERNAME_TAKEN, "That username is already taken.", false, null);
+    }
+
+    public static ErrorPayload emailTaken() {
+        return new ErrorPayload(ErrorCode.EMAIL_TAKEN, "An account with that email already exists.", false, null);
+    }
+
+    public static ErrorPayload weakPassword(String detail) {
+        String msg = (detail != null && !detail.isBlank()) ? detail : "Password does not meet the strength requirements.";
+        return new ErrorPayload(ErrorCode.WEAK_PASSWORD, msg, false, null);
+    }
+
+    public static ErrorPayload invalidEmail() {
+        return new ErrorPayload(ErrorCode.INVALID_EMAIL, "Please enter a valid email address.", false, null);
+    }
+
+    public static ErrorPayload eventNotOnSale() {
+        return new ErrorPayload(ErrorCode.EVENT_NOT_ON_SALE, "Tickets for this event are not currently on sale.", false, null);
+    }
+
+    public static ErrorPayload policyViolation(String detail) {
+        String msg = (detail != null && !detail.isBlank()) ? detail : "Your purchase does not meet the event's purchase policy.";
+        return new ErrorPayload(ErrorCode.POLICY_VIOLATION, msg, false, null);
+    }
+
+    public static ErrorPayload invalidState(String detail) {
+        String msg = (detail != null && !detail.isBlank()) ? detail : "This action cannot be performed in the current state.";
+        return new ErrorPayload(ErrorCode.INVALID_STATE, msg, false, null);
+    }
+
+    public static ErrorPayload paymentFailed(String detail) {
+        String msg = (detail != null && !detail.isBlank()) ? detail : "Payment could not be processed. Please try again.";
+        return new ErrorPayload(ErrorCode.PAYMENT_FAILED, msg, true, null);
+    }
+
+    public static ErrorPayload idempotencyConflict() {
+        return new ErrorPayload(ErrorCode.IDEMPOTENCY_CONFLICT,
+                "This order was already submitted. Check your order history.", false, null);
+    }
+
+    public static ErrorPayload unknown(String detail) {
+        String msg = (detail != null && !detail.isBlank()) ? detail : "Something went wrong. Please try again.";
+        return new ErrorPayload(ErrorCode.UNKNOWN, msg, true, null);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/components/Toasts.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/Toasts.java
@@ -1,8 +1,10 @@
 package com.ticketing.system.Presentation.components;
 
 import com.ticketing.system.Presentation.components.kit.LkIcon;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.notification.Notification;
@@ -39,6 +41,71 @@ public final class Toasts {
     /** Warning toast — amber theme, 5s, top-end. Use for near-expiry or "be careful" hints. */
     public static void warn(String msg) {
         toast(msg, NotificationVariant.LUMO_WARNING, 5000);
+    }
+
+    /**
+     * Structured failure toast driven by an {@link ErrorPayload}.
+     * Retryable errors use amber (warning); permanent errors use red.
+     * If {@code payload.helpHref()} is set a "Learn more" anchor is appended.
+     */
+    public static void failure(ErrorPayload payload) {
+        failure(payload, null);
+    }
+
+    /**
+     * Structured failure toast with an optional retry callback.
+     * When {@code onRetry} is non-null and {@code payload.retryable()} is true
+     * a "Retry" button is shown that invokes the callback then closes the toast.
+     */
+    public static void failure(ErrorPayload payload, Runnable onRetry) {
+        NotificationVariant variant = payload.retryable()
+                ? NotificationVariant.LUMO_WARNING
+                : NotificationVariant.LUMO_ERROR;
+        int duration = payload.retryable() ? 8000 : 6000;
+
+        Notification n = new Notification();
+        n.setPosition(Notification.Position.TOP_END);
+        n.setDuration(duration);
+        n.addThemeVariants(variant);
+
+        Div content = new Div();
+        content.getStyle()
+                .set("display", "flex")
+                .set("align-items", "center")
+                .set("gap", "14px");
+
+        Span text = new Span(payload.message());
+        text.getStyle().set("flex", "1 1 auto");
+        content.add(text);
+
+        if (payload.retryable() && onRetry != null) {
+            Button retryBtn = new Button("Retry", e -> {
+                n.close();
+                onRetry.run();
+            });
+            retryBtn.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE, ButtonVariant.LUMO_SMALL);
+            retryBtn.getStyle().set("color", "inherit").set("font-weight", "600");
+            content.add(retryBtn);
+        }
+
+        if (payload.helpHref() != null && !payload.helpHref().isBlank()) {
+            Anchor link = new Anchor(payload.helpHref(), "Learn more");
+            link.setTarget("_blank");
+            link.getStyle().set("color", "inherit").set("font-size", "0.85em");
+            content.add(link);
+        }
+
+        Button close = new Button(new LkIcon("close", 14), e -> n.close());
+        close.addThemeVariants(ButtonVariant.LUMO_TERTIARY_INLINE, ButtonVariant.LUMO_SMALL);
+        close.getElement().setAttribute("aria-label", "Dismiss");
+        close.getStyle()
+                .set("color", "inherit")
+                .set("opacity", "0.7")
+                .set("margin", "-4px -6px -4px 0");
+        content.add(close);
+
+        n.add(content);
+        n.open();
     }
 
     private static void toast(String msg, NotificationVariant variant, int durationMs) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/ExceptionTranslator.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/ExceptionTranslator.java
@@ -1,0 +1,76 @@
+package com.ticketing.system.Presentation.presenters;
+
+import java.util.function.Supplier;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import com.ticketing.system.Core.Domain.exceptions.EventNotOnSaleException;
+import com.ticketing.system.Core.Domain.exceptions.GuestSessionRequiredException;
+import com.ticketing.system.Core.Domain.exceptions.IdempotencyConflictException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidEmailFormatException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
+import com.ticketing.system.Core.Domain.exceptions.DuplicateEmailException;
+import com.ticketing.system.Core.Domain.exceptions.DuplicateUsernameException;
+import com.ticketing.system.Core.Domain.exceptions.WeakPasswordException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+
+/**
+ * Translates domain exceptions into {@link ErrorPayload} instances and
+ * wraps service calls in a typed {@link Outcome}.
+ *
+ * <p>Presenters that don't need custom failure variants can delegate
+ * entirely:
+ * <pre>
+ *   return translator.wrap(() -> service.doSomething(token));
+ * </pre>
+ *
+ * <p>Presenters with rich sealed hierarchies (LoginPresenter,
+ * CheckoutPresenter) catch their domain-specific cases first and fall
+ * through to {@link #toPayload(RuntimeException)} for the generic ones,
+ * so the {@link com.ticketing.system.Presentation.components.ErrorCode}
+ * lands consistently in telemetry.
+ */
+@Component
+public class ExceptionTranslator {
+
+    /** Wraps a value-returning service call. */
+    public <T> Outcome<T> wrap(Supplier<T> call) {
+        try {
+            return new Outcome.Success<>(call.get());
+        } catch (RuntimeException e) {
+            return new Outcome.Failure<>(toPayload(e));
+        }
+    }
+
+    /** Wraps a void service call. */
+    public Outcome<Void> wrapVoid(Runnable call) {
+        return wrap(() -> { call.run(); return null; });
+    }
+
+    /**
+     * Maps a domain exception to the canonical {@link ErrorPayload}.
+     * Static so presenters with rich sealed hierarchies can call it
+     * without injecting the full translator.
+     */
+    public static ErrorPayload toPayload(RuntimeException e) {
+        return switch (e) {
+            case AuthenticationFailedException ex   -> ErrorPayload.authFailed();
+            case GuestSessionRequiredException ex   -> ErrorPayload.guestSessionExpired();
+            case InvalidTokenException ex           -> ErrorPayload.guestSessionExpired();
+            case DuplicateUsernameException ex      -> ErrorPayload.usernameTaken();
+            case DuplicateEmailException ex         -> ErrorPayload.emailTaken();
+            case WeakPasswordException ex           -> ErrorPayload.weakPassword(ex.getMessage());
+            case InvalidEmailFormatException ex     -> ErrorPayload.invalidEmail();
+            case EventNotOnSaleException ex         -> ErrorPayload.eventNotOnSale();
+            case PolicyViolationException ex        -> ErrorPayload.policyViolation(ex.getMessage());
+            case InvalidStateTransitionException ex -> ErrorPayload.invalidState(ex.getMessage());
+            case PaymentGatewayException ex         -> ErrorPayload.paymentFailed(ex.getMessage());
+            case IdempotencyConflictException ex    -> ErrorPayload.idempotencyConflict();
+            default                                 -> ErrorPayload.unknown(e.getMessage());
+        };
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/Outcome.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/Outcome.java
@@ -1,0 +1,14 @@
+package com.ticketing.system.Presentation.presenters;
+
+import com.ticketing.system.Presentation.components.ErrorPayload;
+
+/**
+ * Generic presenter outcome for simple read/query operations that don't
+ * need per-exception failure variants. Presenters with rich failure
+ * hierarchies (LoginPresenter, CheckoutPresenter) keep their own sealed
+ * types — see docs/coding-standards.md for the full convention.
+ */
+public sealed interface Outcome<T> permits Outcome.Success, Outcome.Failure {
+    record Success<T>(T value) implements Outcome<T> { }
+    record Failure<T>(ErrorPayload error) implements Outcome<T> { }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/account/MyInvitationsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/account/MyInvitationsPresenter.java
@@ -9,6 +9,8 @@ import com.ticketing.system.Core.Application.dto.AppointmentResponseDTO;
 import com.ticketing.system.Core.Application.dto.InvitationDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code MyInvitationsView}. Holds no Vaadin imports so the
@@ -50,7 +52,7 @@ public class MyInvitationsPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -75,7 +77,7 @@ public class MyInvitationsPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -83,13 +85,13 @@ public class MyInvitationsPresenter {
     public sealed interface Outcome {
         record Success(List<InvitationDTO> pending, List<InvitationDTO> history) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of an accept/decline action the view reacts to. */
     public sealed interface ActionOutcome {
         record Success() implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
@@ -4,6 +4,8 @@ import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,7 +33,7 @@ public class AdminLoginPresenter {
         } catch (AuthenticationFailedException e) {
             return new Outcome.InvalidCredentials();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -39,6 +41,6 @@ public class AdminLoginPresenter {
         record Success(AuthTokenDTO authToken) implements Outcome { }
         record InvalidCredentials() implements Outcome { }
         record Locked(String reason) implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/LoginPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/LoginPresenter.java
@@ -5,6 +5,8 @@ import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
 import com.ticketing.system.Core.Domain.exceptions.GuestSessionRequiredException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +45,7 @@ public class LoginPresenter {
         } catch (GuestSessionRequiredException e) {
             return new Outcome.GuestSessionMissing(e.getMessage());
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -52,6 +54,6 @@ public class LoginPresenter {
         record Success(LoginDTO loginDTO) implements Outcome { }
         record InvalidCredentials() implements Outcome { }
         record GuestSessionMissing(String reason) implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/RegisterPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/RegisterPresenter.java
@@ -7,6 +7,8 @@ import com.ticketing.system.Core.Domain.exceptions.DuplicateUsernameException;
 import com.ticketing.system.Core.Domain.exceptions.GuestSessionRequiredException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidEmailFormatException;
 import com.ticketing.system.Core.Domain.exceptions.WeakPasswordException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +52,7 @@ public class RegisterPresenter {
         } catch (IllegalArgumentException e) {
             return new Outcome.InvalidInput(e.getMessage());
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -62,6 +64,6 @@ public class RegisterPresenter {
         record InvalidEmail() implements Outcome { }
         record GuestSessionMissing(String reason) implements Outcome { }
         record InvalidInput(String reason) implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/UsernameAvailabilityPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/UsernameAvailabilityPresenter.java
@@ -1,6 +1,8 @@
 package com.ticketing.system.Presentation.presenters.auth;
 
 import com.ticketing.system.Core.Application.services.MemberQueryService;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.AuthSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -54,7 +56,7 @@ public class UsernameAvailabilityPresenter {
             }
             return new Outcome.Available();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -65,6 +67,6 @@ public class UsernameAvailabilityPresenter {
         record AdminReserved() implements Outcome { }
         record Taken() implements Outcome { }
         record Available() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
@@ -15,8 +15,10 @@ import com.ticketing.system.Core.Application.dto.VenueMapDTO;
 import com.ticketing.system.Core.Application.services.CatalogService;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Domain.events.ZoneType;
+import com.ticketing.system.Presentation.components.ErrorPayload;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatedZonePicker;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 
 @Component
@@ -39,7 +41,7 @@ public class SeatPickerPresenter {
         try {
             VenueMapDTO map = catalogService.getEventVenueMap(identity.credential(), eventId);
             if (map == null) {
-                return new LoadOutcome.Failure("Could not load venue map");
+                return new LoadOutcome.Failure(ErrorPayload.unknown("Could not load venue map"));
             }
             InventoryZoneDTO zone = map.inventoryZones().stream()
                     .filter(z -> z.getId() == zoneId)
@@ -51,7 +53,7 @@ public class SeatPickerPresenter {
             ZoneType zoneType = ZoneType.valueOf(zone.getZoneType());
             return new LoadOutcome.Loaded(zone, zoneType);
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure("Could not load this zone — please refresh and try again");
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -64,7 +66,7 @@ public class SeatPickerPresenter {
             }
             return new ReserveOutcome.Success(selection.getSeatNumbers().size());
         } catch (RuntimeException e) {
-            return new ReserveOutcome.Failure(e.getMessage());
+            return new ReserveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -78,7 +80,7 @@ public class SeatPickerPresenter {
             }
             return new ReserveOutcome.Success(quantity);
         } catch (RuntimeException e) {
-            return new ReserveOutcome.Failure(e.getMessage());
+            return new ReserveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -133,11 +135,11 @@ public class SeatPickerPresenter {
     public sealed interface LoadOutcome {
         record Loaded(InventoryZoneDTO zone, ZoneType zoneType) implements LoadOutcome { }
         record NotFound(String message) implements LoadOutcome { }
-        record Failure(String message)  implements LoadOutcome { }
+        record Failure(ErrorPayload error) implements LoadOutcome { }
     }
 
     public sealed interface ReserveOutcome {
-        record Success(int quantity)   implements ReserveOutcome { }
-        record Failure(String message) implements ReserveOutcome { }
+        record Success(int quantity)          implements ReserveOutcome { }
+        record Failure(ErrorPayload error)    implements ReserveOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -10,6 +10,8 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 @Component
 public class CompanyEventListPresenter {
@@ -35,7 +37,7 @@ public class CompanyEventListPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -43,6 +45,6 @@ public class CompanyEventListPresenter {
         record Success(List<EventDetailDTO> events) implements Outcome {}
         record NotAuthenticated() implements Outcome {}
         record NoCompany() implements Outcome {}
-        record Failure(String reason) implements Outcome {}
+        record Failure(ErrorPayload error) implements Outcome {}
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyRegistrationPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyRegistrationPresenter.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component;
 import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.session.CurrentCompanies;
 
@@ -34,7 +36,7 @@ public class CompanyRegistrationPresenter {
         } catch (IllegalStateException e) {
             return new Outcome.NameTaken(e.getMessage());
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -47,6 +49,6 @@ public class CompanyRegistrationPresenter {
 
         record NameTaken(String reason) implements Outcome { }
 
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -8,6 +8,8 @@ import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 @Component
 public class EventManagementPresenter {
@@ -29,7 +31,7 @@ public class EventManagementPresenter {
         } catch (EventNotFoundException e) {
             return new LoadOutcome.NotFound();
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure(e.getMessage());
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -41,7 +43,7 @@ public class EventManagementPresenter {
         } catch (InvalidTokenException e) {
             return new SaveOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new SaveOutcome.Failure(e.getMessage());
+            return new SaveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -53,7 +55,7 @@ public class EventManagementPresenter {
         } catch (InvalidTokenException e) {
             return new CancelOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new CancelOutcome.Failure(e.getMessage());
+            return new CancelOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -61,18 +63,18 @@ public class EventManagementPresenter {
         record Success(EventDetailDTO event) implements LoadOutcome {}
         record NotAuthenticated() implements LoadOutcome {}
         record NotFound() implements LoadOutcome {}
-        record Failure(String reason) implements LoadOutcome {}
+        record Failure(ErrorPayload error) implements LoadOutcome {}
     }
 
     public sealed interface SaveOutcome {
         record Success() implements SaveOutcome {}
         record NotAuthenticated() implements SaveOutcome {}
-        record Failure(String reason) implements SaveOutcome {}
+        record Failure(ErrorPayload error) implements SaveOutcome {}
     }
 
     public sealed interface CancelOutcome {
         record Success() implements CancelOutcome {}
         record NotAuthenticated() implements CancelOutcome {}
-        record Failure(String reason) implements CancelOutcome {}
+        record Failure(ErrorPayload error) implements CancelOutcome {}
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/ManagerInvitationPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/ManagerInvitationPresenter.java
@@ -11,6 +11,8 @@ import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.users.Permission;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 @Component
 public class ManagerInvitationPresenter {
@@ -37,7 +39,7 @@ public class ManagerInvitationPresenter {
         } catch (UserNotFoundException e) {
             return new Outcome.UserNotFound(inviteeUsername);
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -46,6 +48,6 @@ public class ManagerInvitationPresenter {
         record NotAuthenticated() implements Outcome {}
         record NoCompany() implements Outcome {}
         record UserNotFound(String username) implements Outcome {}
-        record Failure(String reason) implements Outcome {}
+        record Failure(ErrorPayload error) implements Outcome {}
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/ManagerListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/ManagerListPresenter.java
@@ -12,6 +12,8 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Core.Domain.users.Permission;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code ManagerListView}. Holds no Vaadin imports so the
@@ -57,7 +59,7 @@ public class ManagerListPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -80,7 +82,7 @@ public class ManagerListPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -100,7 +102,7 @@ public class ManagerListPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -111,13 +113,13 @@ public class ManagerListPresenter {
                        List<AppointmentInfoDTO> pendingInvitations) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
         record NoCompany() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of a manager mutation (edit permissions / revoke) the view reacts to. */
     public sealed interface ActionOutcome {
         record Success() implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/MyCompaniesPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/MyCompaniesPresenter.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.UserCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.session.CurrentCompanies;
 
@@ -24,14 +26,14 @@ public class MyCompaniesPresenter {
         try {
             return new Outcome.Success(companyManagementService.listForUser(userId));
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
     public sealed interface Outcome {
         record Success(List<UserCompanyDTO> companies) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     public UserCompanyDTO currentCompany() {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/OwnerDashboardPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/OwnerDashboardPresenter.java
@@ -10,6 +10,8 @@ import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyAnalyticsService;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code OwnerDashboardView} (V2-WIRE-OWNER-DASH). Holds no Vaadin imports so
@@ -58,7 +60,7 @@ public class OwnerDashboardPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -68,6 +70,6 @@ public class OwnerDashboardPresenter {
                        CompanyDashboardDTO stats) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
         record NoCompany() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
@@ -11,6 +11,8 @@ import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 @Component
 public class PurchasePolicyEditorPresenter {
@@ -35,7 +37,7 @@ public class PurchasePolicyEditorPresenter {
         } catch (InvalidTokenException e) {
             return new LoadOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure(e.getMessage());
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -54,19 +56,19 @@ public class PurchasePolicyEditorPresenter {
         } catch (InvalidTokenException e) {
             return new SaveOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new SaveOutcome.Failure(e.getMessage());
+            return new SaveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
     public sealed interface LoadOutcome {
         record Success(PurchasePolicyDTO policy) implements LoadOutcome { }
         record NotAuthenticated() implements LoadOutcome { }
-        record Failure(String reason) implements LoadOutcome { }
+        record Failure(ErrorPayload error) implements LoadOutcome { }
     }
 
     public sealed interface SaveOutcome {
         record Success() implements SaveOutcome { }
         record NotAuthenticated() implements SaveOutcome { }
-        record Failure(String reason) implements SaveOutcome { }
+        record Failure(ErrorPayload error) implements SaveOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/VenueMapPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/VenueMapPresenter.java
@@ -12,6 +12,8 @@ import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 @Component
 public class VenueMapPresenter {
@@ -34,7 +36,7 @@ public class VenueMapPresenter {
         } catch (InvalidTokenException e) {
             return new LoadOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure(e.getMessage());
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -49,7 +51,7 @@ public class VenueMapPresenter {
         } catch (InvalidTokenException e) {
             return new SaveOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new SaveOutcome.Failure(e.getMessage());
+            return new SaveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -76,13 +78,13 @@ public class VenueMapPresenter {
     public sealed interface LoadOutcome {
         record Success(VenueLayoutDTO layout) implements LoadOutcome {}
         record NotAuthenticated() implements LoadOutcome {}
-        record Failure(String reason) implements LoadOutcome {}
+        record Failure(ErrorPayload error) implements LoadOutcome {}
     }
 
     public sealed interface SaveOutcome {
         record Success() implements SaveOutcome {}
         record NotAuthenticated() implements SaveOutcome {}
         record NoCompany() implements SaveOutcome {}
-        record Failure(String reason) implements SaveOutcome {}
+        record Failure(ErrorPayload error) implements SaveOutcome {}
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/landing/LandingPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/landing/LandingPresenter.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code LandingView} (V2-LANDING-01). Holds no Vaadin imports so the
@@ -40,13 +42,13 @@ public class LandingPresenter {
             List<EventSummaryDTO> upcoming = catalogService.upcomingOnSale(UPCOMING_LIMIT);
             return new Outcome.Success(featured, upcoming);
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
     /** Sealed outcome the view switches on to render the poster rows or an empty state. */
     public sealed interface Outcome {
         record Success(List<EventSummaryDTO> featured, List<EventSummaryDTO> upcoming) implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminAnnouncementsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminAnnouncementsPresenter.java
@@ -14,6 +14,8 @@ import com.ticketing.system.Core.Application.dto.AnnouncementRequestDTO;
 import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code AdminAnnouncementsView} (#270). Holds no Vaadin imports so the
@@ -50,7 +52,7 @@ public class AdminAnnouncementsPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -68,7 +70,7 @@ public class AdminAnnouncementsPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -129,13 +131,13 @@ public class AdminAnnouncementsPresenter {
     public sealed interface Outcome {
         record Success(List<SentAnnouncement> announcements) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of a send the view reacts to (carries the recipient count for the confirmation). */
     public sealed interface ActionOutcome {
         record Success(int recipientCount) implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminComplaintQueuePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminComplaintQueuePresenter.java
@@ -10,6 +10,8 @@ import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.RespondToComplaintRequestDTO;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code AdminComplaintQueueView} (#269). Holds no Vaadin imports so the
@@ -51,7 +53,7 @@ public class AdminComplaintQueuePresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -69,7 +71,7 @@ public class AdminComplaintQueuePresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -88,7 +90,7 @@ public class AdminComplaintQueuePresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -96,13 +98,13 @@ public class AdminComplaintQueuePresenter {
     public sealed interface Outcome {
         record Success(List<ConversationDTO> complaints) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of a reply / resolve the view reacts to. */
     public sealed interface ActionOutcome {
         record Success() implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/CompanyInquiryInboxPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/CompanyInquiryInboxPresenter.java
@@ -11,6 +11,8 @@ import com.ticketing.system.Core.Application.dto.SendMessageRequestDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code CompanyInquiryInboxView} (#268). Holds no Vaadin imports so the
@@ -65,7 +67,7 @@ public class CompanyInquiryInboxPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -83,7 +85,7 @@ public class CompanyInquiryInboxPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -102,7 +104,7 @@ public class CompanyInquiryInboxPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -112,13 +114,13 @@ public class CompanyInquiryInboxPresenter {
                        List<ConversationDTO> conversations) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
         record NoCompany() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of a reply / close the view reacts to. */
     public sealed interface ActionOutcome {
         record Success() implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/SubmitComplaintPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/SubmitComplaintPresenter.java
@@ -7,6 +7,8 @@ import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.SubmitComplaintRequestDTO;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code SubmitComplaintView} (#267). Holds no Vaadin imports so
@@ -45,7 +47,7 @@ public class SubmitComplaintPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -53,6 +55,6 @@ public class SubmitComplaintPresenter {
     public sealed interface Outcome {
         record Success(String conversationId) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/SupportInboxPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/SupportInboxPresenter.java
@@ -9,6 +9,8 @@ import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.SendMessageRequestDTO;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 
 /**
  * MVP presenter for {@code SupportInboxView} (#277). Holds no Vaadin imports so the
@@ -46,7 +48,7 @@ public class SupportInboxPresenter {
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new Outcome.Failure(e.getMessage());
+            return new Outcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -64,7 +66,7 @@ public class SupportInboxPresenter {
         } catch (InvalidTokenException e) {
             return new ActionOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new ActionOutcome.Failure(e.getMessage());
+            return new ActionOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -72,13 +74,13 @@ public class SupportInboxPresenter {
     public sealed interface Outcome {
         record Success(List<ConversationDTO> conversations) implements Outcome { }
         record NotAuthenticated() implements Outcome { }
-        record Failure(String reason) implements Outcome { }
+        record Failure(ErrorPayload error) implements Outcome { }
     }
 
     /** Result of a reply the view reacts to. */
     public sealed interface ActionOutcome {
         record Success() implements ActionOutcome { }
         record NotAuthenticated() implements ActionOutcome { }
-        record Failure(String reason) implements ActionOutcome { }
+        record Failure(ErrorPayload error) implements ActionOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/order/CartPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/order/CartPresenter.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Component;
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Presentation.components.ErrorPayload;
 import com.ticketing.system.Presentation.components.Money;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 
 @Component
@@ -35,17 +37,17 @@ public class CartPresenter {
             }
             return new LoadOutcome.Shown(toVM(order), subtotalCents(order));
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure(e.getMessage());
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
     public RemoveOutcome removeLine(CartVM.LineVM line) {
         if (line == null) {
-            return new RemoveOutcome.Failure("No line selected");
+            return new RemoveOutcome.Failure(ErrorPayload.unknown("No line selected"));
         }
         String credential = identity.credential();
         if (credential == null || credential.isBlank()) {
-            return new RemoveOutcome.Failure("Your session has expired");
+            return new RemoveOutcome.Failure(ErrorPayload.guestSessionExpired());
         }
         try {
             InventorySelectionDTO selection = (line.seatNumber() != null)
@@ -61,7 +63,7 @@ public class CartPresenter {
             }
             return new RemoveOutcome.Removed(toVM(updated), subtotalCents(updated));
         } catch (RuntimeException e) {
-            return new RemoveOutcome.Failure(e.getMessage());
+            return new RemoveOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -95,11 +97,11 @@ public class CartPresenter {
         record Shown(CartVM cart, long subtotalCents)        implements LoadOutcome { }
         record Empty()                                       implements LoadOutcome { }
         record NotAuthenticated()                            implements LoadOutcome { }
-        record Failure(String reason)                        implements LoadOutcome { }
+        record Failure(ErrorPayload error)                   implements LoadOutcome { }
     }
 
     public sealed interface RemoveOutcome {
         record Removed(CartVM cart, long subtotalCents)      implements RemoveOutcome { }
-        record Failure(String reason)                        implements RemoveOutcome { }
+        record Failure(ErrorPayload error)                   implements RemoveOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
@@ -19,7 +19,9 @@ import com.ticketing.system.Core.Domain.exceptions.InsufficientInventoryExceptio
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
 import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
+import com.ticketing.system.Presentation.components.ErrorPayload;
 import com.ticketing.system.Presentation.components.Money;
+import com.ticketing.system.Presentation.presenters.ExceptionTranslator;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.server.VaadinSession;
 
@@ -67,7 +69,7 @@ public class CheckoutPresenter {
             }
             return new LoadOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
-            return new LoadOutcome.Failure(e.getMessage());
+            return new LoadOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -113,7 +115,7 @@ public class CheckoutPresenter {
             if (cause instanceof InvalidStateTransitionException) return new PayOutcome.OrderExpired("Order expired during checkout");
             if (cause instanceof IdempotencyConflictException)   return new PayOutcome.DuplicateSubmission();
             log.error("Checkout failed unexpectedly", e);
-            return new PayOutcome.Failure(cause.getMessage());
+            return new PayOutcome.Failure(ExceptionTranslator.toPayload(e));
         }
     }
 
@@ -160,7 +162,7 @@ public class CheckoutPresenter {
         record Loaded(ActiveOrderDTO order, Pricing pricing) implements LoadOutcome { }
         record Empty()                implements LoadOutcome { }
         record NotAuthenticated()     implements LoadOutcome { }
-        record Failure(String reason) implements LoadOutcome { }
+        record Failure(ErrorPayload error) implements LoadOutcome { }
     }
 
     public sealed interface PayOutcome {
@@ -170,6 +172,6 @@ public class CheckoutPresenter {
         record SoldOut(String reason)                implements PayOutcome { }
         record OrderExpired(String reason)           implements PayOutcome { }
         record DuplicateSubmission()                 implements PayOutcome { }
-        record Failure(String reason)                implements PayOutcome { }
+        record Failure(ErrorPayload error)           implements PayOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyInvitationsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyInvitationsView.java
@@ -65,7 +65,7 @@ public class MyInvitationsView extends LkPage {
             case MyInvitationsPresenter.Outcome.NotAuthenticated ignored -> content.add(banner(
                 "Your session has expired — please sign in again."));
             case MyInvitationsPresenter.Outcome.Failure fail -> content.add(banner(
-                "Could not load invitations: " + fail.reason()));
+                fail.error().message()));
         }
     }
 
@@ -171,7 +171,7 @@ public class MyInvitationsView extends LkPage {
             case MyInvitationsPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case MyInvitationsPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not accept invitation: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -184,7 +184,7 @@ public class MyInvitationsView extends LkPage {
             case MyInvitationsPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case MyInvitationsPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not decline invitation: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
@@ -96,7 +96,7 @@ public class SupportInboxView extends LkPage implements BeforeEnterObserver {
             case SupportInboxPresenter.Outcome.NotAuthenticated ignored -> showBanner(
                 "Your session has expired — please sign in again.");
             case SupportInboxPresenter.Outcome.Failure fail -> showBanner(
-                "Could not load your conversations: " + fail.reason());
+                fail.error().message());
         }
     }
 
@@ -182,7 +182,7 @@ public class SupportInboxView extends LkPage implements BeforeEnterObserver {
             case SupportInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case SupportInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminAnnouncementsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminAnnouncementsView.java
@@ -106,7 +106,7 @@ public class AdminAnnouncementsView extends LkPage {
             case AdminAnnouncementsPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminAnnouncementsPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send the announcement: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -124,7 +124,7 @@ public class AdminAnnouncementsView extends LkPage {
             case AdminAnnouncementsPresenter.Outcome.NotAuthenticated ignored -> historySlot.add(
                 banner("Your session has expired — please sign in again."));
             case AdminAnnouncementsPresenter.Outcome.Failure fail -> historySlot.add(
-                banner("Could not load announcement history: " + fail.reason()));
+                banner(fail.error().message()));
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintQueueView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintQueueView.java
@@ -79,7 +79,7 @@ public class AdminComplaintQueueView extends LkPage {
             case AdminComplaintQueuePresenter.Outcome.NotAuthenticated ignored -> showBanner(
                 "Your session has expired — please sign in again.");
             case AdminComplaintQueuePresenter.Outcome.Failure fail -> showBanner(
-                "Could not load the complaint queue: " + fail.reason());
+                fail.error().message());
         }
     }
 
@@ -182,7 +182,7 @@ public class AdminComplaintQueueView extends LkPage {
             case AdminComplaintQueuePresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminComplaintQueuePresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -195,7 +195,7 @@ public class AdminComplaintQueueView extends LkPage {
             case AdminComplaintQueuePresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminComplaintQueuePresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not resolve the complaint: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
@@ -70,7 +70,7 @@ public class AdminLoginView extends LkAuthCard {
             case AdminLoginPresenter.Outcome.Locked locked ->
                 Toasts.failure(locked.reason());
             case AdminLoginPresenter.Outcome.Failure fail ->
-                Toasts.failure("Sign-in failed: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
@@ -112,7 +112,7 @@ public class LoginView extends LkAuthCard {
             case LoginPresenter.Outcome.GuestSessionMissing miss ->
                 Toasts.failure("Session expired — please refresh the page. (" + miss.reason() + ")");
             case LoginPresenter.Outcome.Failure fail ->
-                Toasts.failure("Sign-in failed: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/RegisterView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/RegisterView.java
@@ -180,7 +180,7 @@ public class RegisterView extends LkAuthCard {
             case RegisterPresenter.Outcome.InvalidInput bad ->
                 Toasts.failure("Invalid input: " + bad.reason());
             case RegisterPresenter.Outcome.Failure fail ->
-                Toasts.failure("Registration failed: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -84,7 +84,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             case SeatPickerPresenter.LoadOutcome.NotFound nf ->
                 bodyHolder.add(infoBanner(nf.message()));
             case SeatPickerPresenter.LoadOutcome.Failure f ->
-                bodyHolder.add(infoBanner(f.message()));
+                bodyHolder.add(infoBanner(f.error().message()));
         }
     }
 
@@ -228,7 +228,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure(f.message());
+                Toasts.failure(f.error());
         }
     }
 
@@ -283,7 +283,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure(f.message());
+                Toasts.failure(f.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -79,7 +79,7 @@ public class CompanyEventListView extends LkPage {
             case CompanyEventListPresenter.Outcome.NotAuthenticated ignored ->
                 eventsCard.add(Lk.muted("Your session has expired — please sign in again."));
             case CompanyEventListPresenter.Outcome.Failure fail ->
-                eventsCard.add(Lk.muted("Could not load events: " + fail.reason()));
+                eventsCard.add(Lk.muted(fail.error().message()));
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryInboxView.java
@@ -88,7 +88,7 @@ public class CompanyInquiryInboxView extends LkPage {
             case CompanyInquiryInboxPresenter.Outcome.NotAuthenticated ignored -> showBanner(
                 "Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.Outcome.Failure fail -> showBanner(
-                "Could not load inquiries: " + fail.reason());
+                fail.error().message());
         }
     }
 
@@ -210,7 +210,7 @@ public class CompanyInquiryInboxView extends LkPage {
             case CompanyInquiryInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -223,7 +223,7 @@ public class CompanyInquiryInboxView extends LkPage {
             case CompanyInquiryInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not close the inquiry: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyRegistrationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyRegistrationView.java
@@ -101,7 +101,7 @@ public class CompanyRegistrationView extends LkPage {
             case CompanyRegistrationPresenter.Outcome.NameTaken taken ->
                 Toasts.failure(taken.reason());
             case CompanyRegistrationPresenter.Outcome.Failure fail ->
-                Toasts.failure("Registration failed: " + fail.reason());
+                Toasts.failure(fail.error());
         }
 
         if (outcome instanceof CompanyRegistrationPresenter.Outcome.Success) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -90,7 +90,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.LoadOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.LoadOutcome.Failure fail ->
-                Toasts.failure("Could not load event: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -147,7 +147,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.SaveOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.SaveOutcome.Failure fail ->
-                Toasts.failure("Could not save event: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -291,7 +291,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.CancelOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.CancelOutcome.Failure fail ->
-                Toasts.failure("Could not cancel event: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/ManagerInvitationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/ManagerInvitationView.java
@@ -110,7 +110,7 @@ private final ManagerInvitationPresenter presenter;
             case ManagerInvitationPresenter.Outcome.UserNotFound u ->
                 Toasts.failure("User \"" + u.username() + "\" was not found.");
             case ManagerInvitationPresenter.Outcome.Failure fail ->
-                Toasts.failure("Could not send invitation: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
     

--- a/src/main/java/com/ticketing/system/Presentation/views/company/ManagerListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/ManagerListView.java
@@ -73,7 +73,7 @@ public class ManagerListView extends LkPage {
             case ManagerListPresenter.Outcome.NotAuthenticated ignored -> content.add(banner(
                 "Your session has expired — please sign in again."));
             case ManagerListPresenter.Outcome.Failure fail -> content.add(banner(
-                "Could not load managers: " + fail.reason()));
+                fail.error().message()));
         }
     }
 
@@ -152,7 +152,7 @@ public class ManagerListView extends LkPage {
             case ManagerListPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case ManagerListPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not update permissions: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -165,7 +165,7 @@ public class ManagerListView extends LkPage {
             case ManagerListPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case ManagerListPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not revoke manager: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/MyCompaniesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/MyCompaniesView.java
@@ -43,7 +43,7 @@ public class MyCompaniesView extends LkPage {
             case Outcome.Success s                              -> add(buildGridCard(s.companies(), membershipPresenter));
             case Outcome.NotAuthenticated na                    -> add(buildEmptyState());
             case Outcome.Failure f -> {
-                Span msg = new Span("Could not load your companies: " + f.reason());
+                Span msg = new Span(f.error().message());
                 msg.getStyle().set("display", "block").set("margin-bottom", "12px").set("color", "#b91c1c");
                 add(msg);
                 add(buildEmptyState());

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
@@ -59,7 +59,7 @@ public class OwnerDashboardView extends LkPage {
             case OwnerDashboardPresenter.Outcome.NotAuthenticated ignored -> showBanner(
                 "Your session has expired — please sign in again.");
             case OwnerDashboardPresenter.Outcome.Failure fail -> showBanner(
-                "Could not load your workspace: " + fail.reason());
+                fail.error().message());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -186,7 +186,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
             case LoadOutcome.Failure f -> {
                 LkBanner err = new LkBanner(LkBanner.Tone.error,
                     new LkIcon("alert-circle", 16),
-                    "Could not load existing policy: " + f.reason());
+                    f.error().message());
                 LkBtn retry = new LkBtn("Retry").variant(LkBtn.Variant.secondary);
                 retry.addClickListener(ev -> { loadExistingPolicy(); rebuildTree(); });
                 err.setAction(retry);
@@ -566,7 +566,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         switch (presenter.save(AuthSession.token(), companyId, eventId, isEventLevel, nodeToDTO(root))) {
             case SaveOutcome.Success s -> Toasts.success("Policy saved.");
             case SaveOutcome.NotAuthenticated na -> Toasts.failure("Not authenticated.");
-            case SaveOutcome.Failure f -> Toasts.failure("Failed to save: " + f.reason());
+            case SaveOutcome.Failure f -> Toasts.failure(f.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
@@ -120,7 +120,7 @@ public class VenueMapEditorView extends LkPage implements BeforeEnterObserver {
             case VenueMapPresenter.LoadOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case VenueMapPresenter.LoadOutcome.Failure fail ->
-                Toasts.failure("Could not load the venue map: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 
@@ -449,7 +449,7 @@ public class VenueMapEditorView extends LkPage implements BeforeEnterObserver {
             case VenueMapPresenter.SaveOutcome.NoCompany ignored ->
                 Toasts.failure("You don't own a company — register one first.");
             case VenueMapPresenter.SaveOutcome.Failure fail ->
-                Toasts.failure("Could not save venue map: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/messaging/SubmitComplaintView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/messaging/SubmitComplaintView.java
@@ -96,7 +96,7 @@ public class SubmitComplaintView extends LkPage {
             case SubmitComplaintPresenter.Outcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case SubmitComplaintPresenter.Outcome.Failure fail ->
-                Toasts.failure("Could not submit complaint: " + fail.reason());
+                Toasts.failure(fail.error());
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
@@ -45,7 +45,7 @@ public class CartView extends LkPage {
             case CartPresenter.LoadOutcome.NotAuthenticated na -> clearCart();
             case CartPresenter.LoadOutcome.Failure f -> {
                 clearCart();
-                Toasts.failure("Could not load your cart: " + f.reason());
+                Toasts.failure(f.error());
             }
         }
 
@@ -113,7 +113,7 @@ public class CartView extends LkPage {
                         Toasts.success("Removed from cart.");
                     }
                     case CartPresenter.RemoveOutcome.Failure f ->
-                        Toasts.failure("Failed to remove item: " + f.reason());
+                        Toasts.failure(f.error());
                 }
             });
 

--- a/src/test/java/com/ticketing/system/unit/presentation/AdminAnnouncementsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/AdminAnnouncementsPresenterTest.java
@@ -119,7 +119,7 @@ class AdminAnnouncementsPresenterTest {
 
         AdminAnnouncementsPresenter.Outcome.Failure fail =
             assertInstanceOf(AdminAnnouncementsPresenter.Outcome.Failure.class, outcome);
-        assertEquals("history down", fail.reason());
+        assertEquals("history down", fail.error().message());
     }
 
     // -- send -----------------------------------------------------------------
@@ -162,7 +162,7 @@ class AdminAnnouncementsPresenterTest {
 
         AdminAnnouncementsPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(AdminAnnouncementsPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("Announcement matched no recipients", fail.reason());
+        assertEquals("Announcement matched no recipients", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/AdminComplaintQueuePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/AdminComplaintQueuePresenterTest.java
@@ -120,7 +120,7 @@ class AdminComplaintQueuePresenterTest {
 
         AdminComplaintQueuePresenter.Outcome.Failure fail =
             assertInstanceOf(AdminComplaintQueuePresenter.Outcome.Failure.class, outcome);
-        assertEquals("not an admin", fail.reason());
+        assertEquals("not an admin", fail.error().message());
     }
 
     // -- reply ----------------------------------------------------------------
@@ -156,7 +156,7 @@ class AdminComplaintQueuePresenterTest {
 
         AdminComplaintQueuePresenter.ActionOutcome.Failure fail =
             assertInstanceOf(AdminComplaintQueuePresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("conversation closed", fail.reason());
+        assertEquals("conversation closed", fail.error().message());
     }
 
     @Test
@@ -203,7 +203,7 @@ class AdminComplaintQueuePresenterTest {
 
         AdminComplaintQueuePresenter.ActionOutcome.Failure fail =
             assertInstanceOf(AdminComplaintQueuePresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("already resolved", fail.reason());
+        assertEquals("already resolved", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyInquiryInboxPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyInquiryInboxPresenterTest.java
@@ -125,7 +125,7 @@ class CompanyInquiryInboxPresenterTest {
 
         CompanyInquiryInboxPresenter.Outcome.Failure fail =
             assertInstanceOf(CompanyInquiryInboxPresenter.Outcome.Failure.class, outcome);
-        assertEquals("inbox down", fail.reason());
+        assertEquals("inbox down", fail.error().message());
     }
 
     // -- reply ----------------------------------------------------------------
@@ -160,7 +160,7 @@ class CompanyInquiryInboxPresenterTest {
 
         CompanyInquiryInboxPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(CompanyInquiryInboxPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("conversation closed", fail.reason());
+        assertEquals("conversation closed", fail.error().message());
     }
 
     @Test
@@ -200,7 +200,7 @@ class CompanyInquiryInboxPresenterTest {
 
         CompanyInquiryInboxPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(CompanyInquiryInboxPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("already closed", fail.reason());
+        assertEquals("already closed", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/LandingPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/LandingPresenterTest.java
@@ -57,6 +57,6 @@ class LandingPresenterTest {
 
         LandingPresenter.Outcome.Failure fail =
             assertInstanceOf(LandingPresenter.Outcome.Failure.class, outcome);
-        assertEquals("catalog down", fail.reason());
+        assertEquals("catalog down", fail.error().message());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/LoginPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/LoginPresenterTest.java
@@ -92,6 +92,6 @@ class LoginPresenterTest {
 
         LoginPresenter.Outcome.Failure fail =
             assertInstanceOf(LoginPresenter.Outcome.Failure.class, outcome);
-        assertEquals("database down", fail.reason());
+        assertEquals("database down", fail.error().message());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/ManagerListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/ManagerListPresenterTest.java
@@ -90,7 +90,7 @@ class ManagerListPresenterTest {
 
         ManagerListPresenter.Outcome.Failure fail =
             assertInstanceOf(ManagerListPresenter.Outcome.Failure.class, outcome);
-        assertEquals("backend down", fail.reason());
+        assertEquals("backend down", fail.error().message());
     }
 
     // -- editPermissions ------------------------------------------------------
@@ -128,7 +128,7 @@ class ManagerListPresenterTest {
 
         ManagerListPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(ManagerListPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("only the appointer may edit", fail.reason());
+        assertEquals("only the appointer may edit", fail.error().message());
     }
 
     @Test
@@ -174,7 +174,7 @@ class ManagerListPresenterTest {
 
         ManagerListPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(ManagerListPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("Cannot revoke appointment of the founder", fail.reason());
+        assertEquals("Cannot revoke appointment of the founder", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/MyInvitationsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/MyInvitationsPresenterTest.java
@@ -76,7 +76,7 @@ class MyInvitationsPresenterTest {
 
         MyInvitationsPresenter.Outcome.Failure fail =
             assertInstanceOf(MyInvitationsPresenter.Outcome.Failure.class, outcome);
-        assertEquals("backend down", fail.reason());
+        assertEquals("backend down", fail.error().message());
     }
 
     @Test
@@ -131,7 +131,7 @@ class MyInvitationsPresenterTest {
 
         MyInvitationsPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(MyInvitationsPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("no pending appointment", fail.reason());
+        assertEquals("no pending appointment", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/OwnerDashboardPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OwnerDashboardPresenterTest.java
@@ -107,6 +107,6 @@ class OwnerDashboardPresenterTest {
 
         OwnerDashboardPresenter.Outcome.Failure fail =
             assertInstanceOf(OwnerDashboardPresenter.Outcome.Failure.class, outcome);
-        assertEquals("backend down", fail.reason());
+        assertEquals("backend down", fail.error().message());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/RegisterPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/RegisterPresenterTest.java
@@ -141,6 +141,6 @@ class RegisterPresenterTest {
 
         RegisterPresenter.Outcome.Failure fail =
             assertInstanceOf(RegisterPresenter.Outcome.Failure.class, outcome);
-        assertEquals("database down", fail.reason());
+        assertEquals("database down", fail.error().message());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/SubmitComplaintPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SubmitComplaintPresenterTest.java
@@ -83,7 +83,7 @@ class SubmitComplaintPresenterTest {
 
         SubmitComplaintPresenter.Outcome.Failure fail =
             assertInstanceOf(SubmitComplaintPresenter.Outcome.Failure.class, outcome);
-        assertEquals("backend down", fail.reason());
+        assertEquals("backend down", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/SupportInboxPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SupportInboxPresenterTest.java
@@ -80,7 +80,7 @@ class SupportInboxPresenterTest {
 
         SupportInboxPresenter.Outcome.Failure fail =
             assertInstanceOf(SupportInboxPresenter.Outcome.Failure.class, outcome);
-        assertEquals("backend down", fail.reason());
+        assertEquals("backend down", fail.error().message());
     }
 
     @Test
@@ -124,7 +124,7 @@ class SupportInboxPresenterTest {
 
         SupportInboxPresenter.ActionOutcome.Failure fail =
             assertInstanceOf(SupportInboxPresenter.ActionOutcome.Failure.class, outcome);
-        assertEquals("conversation closed", fail.reason());
+        assertEquals("conversation closed", fail.error().message());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/UsernameAvailabilityPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/UsernameAvailabilityPresenterTest.java
@@ -67,6 +67,6 @@ class UsernameAvailabilityPresenterTest {
         when(memberQueryService.usernameExists("anyone")).thenThrow(new IllegalStateException("db down"));
 
         Outcome.Failure failure = assertInstanceOf(Outcome.Failure.class, presenter.check("anyone"));
-        assertEquals("db down", failure.reason());
+        assertEquals("db down", failure.error().message());
     }
 }

--- a/wire-up-plan.md
+++ b/wire-up-plan.md
@@ -16,6 +16,8 @@ V2 ships a Vaadin frontend whose every view talks to the real application servic
 
 ## The pattern (already in flight)
 
+> **Convention reference:** [docs/coding-standards.md](docs/coding-standards.md) — presenter outcome shapes, `ErrorPayload` factory methods, exception → `ErrorCode` mapping table, and `Toasts` usage rules.
+
 `#299` (V2-AUTH-01) shipped `LoginPresenter` / `RegisterPresenter` as Vaadin-free POJOs with sealed `Outcome` hierarchies. Every other write-side view inherits this shape:
 
 ```


### PR DESCRIPTION
close #255 
- Introduces `ErrorCode`, `ErrorPayload`, `ExceptionTranslator`, and a generic `Outcome<T>` sealed interface as the foundation for structured error handling across the presentation layer (V2-ERROR-01)
- Migrates all 21 presenters from `Failure(String reason)` to `Failure(ErrorPayload error)`, replacing ad-hoc `e.getMessage()` catch clauses with `ExceptionTranslator.toPayload(e)` which maps domain exceptions to typed error codes
- Adds `Toasts.failure(ErrorPayload)` overload that automatically chooses amber (retryable) or red (permanent) styling and shows a "Retry" button or "Learn more" link when applicable
- Updates all corresponding view call sites and presenter unit tests to use the new `fail.error()` accessor