### PR TITLE
fix(cart): CartView countdown passes Long to executeJs, crashing the cart

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
@@ -145,7 +145,7 @@ public class CartView extends LkPage {
             "  s--; " +
             "  window.cartTimerId = setTimeout(tick,1000);" +
             "}" +
-            "tick();", remainingSeconds);
+            "tick();", (int) remainingSeconds);   // Vaadin's JsonCodec can't encode Long — pass an int (a hold timer never overflows)
 
         timer.addDetachListener(ev ->
             timer.getElement().executeJs("if(window.cartTimerId) { clearTimeout(window.cartTimerId); }"));


### PR DESCRIPTION
## Bug
Holding tickets and opening the cart crashes:
```
java.lang.IllegalArgumentException: Can't encode class java.lang.Long to json
  at com.vaadin.flow.dom.Element.executeJs(...)
  at CartView.buildCountdownBanner(CartView.java:138)
```
→ `BeanCreationException` instantiating `CartView` → navigation to the cart fails.

## Root cause
`buildCountdownBanner(long remainingSeconds)` passed the `long` straight into `executeJs(...)`. Java autoboxes it to `Long`, and Vaadin's `JsonCodec` can't encode `Long` (only `String` / `Boolean` / `Integer` / `Double` / `JsonValue` / `Element` / `Component`). So the expiry countdown threw whenever the cart had a held line.

## Fix
Cast to `int` — a hold timer is ~600s, far below `int` overflow. One line.

The other two countdown timers (`CheckoutView:227`, `LkTopBar:197`) already pass a `double`, so they were unaffected — `CartView` was the lone offender.

## Why it escaped CI
`VaadinSmokeTest` constructs `CartView` with an **empty** cart, so the countdown branch never ran; and the seeder only reserves on the backend, never rendering the view. A smoke test that builds `CartView` with a non-empty active order would catch this class of bug (suggested follow-up).

## Verification
`./mvnw -o -Pno-vaadin compile` → clean.