### PR TITLE
V2 wire-up: EventDetails, Receipt, member refund, top-bar search, server-side Browse filters (#272, #276, #284, #281, #271)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/EventDetailDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/EventDetailDTO.java
@@ -20,5 +20,6 @@ public record EventDetailDTO(
     String companyId,
     String companyName,
     EventStatus status,                     // EventStatus value as string
-    List<ShowDate> showDates
+    List<ShowDate> showDates,
+    List<String> artistsNames               // lineup (Event.getArtistsNames())
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/dto/SearchResultDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/SearchResultDTO.java
@@ -1,0 +1,11 @@
+package com.ticketing.system.Core.Application.dto;
+
+// One row of the top-bar search (V2-SEARCH-01 / #281). Covers events, artists, and venues; every
+// row carries the representative event to open, since there are no dedicated artist/venue pages —
+// each row navigates to that event's EventDetailsView.
+public record SearchResultDTO(
+    String type,      // "EVENT" | "ARTIST" | "VENUE" — drives grouping + icon in the panel
+    String title,     // event name / artist name / venue location
+    String subtitle,  // secondary context (company name, or "Artist · {event}" / "Venue · {event}")
+    int eventId       // representative event to open
+) {}

--- a/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
@@ -1,10 +1,12 @@
 package com.ticketing.system.Core.Application.dtoMappers;
 
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.dto.ShowDateDTO;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.Location;
 
 public class EventMapper {
 
@@ -29,6 +31,26 @@ public class EventMapper {
                 minPrice,
                 maxPrice,
                 event.getStatus() == EventStatus.SOLD_OUT);
+    }
+
+
+    // HELPER METHOD to convert Event --> EventDetailDTO (full detail, incl. lineup).
+    // Used by EventManagementService (owner-side) and CatalogService (guest-side); the
+    // caller resolves the company name since the two services reach the company differently.
+    public EventDetailDTO toEventDetailDTO(Event event, String companyName) {
+        Location location = event.getVenueMap() != null ? event.getVenueMap().getLocation() : null;
+        return new EventDetailDTO(
+                String.valueOf(event.getId()),
+                event.getName(),
+                event.getRating(),
+                event.getDescription(),
+                event.getCategory(),
+                location,
+                String.valueOf(event.getCompanyId()),
+                companyName,
+                event.getStatus(),
+                event.getShowDates(),
+                event.getArtistsNames());
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -221,18 +221,24 @@ public class CatalogService {
         Set<String> seenVenues = new LinkedHashSet<>();
 
         for (Event event : eventRepository.findByStatus(EventStatus.ON_SALE)) {
+            if (events.size() >= limit && artists.size() >= limit && venues.size() >= limit) {
+                break; // every bucket is full — nothing more can surface
+            }
             ProductionCompany company = activeCompanyOrNull(event.getCompanyId());
             if (company == null) {
                 continue; // closed / unknown company — not publicly visible
             }
 
             String eventName = event.getName();
-            if (eventName != null && eventName.toLowerCase().contains(q)) {
+            if (events.size() < limit && eventName != null && eventName.toLowerCase().contains(q)) {
                 events.add(new SearchResultDTO("EVENT", eventName, company.getName(), event.getId()));
             }
 
-            if (event.getArtistsNames() != null) {
+            if (artists.size() < limit && event.getArtistsNames() != null) {
                 for (String artist : event.getArtistsNames()) {
+                    if (artists.size() >= limit) {
+                        break;
+                    }
                     if (artist != null && artist.toLowerCase().contains(q)
                             && seenArtists.add(artist.toLowerCase())) {
                         artists.add(new SearchResultDTO("ARTIST", artist, "Artist · " + eventName, event.getId()));
@@ -241,7 +247,8 @@ public class CatalogService {
             }
 
             String venue = venueLabel(event);
-            if (venue != null && venue.toLowerCase().contains(q) && seenVenues.add(venue.toLowerCase())) {
+            if (venues.size() < limit && venue != null && venue.toLowerCase().contains(q)
+                    && seenVenues.add(venue.toLowerCase())) {
                 venues.add(new SearchResultDTO("VENUE", venue, "Venue · " + eventName, event.getId()));
             }
         }

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -13,6 +13,7 @@ import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapDTO;
 import com.ticketing.system.Core.Application.dtoMappers.VenueMapMapper;
@@ -323,7 +324,42 @@ public class CatalogService {
 
             log.info("Venue map found for eventId: {} while getting venue map and being returned", eventId);
             return new VenueMapMapper().venueMapToVenueMapDTO(event.getVenueMap());
-        
+
     }
-    
+
+
+    // UC-8: Public single-event detail for the buyer event page (header, description, schedule, lineup).
+    // Accepts either a JWT (Member) or a raw sessionId (Guest) — same audience as browse / getEventVenueMap.
+    public EventDetailDTO getEventDetail(String credential, int eventId) {
+        log.info("Fetching event detail for eventId: {}", eventId);
+
+        if (!this.sessionManager.validateCredential(credential)) {
+            log.warn("Invalid credential provided while getting event detail for eventId: {}", eventId);
+            throw new InvalidTokenException();
+        }
+
+        Event event = this.eventRepository.findById(eventId);
+        if (event == null) {
+            log.warn("Event not found while getting event detail: {}", eventId);
+            throw new EventNotFoundException("Event with ID " + eventId + " not found while getting event detail");
+        }
+
+        // Enforce company status is ACTIVE — closed companies' events are not publicly visible.
+        ProductionCompany company = productionCompanyRepository.getCompanyById(event.getCompanyId());
+        if (company == null || company.getStatus() != CompanyStatus.ACTIVE) {
+            log.warn("Attempt to access event detail for eventId: {} from inactive company", eventId);
+            throw new CompanyClosedException("Event with ID " + eventId + " not found while getting event detail");
+        }
+
+        // DRAFT / SCHEDULED events are not yet public; ON_SALE / SOLD_OUT / CANCELED / COMPLETED are viewable
+        // (the buyer page renders a status badge and disables purchasing for the non-purchasable ones).
+        if (event.getStatus() == EventStatus.DRAFT || event.getStatus() == EventStatus.SCHEDULED) {
+            log.warn("Attempt to access non-public event detail (status {}) for eventId: {}", event.getStatus(), eventId);
+            throw new EventNotFoundException("Event with ID " + eventId + " not found while getting event detail");
+        }
+
+        log.info("Event detail found for eventId: {} and being returned", eventId);
+        return new EventMapper().toEventDetailDTO(event, company.getName());
+    }
+
 }

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -3,7 +3,9 @@ package com.ticketing.system.Core.Application.services;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -15,6 +17,7 @@ import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
+import com.ticketing.system.Core.Application.dto.SearchResultDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapDTO;
 import com.ticketing.system.Core.Application.dtoMappers.VenueMapMapper;
 import com.ticketing.system.Core.Application.dtoMappers.EventMapper;
@@ -190,6 +193,77 @@ public class CatalogService {
                 companyId, effectiveFilters, results.size());
 
         return results;
+    }
+
+
+
+
+    //* V2-SEARCH-01 (#281): Top-bar search across events, artists, and venues. Accepts a JWT (Member)
+    //* or a raw sessionId (Guest) — same audience as browse/search. Matches the query (case-insensitive
+    //* substring) over publicly-visible ON_SALE events from ACTIVE companies and emits typed rows;
+    //* artists/venues are de-duplicated. There are no dedicated artist/venue pages, so every row points
+    //* at a representative event (its EventDetailsView). Results are round-robined across the three types
+    //* so one kind can't crowd out the others, then capped to {limit}.
+    public List<SearchResultDTO> search(String credential, String query, int limit) {
+        if (!this.sessionManager.validateCredential(credential)) {
+            log.warn("Invalid credential provided while performing top-bar search");
+            throw new InvalidTokenException();
+        }
+        String q = query == null ? "" : query.trim().toLowerCase();
+        if (q.isEmpty() || limit <= 0) {
+            return List.of();
+        }
+
+        List<SearchResultDTO> events = new ArrayList<>();
+        List<SearchResultDTO> artists = new ArrayList<>();
+        List<SearchResultDTO> venues = new ArrayList<>();
+        Set<String> seenArtists = new LinkedHashSet<>();
+        Set<String> seenVenues = new LinkedHashSet<>();
+
+        for (Event event : eventRepository.findByStatus(EventStatus.ON_SALE)) {
+            ProductionCompany company = activeCompanyOrNull(event.getCompanyId());
+            if (company == null) {
+                continue; // closed / unknown company — not publicly visible
+            }
+
+            String eventName = event.getName();
+            if (eventName != null && eventName.toLowerCase().contains(q)) {
+                events.add(new SearchResultDTO("EVENT", eventName, company.getName(), event.getId()));
+            }
+
+            if (event.getArtistsNames() != null) {
+                for (String artist : event.getArtistsNames()) {
+                    if (artist != null && artist.toLowerCase().contains(q)
+                            && seenArtists.add(artist.toLowerCase())) {
+                        artists.add(new SearchResultDTO("ARTIST", artist, "Artist · " + eventName, event.getId()));
+                    }
+                }
+            }
+
+            String venue = venueLabel(event);
+            if (venue != null && venue.toLowerCase().contains(q) && seenVenues.add(venue.toLowerCase())) {
+                venues.add(new SearchResultDTO("VENUE", venue, "Venue · " + eventName, event.getId()));
+            }
+        }
+
+        List<SearchResultDTO> results = new ArrayList<>();
+        boolean added = true;
+        for (int i = 0; results.size() < limit && added; i++) {
+            added = false;
+            if (i < events.size())  { results.add(events.get(i));  added = true; if (results.size() == limit) break; }
+            if (i < artists.size()) { results.add(artists.get(i)); added = true; if (results.size() == limit) break; }
+            if (i < venues.size())  { results.add(venues.get(i));  added = true; if (results.size() == limit) break; }
+        }
+        log.info("Top-bar search for '{}' returning {} results", q, results.size());
+        return results;
+    }
+
+    // *HELPER METHOD* — "city, country" label for an event's venue, or null if it has no location.
+    private String venueLabel(Event event) {
+        if (event.getVenueMap() == null || event.getVenueMap().getLocation() == null) {
+            return null;
+        }
+        return event.getVenueMap().getLocation().toString();
     }
 
     

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -25,6 +25,7 @@ import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Core.Application.dto.ShowDateDTO;
 import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
 import com.ticketing.system.Core.Application.dto.VenueLayoutDTO;
+import com.ticketing.system.Core.Application.dtoMappers.EventMapper;
 import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
 import com.ticketing.system.Core.Application.dto.ZoneDetailDTO;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
@@ -166,17 +167,7 @@ public class EventManagementService {
         eventRepository.save(newEvent);
 
         log.info("Event {} created successfully with ID {}", request.name(), newEventId);
-        return new EventDetailDTO(
-                String.valueOf(newEventId),
-                newEvent.getName(),
-                newEvent.getRating(),
-                newEvent.getDescription(),
-                newEvent.getCategory(),
-                request.location(),
-                String.valueOf(newEvent.getCompanyId()),
-                company.getName(),
-                newEvent.getStatus(),
-                newEvent.getShowDates());
+        return new EventMapper().toEventDetailDTO(newEvent, company.getName());
     }
 
 
@@ -187,19 +178,9 @@ public class EventManagementService {
         user.requirePermissionInCompany(companyId, Permission.MANAGE_INVENTORY);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
 
+        EventMapper mapper = new EventMapper();
         return eventRepository.findByCompanyId(companyId).stream()
-            .map(e -> new EventDetailDTO(
-                String.valueOf(e.getId()),
-                e.getName(),
-                e.getRating(),
-                e.getDescription(),
-                e.getCategory(),
-                e.getVenueMap() != null ? e.getVenueMap().getLocation() : null,
-                String.valueOf(companyId),
-                company.getName(),
-                e.getStatus(),
-                e.getShowDates()
-            ))
+            .map(e -> mapper.toEventDetailDTO(e, company.getName()))
             .toList();
     }
 
@@ -707,20 +688,7 @@ public class EventManagementService {
         User user = userRepository.getUserById(userId);
         user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
 
-        Location location = event.getVenueMap() != null ? event.getVenueMap().getLocation() : null;
-
-        return new EventDetailDTO(
-                String.valueOf(event.getId()),
-                event.getName(),
-                event.getRating(),
-                event.getDescription(),
-                event.getCategory(),
-                location,
-                String.valueOf(event.getCompanyId()),
-                company.getName(),
-                event.getStatus(),
-                event.getShowDates()
-        );
+        return new EventMapper().toEventDetailDTO(event, company.getName());
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
@@ -7,6 +7,9 @@ import com.ticketing.system.Core.Application.dtoMappers.OrderReceiptMapper;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 
@@ -76,6 +79,31 @@ public class MemberAccountService {
                     authenticationService.extractUserId(authToken.token()), e.getMessage(), e);
         }
         return new PurchaseHistoryDTO(new ArrayList<>()); // Return empty history on failure.
+    }
+
+    // UC-16 (single receipt): one member-owned order, enriched for the receipt page (#276).
+    // Unlike viewMyHistory (which degrades to an empty list), this THROWS so the presenter can
+    // tell apart auth failure, a missing receipt, and a receipt that isn't the caller's (403).
+    public PurchaseRecordDTO viewMyReceipt(String token, int receiptId) {
+        log.info("Received request to view receipt {} for the authenticated member", receiptId);
+        if (!authenticationService.validateToken(token)) {
+            throw new InvalidTokenException();
+        }
+        int userId = authenticationService.extractUserId(token);
+
+        OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(receiptId)
+                .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", receiptId));
+
+        // Authorization is a domain concern: a member may only view their own receipt.
+        Integer holderUserId = receipt.getHolderUserId();
+        if (holderUserId == null || holderUserId != userId) {
+            throw new UnauthorizedActionException("view receipt " + receiptId, userId);
+        }
+
+        // Buyer is the member themselves and company isn't shown on the receipt, so pass null for
+        // those repos (the mapper yields null for the unresolved names — see OrderReceiptMapper).
+        return new OrderReceiptMapper().toPurchaseRecordDTO(
+                receipt, ticketRepository, eventRepository, null, null);
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
@@ -64,7 +64,9 @@ public class RefundService {
      * @throws RefundFailedException          the gateway refund failed / no original charge
      */
     public RefundResultDTO requestRefund(String token, int orderId, String reason) {
-        log.info("Member refund requested for order {} (reason: {})", orderId, reason);
+        // Don't log the raw reason — it's user free-text and may carry sensitive data; length only.
+        log.info("Member refund requested for order {} (reason length: {})",
+                orderId, reason == null ? 0 : reason.length());
         if (!authenticationService.validateToken(token)) {
             throw new InvalidTokenException();
         }

--- a/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
@@ -1,0 +1,132 @@
+package com.ticketing.system.Core.Application.services;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+import com.ticketing.system.Core.Domain.orders.TransactionRecord;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Member-initiated refund of one owned order (I.3.3 / #64, #284). The owner/admin side of refunds
+ * lives elsewhere ({@link EventManagementService#cancelEventAndRefund}); this is the buyer's
+ * "Request refund" path from {@code ReceiptView} / {@code MyAccountView}.
+ *
+ * <p>Mirrors the cancellation refund mechanics, scoped to a single member-owned receipt: charge
+ * the gateway refund first, then flip the receipt + its tickets to refunded. Refunds are
+ * <strong>immediate</strong> (no request lifecycle exists in the domain) and whole-order (the
+ * receipt's refunded flag is all-or-nothing). It deliberately dispatches <strong>no</strong>
+ * notification — real-time notifications (I.5) are a Grade ג' V2 exemption, which also keeps this
+ * flow clear of the unimplemented {@code NotificationDispatchService.dispatchFromEvent} (#304).
+ *
+ * <p>Throws typed domain exceptions; the presenter translates them into UI outcomes.
+ */
+@Service
+@Slf4j
+public class RefundService {
+
+    private final AuthenticationService authenticationService;
+    private final IOrderReceiptRepository orderReceiptRepository;
+    private final ITicketRepository ticketRepository;
+    private final IPaymentGateway paymentGateway;
+
+    public RefundService(
+            AuthenticationService authenticationService,
+            IOrderReceiptRepository orderReceiptRepository,
+            ITicketRepository ticketRepository,
+            IPaymentGateway paymentGateway) {
+        this.authenticationService = authenticationService;
+        this.orderReceiptRepository = orderReceiptRepository;
+        this.ticketRepository = ticketRepository;
+        this.paymentGateway = paymentGateway;
+    }
+
+    /**
+     * Refunds the whole order identified by {@code orderId} on behalf of the authenticated member.
+     *
+     * @throws InvalidTokenException          token missing/invalid
+     * @throws EntityNotFoundException        no such receipt
+     * @throws UnauthorizedActionException    the receipt isn't the caller's (403)
+     * @throws BusinessRuleViolationException the order isn't refund-eligible (already refunded)
+     * @throws RefundFailedException          the gateway refund failed / no original charge
+     */
+    public RefundResultDTO requestRefund(String token, int orderId, String reason) {
+        log.info("Member refund requested for order {} (reason: {})", orderId, reason);
+        if (!authenticationService.validateToken(token)) {
+            throw new InvalidTokenException();
+        }
+        int userId = authenticationService.extractUserId(token);
+
+        OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(orderId)
+                .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", orderId));
+
+        Integer holderUserId = receipt.getHolderUserId();
+        if (holderUserId == null || holderUserId != userId) {
+            throw new UnauthorizedActionException("refund order " + orderId, userId);
+        }
+
+        if (receipt.wasRefunded()) {
+            throw new BusinessRuleViolationException("Order " + orderId + " has already been refunded");
+        }
+
+        double refundAmount = receipt.getTotalAmount();
+        // Charge the gateway BEFORE touching domain state — we never want a receipt marked refunded
+        // while the gateway disagrees.
+        int paymentTransactionId = receipt.getPaymentTransactionId()
+                .orElseThrow(() -> new RefundFailedException(orderId, "receipt does not contain a payment transaction"));
+
+        RefundResultDTO refundResult = paymentGateway.refund(paymentTransactionId, refundAmount);
+        validateRefundResult(orderId, refundAmount, refundResult);
+
+        receipt.markRefunded(TransactionRecord.refund(
+                refundResult.refundTransactionId(),
+                paymentGateway.getId(),
+                refundResult.totalRefunded(),
+                receipt.getPaymentCurrency(),
+                refundResult.refundedAt()));
+        orderReceiptRepository.save(receipt);
+
+        // PAID/ISSUED tickets become REFUNDED; anything else (e.g. reserved-but-unissued) is voided.
+        List<Ticket> tickets = ticketRepository.findByOrderReceiptId(orderId);
+        for (Ticket ticket : tickets) {
+            if (ticket.getStatus() == TicketStatus.PAID || ticket.getStatus() == TicketStatus.ISSUED) {
+                ticket.markRefunded();
+            } else {
+                ticket.markVoided();
+            }
+            ticketRepository.save(ticket);
+        }
+
+        log.info("Member refund completed for order {} — {} refunded (ref {})",
+                orderId, refundResult.totalRefunded(), refundResult.refundTransactionId());
+        return refundResult;
+    }
+
+    private void validateRefundResult(int receiptId, double expectedRefundAmount, RefundResultDTO refundResult) {
+        if (refundResult == null) {
+            throw new RefundFailedException(receiptId, "payment gateway returned null refund result");
+        }
+        if (refundResult.refundTransactionId() == null || refundResult.refundTransactionId().isBlank()) {
+            throw new RefundFailedException(receiptId, "refund transaction id is missing");
+        }
+        if (Math.abs(refundResult.totalRefunded() - expectedRefundAmount) > 0.0001) {
+            throw new RefundFailedException(receiptId, "refund amount mismatch");
+        }
+        if (refundResult.refundedAt() == null) {
+            throw new RefundFailedException(receiptId, "refund timestamp is missing");
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/components/buyer/BzRefundDialog.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/buyer/BzRefundDialog.java
@@ -1,94 +1,49 @@
 package com.ticketing.system.Presentation.components.buyer;
 
-import com.ticketing.system.Presentation.components.Toasts;
-import com.ticketing.system.Presentation.components.kit.Lk;
+import java.util.function.Consumer;
+
 import com.ticketing.system.Presentation.components.kit.LkBanner;
-import com.ticketing.system.Presentation.components.kit.LkCol;
+import com.ticketing.system.Presentation.components.kit.LkConfirm;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
-import com.ticketing.system.Presentation.components.kit.LkSelect;
-import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.button.ButtonVariant;
-import com.vaadin.flow.component.dialog.Dialog;
-import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.TextArea;
 
-import java.util.List;
-
 /**
- * Refund-request modal — ticket summary, reason picker, optional notes,
- * policy banner, and Cancel / Request-refund actions. Submission is
- * mocked (toast only) until V2-RES-04 wires
- * {@code ReservationService.requestRefund}.
+ * Member refund-request confirm (V2-DLG-01 / #284). A thin reusable wrapper over {@link LkConfirm}
+ * that adds a reason {@link TextArea} and, on confirm, hands the reason back to the caller — which
+ * runs the actual refund through {@code RefundPresenter}. Shared by {@code ReceiptView} and
+ * {@code MyAccountView} so the confirm UX lives in one place.
  */
 public final class BzRefundDialog {
 
     private BzRefundDialog() { }
 
-    public static void show(BzTicketDialog.TicketInfo ticket) {
-        Dialog d = new Dialog();
-        d.setHeaderTitle("Request a refund");
-        d.setWidth("460px");
-        d.setMaxWidth("92vw");
+    /**
+     * Opens the refund confirm for one order. {@code onConfirm} is invoked (with the typed reason)
+     * only if the member confirms; it is never called on cancel/dismiss.
+     */
+    public static void open(String orderLabel, double amount, Consumer<String> onConfirm) {
+        TextArea reason = new TextArea("Reason for refund");
+        reason.setPlaceholder("Optional — tell us why (helps the organizer).");
+        reason.setMinHeight("80px");
+        reason.setWidthFull();
 
-        LkCol col = new LkCol().gap(14);
-        col.add(buildTicketSummary(ticket));
-
-        LkSelect reason = new LkSelect("Event cancelled", List.of(
-            "Event cancelled",
-            "I can no longer attend",
-            "Duplicate purchase",
-            "Wrong ticket",
-            "Other"
-        )).label("Reason for refund").required();
-        col.add(reason);
-
-        TextArea notes = new TextArea("Additional details (optional)");
-        notes.setPlaceholder("Anything else we should know…");
-        notes.setMinHeight("80px");
-        notes.setWidthFull();
-        col.add(notes);
-
-        col.add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 17),
-            "Refunds are processed in 3–5 business days. The event organizer is notified."));
-
-        d.add(col);
-
-        Button cancel = new Button("Cancel", e -> d.close());
-        cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
-
-        Button submit = new Button("Request refund", e -> {
-            Toasts.success("Refund requested for " + ticket.zone() + " · " + ticket.seat()
-                + " — we'll email when it's processed.");
-            d.close();
-        });
-        submit.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
-
-        d.getFooter().add(cancel, submit);
-        d.open();
+        new LkConfirm("Request a refund",
+                "Refund order " + orderLabel + " (" + money(amount) + ")? "
+                    + "Approved refunds are processed in 3–5 business days.",
+                LkConfirm.Severity.warn)
+            .confirmText("Request refund")
+            .addToBody(reason,
+                new LkBanner(LkBanner.Tone.info, new LkIcon("info", 17),
+                    "The event organizer is notified of your request."))
+            .prompt()
+            .thenAccept(ok -> {
+                if (Boolean.TRUE.equals(ok)) {
+                    onConfirm.accept(reason.getValue());
+                }
+            });
     }
 
-    private static Div buildTicketSummary(BzTicketDialog.TicketInfo t) {
-        Div summary = new Div();
-        summary.getStyle()
-            .set("background", "#f8fafc")
-            .set("border", "1px solid var(--border)")
-            .set("border-radius", "10px")
-            .set("padding", "14px 16px");
-
-        Span title = new Span();
-        title.getElement().setProperty("innerHTML", "<b>" + escape(t.event()) + "</b>");
-        title.getStyle().set("display", "block").set("color", "#0f172a");
-
-        Span line = Lk.muted(t.zone() + " · " + t.seat() + " · " + t.price()
-            + (t.date() == null ? "" : " · " + t.date()));
-        line.getStyle().set("font-size", "13px").set("display", "block").set("margin-top", "4px");
-
-        summary.add(title, line);
-        return summary;
-    }
-
-    private static String escape(String s) {
-        return s == null ? "" : s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    private static String money(double amount) {
+        return String.format("$%,.2f", amount);
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/components/buyer/BzRefundDialog.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/buyer/BzRefundDialog.java
@@ -23,7 +23,7 @@ public final class BzRefundDialog {
      */
     public static void open(String orderLabel, double amount, Consumer<String> onConfirm) {
         TextArea reason = new TextArea("Reason for refund");
-        reason.setPlaceholder("Optional — tell us why (helps the organizer).");
+        reason.setPlaceholder("Optional — for your records.");
         reason.setMinHeight("80px");
         reason.setWidthFull();
 
@@ -34,10 +34,10 @@ public final class BzRefundDialog {
             .confirmText("Request refund")
             .addToBody(reason,
                 new LkBanner(LkBanner.Tone.info, new LkIcon("info", 17),
-                    "The event organizer is notified of your request."))
+                    "Refunds are returned to your original payment method."))
             .prompt()
             .thenAccept(ok -> {
-                if (Boolean.TRUE.equals(ok)) {
+                if (Boolean.TRUE.equals(ok) && onConfirm != null) {
                     onConfirm.accept(reason.getValue());
                 }
             });

--- a/src/main/java/com/ticketing/system/Presentation/components/kit/LkSearchPanel.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/kit/LkSearchPanel.java
@@ -3,19 +3,35 @@ package com.ticketing.system.Presentation.components.kit;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * Search popover panel — recent-search chip row + grouped result lists.
- * Ports the React {@code SearchPanel}. Static {@link #defaults()}
- * factory returns the reference content.
+ *
+ * <p>Two flavours:
+ * <ul>
+ *   <li>the original <b>static</b> {@code (recents, groups)} constructor + {@link #defaults()},
+ *       a render-only reference panel; and</li>
+ *   <li>the <b>live</b> {@code (recents, searchFn)} constructor (V2-SEARCH-01 / #281) — a debounced
+ *       {@link TextField} that calls {@code searchFn} and renders typed rows, an empty state, and a
+ *       zero-results state. The kit stays framework-pure: callers inject a
+ *       {@code Function<String, List<Row>>} and each {@link Row} carries its own navigation
+ *       {@code onPick} {@link Runnable}, so the panel needs no application DTOs.</li>
+ * </ul>
  */
 public class LkSearchPanel extends Div {
 
     public record Result(String title, String detail) { }
     public record Group(String label, String iconName, List<Result> items) { }
 
+    /** A live result row: {@code type} drives grouping/icon; {@code onPick} runs on click. */
+    public record Row(String type, String title, String subtitle, Runnable onPick) { }
+
+    // ---- static reference panel (render-only) ----
     public LkSearchPanel(List<String> recents, List<Group> groups) {
         addClassName("lk-searchpop");
 
@@ -56,6 +72,105 @@ public class LkSearchPanel extends Div {
             }
             add(sect);
         }
+    }
+
+    // ---- live, backend-driven panel (#281) ----
+    public LkSearchPanel(List<String> recents, Function<String, List<Row>> searchFn) {
+        addClassName("lk-searchpop");
+
+        TextField input = new TextField();
+        input.addClassName("lk-search-input");
+        input.setPlaceholder("Search events, artists, venues…");
+        input.setClearButtonVisible(true);
+        input.setWidthFull();
+        input.setValueChangeMode(ValueChangeMode.LAZY);
+        input.setValueChangeTimeout(200);   // 200ms debounce
+        input.setPrefixComponent(new LkIcon("search", 16));
+        add(input);
+
+        Div results = new Div();
+        results.addClassName("lk-search-results");
+        add(results);
+
+        input.addValueChangeListener(e -> renderLive(results, input, recents, searchFn, e.getValue()));
+        renderLive(results, input, recents, searchFn, "");   // initial: recents / empty hint
+    }
+
+    private void renderLive(Div container, TextField input, List<String> recents,
+                            Function<String, List<Row>> searchFn, String raw) {
+        container.removeAll();
+        String q = raw == null ? "" : raw.trim();
+        if (q.isEmpty()) {
+            renderRecents(container, input, recents);
+            return;
+        }
+        List<Row> rows = searchFn.apply(q);
+        if (rows == null || rows.isEmpty()) {
+            container.add(emptyState("No matches for “" + q + "”"));
+            return;
+        }
+        renderGroup(container, "Events",  "ticket", rows, "EVENT");
+        renderGroup(container, "Artists", "mic",    rows, "ARTIST");
+        renderGroup(container, "Venues",  "map",    rows, "VENUE");
+    }
+
+    private void renderRecents(Div container, TextField input, List<String> recents) {
+        if (recents == null || recents.isEmpty()) {
+            container.add(emptyState("Start typing to search events, artists, and venues."));
+            return;
+        }
+        Div sect = new Div();
+        sect.addClassName("lk-search-recent");
+        sect.add(new LkMenu.Label("Recent searches"));
+        Div chips = new Div();
+        chips.addClassName("lk-recent-chips");
+        for (String r : recents) {
+            Span chip = new Span();
+            chip.addClassName("lk-recent-chip");
+            chip.getStyle().set("cursor", "pointer");
+            chip.add(new LkIcon("clock", 12));
+            chip.add(new Span(r));
+            chip.getElement().addEventListener("click", e -> input.setValue(r)); // re-runs the search
+            chips.add(chip);
+        }
+        sect.add(chips);
+        container.add(sect);
+    }
+
+    private void renderGroup(Div container, String label, String iconName, List<Row> rows, String type) {
+        List<Row> matching = rows.stream().filter(r -> type.equals(r.type())).toList();
+        if (matching.isEmpty()) return;
+
+        Div sect = new Div();
+        sect.addClassName("lk-search-group");
+        sect.add(new LkMenu.Label(label));
+        for (Row it : matching) {
+            NativeButton row = new NativeButton();
+            row.addClassName("lk-search-res");
+            Span ico = new Span();
+            ico.addClassName("lk-search-res-ic");
+            ico.add(new LkIcon(iconName, 16));
+            Span body = new Span();
+            body.addClassName("lk-search-res-body");
+            Span t = new Span(it.title());    t.addClassName("lk-search-res-t");
+            Span d = new Span(it.subtitle()); d.addClassName("lk-search-res-d");
+            body.add(t, d);
+            LkIcon go = new LkIcon("arrowRight", 15);
+            go.addClassName("lk-search-res-go");
+            row.add(ico, body, go);
+            if (it.onPick() != null) {
+                row.addClickListener(e -> it.onPick().run());
+            }
+            sect.add(row);
+        }
+        container.add(sect);
+    }
+
+    private static Div emptyState(String message) {
+        Div empty = new Div();
+        empty.addClassName("lk-search-empty");
+        empty.setText(message);
+        return empty;
     }
 
     public static LkSearchPanel defaults() {

--- a/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
@@ -1,7 +1,6 @@
 package com.ticketing.system.Presentation.layouts;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
-import com.ticketing.system.Core.Application.dto.SearchResultDTO;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;

--- a/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
@@ -1,10 +1,13 @@
 package com.ticketing.system.Presentation.layouts;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
+import com.ticketing.system.Core.Application.dto.SearchResultDTO;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
+import com.ticketing.system.Presentation.components.kit.LkSearchPanel;
 import com.ticketing.system.Presentation.components.kit.LkTopBar;
+import com.ticketing.system.Presentation.presenters.catalog.SearchPresenter;
 import com.ticketing.system.Presentation.security.Capabilities;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.SignOutFlow;
@@ -63,11 +66,14 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
     private LkTopBar topBar;
     private final SignOutFlow signOutFlow;
     private final SessionIdentity identity;
+    private final SearchPresenter searchPresenter;
 
-    public MainLayout(ReservationService reservationService, SignOutFlow signOutFlow, SessionIdentity identity) {
+    public MainLayout(ReservationService reservationService, SignOutFlow signOutFlow,
+                      SessionIdentity identity, SearchPresenter searchPresenter) {
         this.reservationService = reservationService;
         this.signOutFlow = signOutFlow;
         this.identity = identity;
+        this.searchPresenter = searchPresenter;
         rebuildTopBar(null);
     }
 
@@ -132,7 +138,7 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
     LkTopBar bar = new LkTopBar(LkTopBar.Variant.MAIN)
         .brand("TicketHub", LandingView.class)
         .nav(nav, activeLabel)
-        .searchDefault()
+        .search(buildSearchPanel())
         .cart(CartView.class, cartSize, cartDeadlineMs)
         .bellDefault(false);
 
@@ -145,6 +151,22 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
     topBar = bar;
     addToNavbar(topBar);
 }
+
+    /**
+     * Live top-bar search panel (#281). Backs the kit {@link LkSearchPanel} with
+     * {@link SearchPresenter}: the debounced input runs a catalog search via the current
+     * credential, each row records the query as a recent search and opens the event's detail page.
+     */
+    private LkSearchPanel buildSearchPanel() {
+        return new LkSearchPanel(
+            searchPresenter.recents(),
+            query -> searchPresenter.search(identity.credential(), query).stream()
+                .map(r -> new LkSearchPanel.Row(r.type(), r.title(), r.subtitle(), () -> {
+                    searchPresenter.record(query);
+                    UI.getCurrent().navigate("events/" + r.eventId());
+                }))
+                .toList());
+    }
 
     /** Member-persona account menu — wired to {@link AuthSession} + view routes. */
     private LkAccountMenu buildMemberMenu(String name) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/account/ReceiptPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/account/ReceiptPresenter.java
@@ -1,0 +1,54 @@
+package com.ticketing.system.Presentation.presenters.account;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
+import com.ticketing.system.Core.Application.services.MemberAccountService;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Read-only presenter for {@code ReceiptView} (#276). Loads one member-owned order receipt and
+ * returns a sealed {@link Outcome} the view switches on — the view never calls the service
+ * directly nor uses {@code try/catch}.
+ *
+ * <p>Takes the member's token (the view passes {@code SessionIdentity.memberToken()}, which is
+ * {@code null} for guests → an auth {@link Outcome.Failure}). A receipt that belongs to another
+ * account surfaces as {@link Outcome.Forbidden} (the issue's "403").
+ */
+@Slf4j
+@Component
+public class ReceiptPresenter {
+
+    private final MemberAccountService memberAccountService;
+
+    public ReceiptPresenter(MemberAccountService memberAccountService) {
+        this.memberAccountService = memberAccountService;
+    }
+
+    public Outcome load(String token, int receiptId) {
+        try {
+            return new Outcome.Success(memberAccountService.viewMyReceipt(token, receiptId));
+        } catch (EntityNotFoundException e) {
+            return new Outcome.NotFound("We couldn't find that receipt.");
+        } catch (UnauthorizedActionException e) {
+            return new Outcome.Forbidden("This receipt belongs to another account.");
+        } catch (InvalidTokenException e) {
+            return new Outcome.Failure("Please sign in to view this receipt.");
+        } catch (RuntimeException e) {
+            log.warn("Failed to load receipt {}: {}", receiptId, e.getMessage());
+            return new Outcome.Failure("We couldn't load this receipt right now.");
+        }
+    }
+
+    /** Sealed outcome the view switches on to render the receipt or an error banner. */
+    public sealed interface Outcome {
+        record Success(PurchaseRecordDTO receipt) implements Outcome { }
+        record NotFound(String message)  implements Outcome { }
+        record Forbidden(String message) implements Outcome { }
+        record Failure(String message)   implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/account/RefundPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/account/RefundPresenter.java
@@ -1,0 +1,56 @@
+package com.ticketing.system.Presentation.presenters.account;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.services.RefundService;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Presenter for the member "Request refund" action (#284), shared by {@code ReceiptView} and
+ * {@code MyAccountView}. Vaadin-free; calls {@link RefundService} and returns a sealed
+ * {@link Outcome} the view switches on. The view passes the member token
+ * ({@code SessionIdentity.memberToken()}).
+ */
+@Slf4j
+@Component
+public class RefundPresenter {
+
+    private final RefundService refundService;
+
+    public RefundPresenter(RefundService refundService) {
+        this.refundService = refundService;
+    }
+
+    public Outcome requestRefund(String token, int orderId, String reason) {
+        try {
+            RefundResultDTO result = refundService.requestRefund(token, orderId, reason);
+            return new Outcome.Success(result.refundTransactionId(), result.totalRefunded());
+        } catch (BusinessRuleViolationException e) {
+            return new Outcome.NotEligible("This order isn't eligible for a refund.");
+        } catch (EntityNotFoundException e) {
+            return new Outcome.NotFound("We couldn't find that order.");
+        } catch (UnauthorizedActionException e) {
+            return new Outcome.Forbidden("This order belongs to another account.");
+        } catch (InvalidTokenException e) {
+            return new Outcome.Failure("Please sign in to request a refund.");
+        } catch (RuntimeException e) {
+            log.warn("Refund failed for order {}: {}", orderId, e.getMessage());
+            return new Outcome.Failure("We couldn't process this refund right now.");
+        }
+    }
+
+    /** Sealed outcome the view switches on after a refund attempt. */
+    public sealed interface Outcome {
+        record Success(String reference, double amount) implements Outcome { }
+        record NotEligible(String message) implements Outcome { }
+        record NotFound(String message)    implements Outcome { }
+        record Forbidden(String message)   implements Outcome { }
+        record Failure(String message)     implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/BrowseEventsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/BrowseEventsPresenter.java
@@ -4,20 +4,21 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.services.CatalogService;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Read-only presenter for {@code BrowseEventsView}. Fetches the public
- * on-sale catalog from {@link CatalogService}; the view keeps its own
- * client-side category / region / date / price filtering over the result.
+ * Read-only presenter for {@code BrowseEventsView} (#271). Runs the public catalog search
+ * server-side via {@link CatalogService#searchGlobal}: the view builds a
+ * {@link CatalogSearchFiltersDTO} from its filter chips/selects and re-queries on every change
+ * (an empty filter is the unfiltered catalog).
  *
- * <p>Holds no Vaadin imports — the view renders, this only talks to the
- * service. A read-only query, so it returns the DTO list directly (no
- * {@code Outcome}) and degrades to an empty list on failure so the view
- * shows its empty state rather than crashing.
+ * <p>Holds no Vaadin imports. A read-only query, so it returns the DTO list directly (no
+ * {@code Outcome}) and degrades to an empty list on failure so the view shows its empty state
+ * rather than crashing.
  */
 @Slf4j
 @Component
@@ -29,12 +30,12 @@ public class BrowseEventsPresenter {
         this.catalogService = catalogService;
     }
 
-    /** All ON_SALE events from active companies; empty on failure. */
-    public List<EventSummaryDTO> loadCatalog() {
+    /** Server-side filtered catalog (empty filter = full on-sale catalog); empty list on failure. */
+    public List<EventSummaryDTO> search(String credential, CatalogSearchFiltersDTO filters) {
         try {
-            return catalogService.browseEventCatalog();
+            return catalogService.searchGlobal(credential, filters);
         } catch (RuntimeException e) {
-            log.warn("Failed to load event catalog: {}", e.getMessage());
+            log.warn("Browse search failed: {}", e.getMessage());
             return List.of();
         }
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/EventDetailsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/EventDetailsPresenter.java
@@ -1,0 +1,75 @@
+package com.ticketing.system.Presentation.presenters.catalog;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.InventoryZoneDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapDTO;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Domain.exceptions.CompanyClosedException;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * MVP presenter for {@code EventDetailsView} (#272). Loads the public event detail plus a
+ * best-effort venue/zone summary and returns a sealed {@link Outcome} the view switches on —
+ * the view never calls services directly nor uses {@code try/catch}.
+ */
+@Slf4j
+@Component
+public class EventDetailsPresenter {
+
+    /** Fallback grid when an event has no (accessible) venue map yet. */
+    private static final int DEFAULT_GRID = 3;
+
+    private final CatalogService catalogService;
+
+    public EventDetailsPresenter(CatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    /**
+     * Loads the event header/description/schedule/lineup plus its zone summary. The venue map is
+     * best-effort: an event with no accessible inventory still renders its detail (empty zones).
+     */
+    public Outcome load(String credential, int eventId) {
+        EventDetailDTO event;
+        try {
+            event = catalogService.getEventDetail(credential, eventId);
+        } catch (EventNotFoundException | CompanyClosedException e) {
+            return new Outcome.NotFound("This event isn't available.");
+        } catch (InvalidTokenException e) {
+            return new Outcome.Failure("Your session has expired - please refresh and try again.");
+        } catch (RuntimeException e) {
+            log.warn("Failed to load event detail for eventId {}: {}", eventId, e.getMessage());
+            return new Outcome.Failure("We couldn't load this event right now.");
+        }
+
+        List<InventoryZoneDTO> zones = List.of();
+        int gridRows = DEFAULT_GRID;
+        int gridCols = DEFAULT_GRID;
+        try {
+            VenueMapDTO map = catalogService.getEventVenueMap(credential, eventId);
+            zones = map.inventoryZones();
+            gridRows = map.gridRows();
+            gridCols = map.gridCols();
+        } catch (RuntimeException e) {
+            // No (accessible) venue map — show the detail with an empty zones rail.
+            log.debug("No accessible venue map for eventId {}: {}", eventId, e.getMessage());
+        }
+
+        return new Outcome.Success(event, zones, gridRows, gridCols);
+    }
+
+    /** Sealed outcome the view switches on to render the page or an error banner. */
+    public sealed interface Outcome {
+        record Success(EventDetailDTO event, List<InventoryZoneDTO> zones,
+                       int gridRows, int gridCols) implements Outcome { }
+        record NotFound(String message) implements Outcome { }
+        record Failure(String message)  implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SearchPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SearchPresenter.java
@@ -1,0 +1,51 @@
+package com.ticketing.system.Presentation.presenters.catalog;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.SearchResultDTO;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Presentation.session.RecentSearches;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Presenter for the top-bar search (V2-SEARCH-01 / #281). Vaadin-free; backs the live
+ * {@code LkSearchPanel}. Follows {@code BrowseEventsPresenter} — a debounced live search renders
+ * its own empty / zero-results states, so this returns a plain list and degrades to empty on
+ * failure rather than carrying a sealed Outcome.
+ */
+@Slf4j
+@Component
+public class SearchPresenter {
+
+    /** Max rows per query — keeps the dropdown tight. */
+    private static final int LIMIT = 8;
+
+    private final CatalogService catalogService;
+
+    public SearchPresenter(CatalogService catalogService) {
+        this.catalogService = catalogService;
+    }
+
+    /** Live results for a query; empty on blank query or any failure. */
+    public List<SearchResultDTO> search(String credential, String query) {
+        try {
+            return catalogService.search(credential, query, LIMIT);
+        } catch (RuntimeException e) {
+            log.warn("Top-bar search failed for '{}': {}", query, e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** The visitor's recent searches (most-recent-first); empty outside a Vaadin session. */
+    public List<String> recents() {
+        return RecentSearches.get();
+    }
+
+    /** Records a picked/executed query so it surfaces as a recent search next time. */
+    public void record(String query) {
+        RecentSearches.add(query);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/session/RecentSearches.java
+++ b/src/main/java/com/ticketing/system/Presentation/session/RecentSearches.java
@@ -1,0 +1,56 @@
+package com.ticketing.system.Presentation.session;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Session-scoped holder for the visitor's recent top-bar searches (V2-SEARCH-01 / #281).
+ *
+ * <p>Recent searches are per-user transient state; with no preferences persistence in V2 the
+ * VaadinSession is the natural home (mirrors {@link GuestSession} / {@code CurrentCompanies}).
+ * The list is most-recent-first, de-duplicated case-insensitively, and capped at {@link #MAX}.
+ * All methods are null-safe when there is no live Vaadin session (e.g. unit tests).
+ */
+public final class RecentSearches {
+
+    private static final String KEY = "recentSearches.list";
+    private static final int MAX = 8;
+
+    private RecentSearches() { }
+
+    /** Recent queries, most-recent-first; empty when no session / none recorded. */
+    @SuppressWarnings("unchecked")
+    public static List<String> get() {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s == null) return List.of();
+        List<String> list = (List<String>) s.getAttribute(KEY);
+        return list == null ? List.of() : List.copyOf(list);
+    }
+
+    /** Records a query at the front (trimmed, de-duped case-insensitively, capped). No-op if blank. */
+    @SuppressWarnings("unchecked")
+    public static void add(String query) {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s == null || query == null) return;
+        String q = query.trim();
+        if (q.isEmpty()) return;
+
+        List<String> existing = (List<String>) s.getAttribute(KEY);
+        List<String> next = new ArrayList<>();
+        next.add(q);
+        if (existing != null) {
+            for (String prev : existing) {
+                if (!prev.equalsIgnoreCase(q)) next.add(prev);
+                if (next.size() >= MAX) break;
+            }
+        }
+        s.setAttribute(KEY, next);
+    }
+
+    public static void clear() {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s != null) s.setAttribute(KEY, null);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyAccountView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyAccountView.java
@@ -4,6 +4,8 @@ import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
 import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
+import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.components.buyer.BzRefundDialog;
 import com.ticketing.system.Presentation.components.buyer.BzTicketDialog;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkCard;
@@ -14,7 +16,9 @@ import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkStatusDot;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.presenters.account.MyAccountPresenter;
+import com.ticketing.system.Presentation.presenters.account.RefundPresenter;
 import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -40,9 +44,14 @@ public class MyAccountView extends LkPage {
     private static final DateTimeFormatter DATETIME_FMT = DateTimeFormatter.ofPattern("EEE d MMM yyyy · HH:mm");
 
     private final PurchaseHistoryDTO history;
+    private final RefundPresenter refundPresenter;
+    private final SessionIdentity sessionIdentity;
 
-    public MyAccountView(MyAccountPresenter presenter) {
+    public MyAccountView(MyAccountPresenter presenter, RefundPresenter refundPresenter,
+                         SessionIdentity sessionIdentity) {
         this.history = presenter.loadHistory();
+        this.refundPresenter = refundPresenter;
+        this.sessionIdentity = sessionIdentity;
 
         add(buildHero());
         add(Lk.h2("My orders"));
@@ -131,8 +140,42 @@ public class MyAccountView extends LkPage {
         view.addClassName("bz-link");
         view.getStyle().set("background", "none").set("border", "none").set("padding", "0").set("cursor", "pointer");
         view.addClickListener(e -> UI.getCurrent().navigate("receipt/" + r.orderReceiptId()));
-        row.put("receipt", view);
+
+        if (refundEligible(r)) {
+            NativeButton refund = new NativeButton("Request refund");
+            refund.addClassName("bz-link");
+            refund.getStyle().set("background", "none").set("border", "none").set("padding", "0")
+                .set("cursor", "pointer").set("margin-left", "14px");
+            refund.addClickListener(e -> BzRefundDialog.open("#" + r.orderReceiptId(), r.totalPaid(),
+                reason -> handleRefund(r.orderReceiptId(), reason)));
+            Div cell = new Div(view, refund);
+            row.put("receipt", cell);
+        } else {
+            row.put("receipt", view);
+        }
         grid.row(row);
+    }
+
+    private static boolean refundEligible(PurchaseRecordDTO r) {
+        if (r.refunded() || r.buyerUserId() == null) {
+            return false;   // already refunded, or a guest order (member-only flow)
+        }
+        return r.tickets().stream().anyMatch(t ->
+            t.currentStatus() == TicketStatus.PAID || t.currentStatus() == TicketStatus.ISSUED);
+    }
+
+    private void handleRefund(int orderId, String reason) {
+        switch (refundPresenter.requestRefund(sessionIdentity.memberToken(), orderId, reason)) {
+            case RefundPresenter.Outcome.Success s -> {
+                Toasts.success("Refund requested — reference " + s.reference()
+                    + ". Processed in 3–5 business days.");
+                UI.getCurrent().getPage().reload();   // refresh orders + tickets
+            }
+            case RefundPresenter.Outcome.NotEligible n -> Toasts.warn(n.message());
+            case RefundPresenter.Outcome.NotFound n    -> Toasts.failure(n.message());
+            case RefundPresenter.Outcome.Forbidden f   -> Toasts.failure(f.message());
+            case RefundPresenter.Outcome.Failure f     -> Toasts.failure(f.message());
+        }
     }
 
     private Component buildTicketsCard() {

--- a/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
@@ -1,10 +1,13 @@
 package com.ticketing.system.Presentation.views.account;
 
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TransactionRecordDTO;
 import com.ticketing.system.Presentation.components.Toasts;
-import com.ticketing.system.Presentation.components.buyer.BzRefundDialog;
 import com.ticketing.system.Presentation.components.buyer.BzTicketDialog;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkCol;
@@ -13,7 +16,10 @@ import com.ticketing.system.Presentation.components.kit.LkIconBtn;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Presentation.presenters.account.ReceiptPresenter;
+import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -22,110 +28,100 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
-import java.util.LinkedHashMap;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Map;
 
 /**
- * Full-page receipt view for a past order. Reached by clicking "View"
- * on the {@code MyAccountView} orders grid. Looks up the receipt by
- * route parameter; each row's per-ticket action buttons open the same
- * {@code BzTicketDialog} and {@code BzRefundDialog} the account screen
- * uses.
+ * Full-page receipt for one member-owned order (#276). Reached by clicking "View" on the
+ * {@code MyAccountView} orders grid ({@code receipt/{orderReceiptId}}). Loads the real receipt
+ * through {@link ReceiptPresenter}; the view never calls the service directly nor uses
+ * {@code try/catch} — it switches on the presenter's sealed {@code Outcome}. A receipt that isn't
+ * the signed-in member's renders a 403 banner.
  */
 @Route(value = "receipt/:receiptId", layout = MainLayout.class)
 @PageTitle("Receipt · TicketHub")
 @PermitAll
 public class ReceiptView extends LkPage implements BeforeEnterObserver {
 
-    private record OrderLine(String label, int priceCents) { }
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("d MMM yyyy · HH:mm");
+    private static final DateTimeFormatter EVENT_FMT = DateTimeFormatter.ofPattern("EEE d MMM yyyy · HH:mm");
 
-    private record ReceiptData(
-        String id, String transactionId, String date, String status, boolean refunded,
-        int subtotalCents, int feeCents, int totalCents, String paymentMethod,
-        List<OrderLine> lines, List<BzTicketDialog.TicketInfo> tickets
-    ) { }
+    private final ReceiptPresenter presenter;
+    private final SessionIdentity sessionIdentity;
 
-    private static final Map<String, ReceiptData> RECEIPTS = new LinkedHashMap<>();
-    static {
-        RECEIPTS.put("TKT-20847", new ReceiptData(
-            "TKT-20847", "4c1f-9a2d", "26 Jun 2026 · 14:08", "Paid", false,
-            48000, 2400, 50400, "Visa •••• 4242",
-            List.of(
-                new OrderLine("Coldplay · MOTS · Lower L · Row C · Seat 14", 16000),
-                new OrderLine("Coldplay · MOTS · Lower L · Row C · Seat 15", 16000),
-                new OrderLine("Hapoel TLV · 2 × General Admission",          16000)),
-            List.of(
-                new BzTicketDialog.TicketInfo("Coldplay · Music of the Spheres", "Concert",
-                    "Thu 26 Jun 2026 · 20:00", "Park HaYarkon, Tel Aviv",
-                    "Lower L", "Row C · Seat 14", "$160.00", "7B2K-4Q", "TKT-20847"),
-                new BzTicketDialog.TicketInfo("Coldplay · Music of the Spheres", "Concert",
-                    "Thu 26 Jun 2026 · 20:00", "Park HaYarkon, Tel Aviv",
-                    "Lower L", "Row C · Seat 15", "$160.00", "7B2K-4R", "TKT-20847"),
-                new BzTicketDialog.TicketInfo("Hapoel TLV vs Maccabi Haifa", "Sport",
-                    "Sat 28 Jun 2026 · 21:00", "Bloomfield Stadium, Tel Aviv",
-                    "General Admission", "—", "$80.00", "9F1A-2M", "TKT-20847"),
-                new BzTicketDialog.TicketInfo("Hapoel TLV vs Maccabi Haifa", "Sport",
-                    "Sat 28 Jun 2026 · 21:00", "Bloomfield Stadium, Tel Aviv",
-                    "General Admission", "—", "$80.00", "9F1A-2N", "TKT-20847"))));
+    private final Div bodyHolder = new Div();
+    private int receiptId;
 
-        RECEIPTS.put("TKT-20713", new ReceiptData(
-            "TKT-20713", "9b3d-1f4c", "20 Jun 2026 · 11:22", "Paid", false,
-            16000, 0, 16000, "Mastercard •••• 8721",
-            List.of(new OrderLine("Hapoel TLV vs Maccabi Haifa · 2 × GA", 16000)),
-            List.of(
-                new BzTicketDialog.TicketInfo("Hapoel TLV vs Maccabi Haifa", "Sport",
-                    "Sat 28 Jun 2026 · 21:00", "Bloomfield Stadium, Tel Aviv",
-                    "General Admission", "—", "$80.00", "9F1A-2M", "TKT-20713"),
-                new BzTicketDialog.TicketInfo("Hapoel TLV vs Maccabi Haifa", "Sport",
-                    "Sat 28 Jun 2026 · 21:00", "Bloomfield Stadium, Tel Aviv",
-                    "General Admission", "—", "$80.00", "9F1A-2N", "TKT-20713"))));
-
-        RECEIPTS.put("TKT-20566", new ReceiptData(
-            "TKT-20566", "2a5e-0c91", "12 May 2026 · 19:47", "Refunded", true,
-            12000, 0, 12000, "Visa •••• 4242",
-            List.of(new OrderLine("Othello at Habima · Stalls · Seat 18", 12000)),
-            List.of(
-                new BzTicketDialog.TicketInfo("Othello at Habima", "Theatre",
-                    "Mon 30 May 2026 · 20:30", "Habima National Theatre, Tel Aviv",
-                    "Stalls", "Row F · Seat 18", "$120.00", "3M4Q-7P", "TKT-20566"))));
+    public ReceiptView(ReceiptPresenter presenter, SessionIdentity sessionIdentity) {
+        this.presenter = presenter;
+        this.sessionIdentity = sessionIdentity;
+        add(bodyHolder);
     }
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        String id = event.getRouteParameters().get("receiptId").orElse("TKT-20847");
-        ReceiptData receipt = RECEIPTS.getOrDefault(id, RECEIPTS.get("TKT-20847"));
-
-        title("Receipt #" + receipt.id);
-        subtitle(receipt.date + "  ·  Transaction " + receipt.transactionId);
-        actions(buildHeaderActions());
-
-        add(buildStatusCard(receipt));
-        add(Lk.h2("Items"));
-        add(buildItemsCard(receipt));
-        add(Lk.h2("Payment"));
-        add(buildPaymentCard(receipt));
-        add(Lk.h2("Tickets"));
-        add(buildTicketsCard(receipt));
+        this.receiptId = event.getRouteParameters().get("receiptId")
+                .map(s -> { try { return Integer.parseInt(s); } catch (NumberFormatException e) { return 0; } })
+                .orElse(0);
+        loadAndBuild();
     }
 
-    // ---- header actions ----
+    private void loadAndBuild() {
+        bodyHolder.removeAll();
+        title("Receipt");
+        subtitle(null);
+        actions();
+
+        if (receiptId <= 0) {
+            bodyHolder.add(infoBanner("We couldn't find that receipt."));
+            return;
+        }
+
+        switch (presenter.load(sessionIdentity.memberToken(), receiptId)) {
+            case ReceiptPresenter.Outcome.Success s   -> renderReceipt(s.receipt());
+            case ReceiptPresenter.Outcome.NotFound nf -> bodyHolder.add(infoBanner(nf.message()));
+            case ReceiptPresenter.Outcome.Forbidden f -> bodyHolder.add(infoBanner(f.message()));
+            case ReceiptPresenter.Outcome.Failure f   -> bodyHolder.add(infoBanner(f.message()));
+        }
+    }
+
+    private void renderReceipt(PurchaseRecordDTO receipt) {
+        title("Receipt #" + receipt.orderReceiptId());
+        subtitle(headerSubtitle(receipt));
+        actions(buildHeaderActions());
+
+        bodyHolder.add(buildStatusCard(receipt));
+        bodyHolder.add(Lk.h2("Items"));
+        bodyHolder.add(buildItemsCard(receipt));
+        bodyHolder.add(Lk.h2("Payment"));
+        bodyHolder.add(buildPaymentCard(receipt));
+        bodyHolder.add(Lk.h2("Tickets"));
+        bodyHolder.add(buildTicketsCard(receipt));
+    }
+
+    // ---- header ----
+
+    private String headerSubtitle(PurchaseRecordDTO receipt) {
+        String when = receipt.purchasedAt() == null ? "—" : receipt.purchasedAt().format(DATE_FMT);
+        TransactionRecordDTO charge = paymentCharge(receipt);
+        return charge == null ? when : when + "  ·  Transaction " + charge.externalTransactionId();
+    }
 
     private Component buildHeaderActions() {
         LkRow actions = new LkRow().gap(8);
         actions.add(
-            new LkBtn("Download PDF").variant(LkBtn.Variant.secondary)
+            new LkBtn("Print").variant(LkBtn.Variant.secondary)
                 .icon(new LkIcon("copy", 15))
-                .onClick(e -> Toasts.success("Receipt PDF queued for download (mock).")),
+                .onClick(e -> UI.getCurrent().getPage().executeJs("window.print()")),
             new LkBtn("Email receipt").variant(LkBtn.Variant.tertiary)
-                .onClick(e -> Toasts.success("Receipt resent to alex.morgan@email.com."))
+                .onClick(e -> Toasts.success("Receipt resent to your account email (mock)."))
         );
         return actions;
     }
 
     // ---- status / summary header ----
 
-    private Component buildStatusCard(ReceiptData receipt) {
+    private Component buildStatusCard(PurchaseRecordDTO receipt) {
         LkCard card = new LkCard().pad(18);
         Div row = new Div();
         row.getStyle()
@@ -133,17 +129,19 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
             .set("grid-template-columns", "repeat(auto-fit, minmax(140px, 1fr))")
             .set("gap", "18px");
 
-        LkBadge statusBadge = new LkBadge(receipt.status,
-            receipt.refunded ? LkBadge.Tone.muted : LkBadge.Tone.success).small();
+        LkBadge statusBadge = new LkBadge(receipt.refunded() ? "Refunded" : "Paid",
+            receipt.refunded() ? LkBadge.Tone.muted : LkBadge.Tone.success).small();
 
         Span totalSpan = new Span();
         totalSpan.getElement().setProperty("innerHTML",
-            "<b style='font-size:1.1rem;color:#0f172a'>" + formatPrice(receipt.totalCents) + "</b>");
+            "<b style='font-size:1.1rem;color:#0f172a'>" + money(receipt.totalPaid()) + "</b>");
+
+        int ticketCount = receipt.tickets().size();
 
         row.add(
             statBlock("Status", statusBadge),
-            statBlock("Date",   new Span(receipt.date)),
-            statBlock("Items",  new Span(receipt.lines.size() + " line" + (receipt.lines.size() == 1 ? "" : "s"))),
+            statBlock("Date",   new Span(receipt.purchasedAt() == null ? "—" : receipt.purchasedAt().format(DATE_FMT))),
+            statBlock("Items",  new Span(ticketCount + " ticket" + (ticketCount == 1 ? "" : "s"))),
             statBlock("Total",  totalSpan)
         );
         card.add(row);
@@ -160,18 +158,22 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
         return block;
     }
 
-    // ---- items ----
+    // ---- items (one line per ticket) ----
 
-    private Component buildItemsCard(ReceiptData receipt) {
+    private Component buildItemsCard(PurchaseRecordDTO receipt) {
         LkCard card = new LkCard().pad(0);
+        if (receipt.tickets().isEmpty()) {
+            card.pad(18).add(Lk.muted("No line items on this order."));
+            return card;
+        }
         Div lines = new Div();
         lines.addClassName("bz-order-lines");
-        for (OrderLine line : receipt.lines) {
+        for (TicketRecordDTO t : receipt.tickets()) {
             Div row = new Div();
             row.addClassName("bz-order-line");
-            row.add(new Span(line.label));
+            row.add(new Span(itemLabel(t)));
             Span price = new Span();
-            price.getElement().setProperty("innerHTML", "<b>" + formatPrice(line.priceCents) + "</b>");
+            price.getElement().setProperty("innerHTML", "<b>" + money(t.pricePaid()) + "</b>");
             row.add(price);
             lines.add(row);
         }
@@ -179,19 +181,37 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
         return card;
     }
 
+    private static String itemLabel(TicketRecordDTO t) {
+        String evt = orElse(t.eventName(), "Event #" + t.eventId());
+        String zone = orElse(t.zoneName(), "Zone #" + t.zoneId());
+        String seat = orElse(t.seatNumber(), null);
+        return seat == null ? evt + " · " + zone : evt + " · " + zone + " · " + seat;
+    }
+
     // ---- payment ----
 
-    private Component buildPaymentCard(ReceiptData receipt) {
+    private Component buildPaymentCard(PurchaseRecordDTO receipt) {
         LkCard card = new LkCard().pad(18);
         LkCol col = new LkCol().gap(8);
-        col.add(paymentRow("Subtotal",       formatPrice(receipt.subtotalCents), false));
-        col.add(paymentRow("Service fee",    formatPrice(receipt.feeCents),      false));
+
+        double subtotal = receipt.tickets().stream().mapToDouble(TicketRecordDTO::pricePaid).sum();
+        double fee = Math.max(0, receipt.totalPaid() - subtotal);
+
+        col.add(paymentRow("Subtotal", money(subtotal), false));
+        if (fee > 0.0001) {
+            col.add(paymentRow("Service fee", money(fee), false));
+        }
         col.add(Lk.divider());
-        col.add(paymentRow(receipt.refunded ? "Total refunded" : "Total paid",
-                           formatPrice(receipt.totalCents), true));
-        Span method = Lk.muted("Paid with " + receipt.paymentMethod);
-        method.getStyle().set("font-size", "12.5px").set("display", "block").set("margin-top", "4px");
-        col.add(method);
+        col.add(paymentRow(receipt.refunded() ? "Total refunded" : "Total paid",
+                           money(receipt.totalPaid()), true));
+
+        TransactionRecordDTO charge = paymentCharge(receipt);
+        if (charge != null) {
+            Span method = Lk.muted("Paid with " + charge.providerName()
+                + (charge.currency() == null || charge.currency().isBlank() ? "" : " (" + charge.currency() + ")"));
+            method.getStyle().set("font-size", "12.5px").set("display", "block").set("margin-top", "4px");
+            col.add(method);
+        }
         card.add(col);
         return card;
     }
@@ -212,15 +232,19 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
 
     // ---- tickets list ----
 
-    private Component buildTicketsCard(ReceiptData receipt) {
+    private Component buildTicketsCard(PurchaseRecordDTO receipt) {
         LkCard card = new LkCard().pad(0);
-        for (BzTicketDialog.TicketInfo ticket : receipt.tickets) {
-            card.add(buildTicketRow(ticket, receipt.refunded));
+        if (receipt.tickets().isEmpty()) {
+            card.pad(18).add(Lk.muted("No tickets on this order."));
+            return card;
+        }
+        for (TicketRecordDTO t : receipt.tickets()) {
+            card.add(buildTicketRow(t));
         }
         return card;
     }
 
-    private Div buildTicketRow(BzTicketDialog.TicketInfo t, boolean refunded) {
+    private Div buildTicketRow(TicketRecordDTO t) {
         Div row = new Div();
         row.getStyle()
             .set("display", "flex").set("align-items", "center").set("gap", "16px")
@@ -236,44 +260,78 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
         Div info = new Div();
         info.getStyle().set("flex", "1 1 auto").set("min-width", "0");
         Span title = new Span();
-        title.getElement().setProperty("innerHTML", "<b>" + escape(t.event()) + "</b>");
+        title.getElement().setProperty("innerHTML", "<b>" + escape(orElse(t.eventName(), "Event #" + t.eventId())) + "</b>");
         title.getStyle().set("display", "block").set("color", "#0f172a");
-        Span meta = Lk.muted(t.date() + "  ·  " + t.zone() + "  ·  " + t.seat());
+        Span meta = Lk.muted(ticketMeta(t));
         meta.getStyle().set("font-size", "13px").set("display", "block").set("margin-top", "2px");
         info.add(title, meta);
 
-        Span code = new Span(t.barcode());
+        Span code = new Span(orElse(t.barcode(), "Not yet issued"));
         code.addClassName("lk-mono");
         code.getStyle()
             .set("font-size", "0.78rem").set("color", "var(--muted)").set("letter-spacing", "0.06em");
 
         LkIconBtn viewBtn = new LkIconBtn(new LkIcon("eye", 15), "View ticket");
-        viewBtn.addClickListener(e -> BzTicketDialog.show(t));
+        viewBtn.addClickListener(e -> BzTicketDialog.show(toTicketInfo(t)));
 
         LkRow actions = new LkRow().gap(4).noWrap();
         actions.add(viewBtn);
-        if (!refunded) {
-            LkIconBtn refundBtn = new LkIconBtn(new LkIcon("card", 15), "Request refund");
-            refundBtn.addClickListener(e -> BzRefundDialog.show(t));
-            actions.add(refundBtn);
-        }
 
         row.add(swatch, info, code, actions);
         return row;
     }
 
+    private static String ticketMeta(TicketRecordDTO t) {
+        String when = t.eventStartsAt() == null ? "—" : t.eventStartsAt().format(EVENT_FMT);
+        return when + "  ·  " + orElse(t.zoneName(), "Zone #" + t.zoneId()) + "  ·  " + orElse(t.seatNumber(), "—");
+    }
+
+    private static BzTicketDialog.TicketInfo toTicketInfo(TicketRecordDTO t) {
+        return new BzTicketDialog.TicketInfo(
+            orElse(t.eventName(), "Event #" + t.eventId()),
+            orElse(t.category(), "—"),
+            t.eventStartsAt() == null ? "—" : t.eventStartsAt().format(EVENT_FMT),
+            orElse(t.venue(), "—"),
+            orElse(t.zoneName(), "Zone #" + t.zoneId()),
+            orElse(t.seatNumber(), "—"),
+            money(t.pricePaid()),
+            orElse(t.barcode(), "Not yet issued"),
+            "#" + t.orderReceiptId());
+    }
+
+    // ---- helpers ----
+
+    private static TransactionRecordDTO paymentCharge(PurchaseRecordDTO receipt) {
+        return receipt.transactions().stream()
+            .filter(tx -> "PAYMENT_CHARGE".equals(tx.type()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private Component infoBanner(String message) {
+        LkBanner banner = new LkBanner();
+        banner.tone(LkBanner.Tone.info);
+        banner.setIcon(new LkIcon("info", 18));
+        banner.setBody(new Span(message));
+        return banner;
+    }
+
     private static String[] gradientFor(String cat) {
         return switch (cat == null ? "" : cat.toLowerCase()) {
-            case "concert"    -> new String[]{"#8b5cf6", "#ec4899"};
-            case "sport"      -> new String[]{"#0ea5e9", "#10b981"};
-            case "theatre"    -> new String[]{"#dc2626", "#f59e0b"};
-            case "conference" -> new String[]{"#0d9488", "#1d4ed8"};
-            default           -> new String[]{"#475569", "#1a5490"};
+            case "concert", "music" -> new String[]{"#8b5cf6", "#ec4899"};
+            case "sport", "sports"  -> new String[]{"#0ea5e9", "#10b981"};
+            case "theatre", "theater" -> new String[]{"#dc2626", "#f59e0b"};
+            case "conference"       -> new String[]{"#0d9488", "#1d4ed8"};
+            default                 -> new String[]{"#475569", "#1a5490"};
         };
     }
 
-    private static String formatPrice(int cents) {
-        return "$" + (cents / 100) + "." + String.format("%02d", cents % 100);
+    private static String money(double amount) {
+        return String.format("$%,.2f", amount);
+    }
+
+    private static String orElse(String value, String fallback) {
+        return (value == null || value.isBlank()) ? fallback : value;
     }
 
     private static String escape(String s) {

--- a/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
@@ -3,7 +3,9 @@ package com.ticketing.system.Presentation.views.account;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TransactionRecordDTO;
+import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
 import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.components.buyer.BzRefundDialog;
 import com.ticketing.system.Presentation.components.buyer.BzTicketDialog;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
@@ -17,6 +19,7 @@ import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.presenters.account.ReceiptPresenter;
+import com.ticketing.system.Presentation.presenters.account.RefundPresenter;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -47,13 +50,16 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
     private static final DateTimeFormatter EVENT_FMT = DateTimeFormatter.ofPattern("EEE d MMM yyyy · HH:mm");
 
     private final ReceiptPresenter presenter;
+    private final RefundPresenter refundPresenter;
     private final SessionIdentity sessionIdentity;
 
     private final Div bodyHolder = new Div();
     private int receiptId;
 
-    public ReceiptView(ReceiptPresenter presenter, SessionIdentity sessionIdentity) {
+    public ReceiptView(ReceiptPresenter presenter, RefundPresenter refundPresenter,
+                       SessionIdentity sessionIdentity) {
         this.presenter = presenter;
+        this.refundPresenter = refundPresenter;
         this.sessionIdentity = sessionIdentity;
         add(bodyHolder);
     }
@@ -88,9 +94,12 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
     private void renderReceipt(PurchaseRecordDTO receipt) {
         title("Receipt #" + receipt.orderReceiptId());
         subtitle(headerSubtitle(receipt));
-        actions(buildHeaderActions());
+        actions(buildHeaderActions(receipt));
 
         bodyHolder.add(buildStatusCard(receipt));
+        if (receipt.refunded()) {
+            bodyHolder.add(buildRefundTimeline(receipt));
+        }
         bodyHolder.add(Lk.h2("Items"));
         bodyHolder.add(buildItemsCard(receipt));
         bodyHolder.add(Lk.h2("Payment"));
@@ -107,8 +116,13 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
         return charge == null ? when : when + "  ·  Transaction " + charge.externalTransactionId();
     }
 
-    private Component buildHeaderActions() {
+    private Component buildHeaderActions(PurchaseRecordDTO receipt) {
         LkRow actions = new LkRow().gap(8);
+        if (refundEligible(receipt)) {
+            actions.add(new LkBtn("Request refund").variant(LkBtn.Variant.primary)
+                .icon(new LkIcon("card", 15))
+                .onClick(e -> openRefund(receipt)));
+        }
         actions.add(
             new LkBtn("Print").variant(LkBtn.Variant.secondary)
                 .icon(new LkIcon("copy", 15))
@@ -117,6 +131,60 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
                 .onClick(e -> Toasts.success("Receipt resent to your account email (mock)."))
         );
         return actions;
+    }
+
+    // ---- refund (#284): order-level, member-initiated ----
+
+    private static boolean refundEligible(PurchaseRecordDTO r) {
+        if (r.refunded() || r.buyerUserId() == null) {
+            return false;   // already refunded, or a guest order (member-only flow)
+        }
+        return r.tickets().stream().anyMatch(t ->
+            t.currentStatus() == TicketStatus.PAID || t.currentStatus() == TicketStatus.ISSUED);
+    }
+
+    private void openRefund(PurchaseRecordDTO receipt) {
+        BzRefundDialog.open("#" + receipt.orderReceiptId(), receipt.totalPaid(),
+            reason -> handleRefund(receipt.orderReceiptId(), reason));
+    }
+
+    private void handleRefund(int orderId, String reason) {
+        switch (refundPresenter.requestRefund(sessionIdentity.memberToken(), orderId, reason)) {
+            case RefundPresenter.Outcome.Success s -> {
+                Toasts.success("Refund requested — reference " + s.reference()
+                    + ". Processed in 3–5 business days.");
+                loadAndBuild();   // re-render: the order now shows as refunded
+            }
+            case RefundPresenter.Outcome.NotEligible n -> Toasts.warn(n.message());
+            case RefundPresenter.Outcome.NotFound n    -> Toasts.failure(n.message());
+            case RefundPresenter.Outcome.Forbidden f   -> Toasts.failure(f.message());
+            case RefundPresenter.Outcome.Failure f     -> Toasts.failure(f.message());
+        }
+    }
+
+    private Component buildRefundTimeline(PurchaseRecordDTO receipt) {
+        LkCard card = new LkCard().pad(18);
+        LkCol col = new LkCol().gap(10);
+        Span heading = new Span("Refund status");
+        heading.getStyle().set("font-weight", "700").set("color", "#0f172a");
+        col.add(heading);
+
+        LkRow steps = new LkRow().gap(8);
+        steps.add(
+            new LkBadge("✓ Requested", LkBadge.Tone.success).small(),
+            new LkBadge("✓ Processing", LkBadge.Tone.success).small(),
+            new LkBadge("✓ Refunded", LkBadge.Tone.success).small());
+        col.add(steps);
+
+        TransactionRecordDTO refundTx = refundTransaction(receipt);
+        if (refundTx != null) {
+            Span note = Lk.muted("Refunded " + money(refundTx.amount())
+                + (refundTx.timestamp() == null ? "" : " on " + refundTx.timestamp().format(DATE_FMT)));
+            note.getStyle().set("font-size", "12.5px").set("display", "block");
+            col.add(note);
+        }
+        card.add(col);
+        return card;
     }
 
     // ---- status / summary header ----
@@ -212,6 +280,12 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
             method.getStyle().set("font-size", "12.5px").set("display", "block").set("margin-top", "4px");
             col.add(method);
         }
+
+        TransactionRecordDTO refundTx = refundTransaction(receipt);
+        if (refundTx != null) {
+            col.add(Lk.divider());
+            col.add(paymentRow("Refund issued", "-" + money(refundTx.amount()), false));
+        }
         card.add(col);
         return card;
     }
@@ -304,6 +378,13 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
     private static TransactionRecordDTO paymentCharge(PurchaseRecordDTO receipt) {
         return receipt.transactions().stream()
             .filter(tx -> "PAYMENT_CHARGE".equals(tx.type()))
+            .findFirst()
+            .orElse(null);
+    }
+
+    private static TransactionRecordDTO refundTransaction(PurchaseRecordDTO receipt) {
+        return receipt.transactions().stream()
+            .filter(tx -> "REFUND".equals(tx.type()))
             .findFirst()
             .orElse(null);
     }

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Presentation.views.catalog;
 
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Presentation.components.buyer.BzPoster;
 import com.ticketing.system.Presentation.components.kit.Lk;
@@ -16,6 +17,7 @@ import com.ticketing.system.Presentation.components.kit.LkSelect;
 import com.ticketing.system.Presentation.components.kit.LkStatusDot;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
+import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
@@ -29,8 +31,11 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -43,15 +48,16 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
 
     // ---- data model ----
 
-    private record EventRow(String name, String category, String venue, String region,
-            String date, int dayOfYear, int priceCents,
+    private record EventRow(String name, String category, String venue,
+            String date, LocalDateTime startsAt, int priceCents,
             LkStatusDot.Tone tone, String status, String id) {
     }
 
-    // Real catalog (ON_SALE events from active companies), loaded once at construction
-    // via BrowseEventsPresenter and mapped to EventRow. All filtering/sorting below is
-    // client-side over this list.
-    private final List<EventRow> allEvents;
+    /** A resolved from/to date range for a date-range preset; either bound may be null (unbounded). */
+    record DateWindow(LocalDate from, LocalDate to) { }
+
+    private final BrowseEventsPresenter presenter;
+    private final SessionIdentity identity;
 
     private static final String CAT_ALL = "All categories";
     private static final String REGION_ALL = "All regions";
@@ -83,26 +89,29 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private Div gridSlot;
     private Span resultsCountSpan;
 
-    public BrowseEventsView(BrowseEventsPresenter presenter) {
-        this.allEvents = presenter.loadCatalog().stream()
-                .map(BrowseEventsView::toRow)
-                .toList();
+    public BrowseEventsView(BrowseEventsPresenter presenter, SessionIdentity identity) {
+        this.presenter = presenter;
+        this.identity = identity;
+
+        // One unfiltered server query seeds the "Featured this week" strip + the first grid render.
+        List<EventRow> featured = presenter.search(identity.credential(), CatalogSearchFiltersDTO.empty())
+                .stream().map(BrowseEventsView::toRow).toList();
 
         add(buildHero());
         add(buildCategoryChips());
-        if (!allEvents.isEmpty()) {
+        if (!featured.isEmpty()) {
             add(Lk.h2("Featured this week"));
-            add(buildPosterGrid());
+            add(buildPosterGrid(featured));
         }
         add(buildAllEventsHeader());
         add(buildBrowseSplit());
-        renderGrid();
+        renderGrid(featured.stream().sorted(comparatorFor(filterSort)).toList());
     }
 
     /**
-     * Apply a {@code ?category=...} query parameter (e.g. when arriving
-     * from a category card on the landing page) by pre-selecting the
-     * matching chip + sidebar Category select, and filtering the grid.
+     * Apply a {@code ?category=...} query parameter (e.g. when arriving from a category card on the
+     * landing page) by pre-selecting the matching chip + sidebar Category select, which re-runs the
+     * server-side filtered query.
      */
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
@@ -164,15 +173,15 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         chipToCategory.forEach((chip, cat) -> chip.active(cat.equals(category)));
         if (categorySelect != null)
             categorySelect.setValue(category);
-        renderGrid();
+        runSearch();
     }
 
     // ---- featured posters ----
 
-    private Component buildPosterGrid() {
+    private Component buildPosterGrid(List<EventRow> featured) {
         Div grid = new Div();
         grid.addClassName("bz-poster-grid");
-        allEvents.stream().limit(4).forEach(ev ->
+        featured.stream().limit(4).forEach(ev ->
                 grid.add(new BzPoster(ev.category, ev.name, ev.venue + " · " + ev.date,
                         "From $" + (ev.priceCents / 100))
                         .onClick(() -> UI.getCurrent().navigate("events/" + ev.id))));
@@ -213,19 +222,19 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         dateRangeField = new LkDateRangeField().label("Date range");
         dateRangeField.onChange(v -> {
             filterDateRange = v;
-            renderGrid();
+            runSearch();
         });
 
         regionSelect = new LkSelect(REGION_ALL, REGIONS).label("Region");
         regionSelect.onChange(v -> {
             filterRegion = v;
-            renderGrid();
+            runSearch();
         });
 
         sortSelect = new LkSelect(SORTS.get(0), SORTS).label("Sort by");
         sortSelect.onChange(v -> {
             filterSort = v;
-            renderGrid();
+            runSearch();
         });
 
         LkCol col = new LkCol().gap(16);
@@ -251,7 +260,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         priceMin.getStyle().set("flex", "1 1 0");
         priceMin.addValueChangeListener(e -> {
             filterPriceMin = e.getValue();
-            renderGrid();
+            runSearch();
         });
 
         priceMax = new IntegerField();
@@ -264,7 +273,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         priceMax.getStyle().set("flex", "1 1 0");
         priceMax.addValueChangeListener(e -> {
             filterPriceMax = e.getValue();
-            renderGrid();
+            runSearch();
         });
 
         LkRow row = new LkRow().gap(8);
@@ -296,76 +305,75 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         dateRangeField.setValue(DATE_ANY);
         priceMin.clear();
         priceMax.clear();
-        renderGrid();
+        runSearch();
     }
 
-    // ---- filter + render ----
+    // ---- server-side search + render ----
 
-    private List<EventRow> applyFilters() {
-        return allEvents.stream()
-                .filter(this::matchesCategory)
-                .filter(this::matchesRegion)
-                .filter(this::matchesDateRange)
-                .filter(this::matchesPrice)
+    /** Build the filter DTO from current chip/select state, query the server, sort, render. */
+    private void runSearch() {
+        List<EventRow> rows = presenter.search(identity.credential(), currentFilters()).stream()
+                .map(BrowseEventsView::toRow)
                 .sorted(comparatorFor(filterSort))
                 .toList();
+        renderGrid(rows);
     }
 
-    private boolean matchesCategory(EventRow e) {
-        return CAT_ALL.equals(filterCategory) || filterCategory.equals(e.category);
+    private CatalogSearchFiltersDTO currentFilters() {
+        DateWindow dw = dateWindow(filterDateRange, LocalDate.now());
+        return new CatalogSearchFiltersDTO(
+                null,                                       // eventName
+                null,                                       // artistName
+                categoryFilterValue(filterCategory),        // category (enum name, or null = all)
+                null,                                       // keywords
+                filterPriceMin == null ? null : filterPriceMin.doubleValue(),
+                filterPriceMax == null ? null : filterPriceMax.doubleValue(),
+                dw.from(),
+                dw.to(),
+                REGION_ALL.equals(filterRegion) ? null : filterRegion,   // location (city/country substring)
+                null, null, null, null);                    // event/company rating filters unused here
     }
 
-    private boolean matchesRegion(EventRow e) {
-        return REGION_ALL.equals(filterRegion)
-                || (e.region != null && e.region.toLowerCase().contains(filterRegion.toLowerCase()));
-    }
-
-    private boolean matchesDateRange(EventRow e) {
-        // Mock semantics — "today" anchored to day 177 (first event in the dataset)
-        // so each preset actually changes the visible set.
-        return switch (filterDateRange) {
-            case "Today" -> e.dayOfYear == 177;
-            case "This weekend" -> e.dayOfYear == 179 || e.dayOfYear == 180;
-            case "Next 7 days" -> e.dayOfYear <= 183;
-            case "Next 30 days" -> e.dayOfYear <= 206;
-            case "This month" -> e.dayOfYear <= 181;
-            case "Next 3 months" -> true;
-            default -> true; // Any time
+    /** UI category label → EventCategory enum name for the server filter (null = no category filter). */
+    static String categoryFilterValue(String label) {
+        if (label == null) return null;
+        return switch (label) {
+            case "Concerts"  -> "CONCERT";   // seed concerts use CONCERT (enum also has the unused MUSIC)
+            case "Sports"    -> "SPORTS";
+            case "Theatre"   -> "THEATER";
+            case "Festivals" -> "FESTIVAL";
+            case "Comedy"    -> "COMEDY";
+            default          -> null;        // "All categories" / unknown
         };
     }
 
-    private boolean matchesPrice(EventRow e) {
-        int dollars = e.priceCents / 100;
-        if (filterPriceMin != null && dollars < filterPriceMin)
-            return false;
-        if (filterPriceMax != null && dollars > filterPriceMax)
-            return false;
-        return true;
-    }
-
-    private static Comparator<EventRow> comparatorFor(String sort) {
-        return switch (sort) {
-            case "Date · latest" -> Comparator.comparingInt(EventRow::dayOfYear).reversed();
-            case "Price · low to high" -> Comparator.comparingInt(EventRow::priceCents);
-            case "Price · high to low" -> Comparator.comparingInt(EventRow::priceCents).reversed();
-            case "Popularity" -> Comparator.comparing(EventRow::id);
-            default -> Comparator.comparingInt(EventRow::dayOfYear); // soonest
+    /** Date-range preset → concrete [from, to] window relative to {@code today} (null bounds = open). */
+    static DateWindow dateWindow(String preset, LocalDate today) {
+        if (preset == null) return new DateWindow(null, null);
+        return switch (preset) {
+            case "Today" -> new DateWindow(today, today);
+            case "This weekend" -> {
+                LocalDate sat = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+                yield new DateWindow(sat, sat.plusDays(1));
+            }
+            case "Next 7 days" -> new DateWindow(today, today.plusDays(7));
+            case "Next 30 days" -> new DateWindow(today, today.plusDays(30));
+            case "This month" -> new DateWindow(today, today.with(TemporalAdjusters.lastDayOfMonth()));
+            case "Next 3 months" -> new DateWindow(today, today.plusMonths(3));
+            default -> new DateWindow(null, null);   // "Any time"
         };
     }
 
-    private void renderGrid() {
-        List<EventRow> visible = applyFilters();
+    private void renderGrid(List<EventRow> rows) {
         gridSlot.removeAll();
-
         if (resultsCountSpan != null) {
-            resultsCountSpan.setText(formatResultLine(visible.size()));
+            resultsCountSpan.setText(formatResultLine(rows.size()));
         }
-
-        if (visible.isEmpty()) {
+        if (rows.isEmpty()) {
             gridSlot.add(buildEmptyState());
             return;
         }
-        gridSlot.add(buildGrid(visible));
+        gridSlot.add(buildGrid(rows));
     }
 
     private String formatResultLine(int n) {
@@ -428,7 +436,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         return empty;
     }
 
-    // ---- DTO → row mapping ----
+    // ---- DTO → row mapping + sort ----
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("d MMM");
 
@@ -436,13 +444,23 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         LocalDateTime start = (dto.showDates() == null || dto.showDates().isEmpty())
                 ? null : dto.showDates().get(0).startsAt();
         String date = start == null ? "TBA" : start.format(DATE_FMT);
-        int dayOfYear = start == null ? 0 : start.getDayOfYear();
         int priceCents = (int) Math.round(dto.minPrice() * 100);
         LkStatusDot.Tone tone = dto.soldOut() ? LkStatusDot.Tone.muted : LkStatusDot.Tone.ok;
         String status = dto.soldOut() ? "Sold out" : "On sale";
         return new EventRow(dto.name(), prettyCategory(dto.category()), dto.location(),
-                dto.location(), date, dayOfYear, priceCents, tone, status,
-                String.valueOf(dto.eventId()));
+                date, start, priceCents, tone, status, String.valueOf(dto.eventId()));
+    }
+
+    private static Comparator<EventRow> comparatorFor(String sort) {
+        Comparator<EventRow> bySoonest = Comparator.comparing(EventRow::startsAt,
+                Comparator.nullsLast(Comparator.naturalOrder()));
+        return switch (sort) {
+            case "Date · latest" -> bySoonest.reversed();
+            case "Price · low to high" -> Comparator.comparingInt(EventRow::priceCents);
+            case "Price · high to low" -> Comparator.comparingInt(EventRow::priceCents).reversed();
+            case "Popularity" -> Comparator.comparing(EventRow::id);
+            default -> bySoonest; // soonest
+        };
     }
 
     private static String prettyCategory(String enumName) {

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -40,6 +40,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Route(value = "browse", layout = MainLayout.class)
 @PageTitle("Browse Events · TicketHub")
@@ -221,18 +222,21 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
 
         dateRangeField = new LkDateRangeField().label("Date range");
         dateRangeField.onChange(v -> {
+            if (Objects.equals(filterDateRange, v)) return;   // skip redundant re-query (e.g. clearFilters sync)
             filterDateRange = v;
             runSearch();
         });
 
         regionSelect = new LkSelect(REGION_ALL, REGIONS).label("Region");
         regionSelect.onChange(v -> {
+            if (Objects.equals(filterRegion, v)) return;
             filterRegion = v;
             runSearch();
         });
 
         sortSelect = new LkSelect(SORTS.get(0), SORTS).label("Sort by");
         sortSelect.onChange(v -> {
+            if (Objects.equals(filterSort, v)) return;
             filterSort = v;
             runSearch();
         });
@@ -259,6 +263,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         priceMin.setValueChangeMode(ValueChangeMode.LAZY);
         priceMin.getStyle().set("flex", "1 1 0");
         priceMin.addValueChangeListener(e -> {
+            if (Objects.equals(filterPriceMin, e.getValue())) return;
             filterPriceMin = e.getValue();
             runSearch();
         });
@@ -272,6 +277,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         priceMax.setValueChangeMode(ValueChangeMode.LAZY);
         priceMax.getStyle().set("flex", "1 1 0");
         priceMax.addValueChangeListener(e -> {
+            if (Objects.equals(filterPriceMax, e.getValue())) return;
             filterPriceMax = e.getValue();
             runSearch();
         });

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -458,10 +458,14 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     }
 
     private static Comparator<EventRow> comparatorFor(String sort) {
+        // Undated (TBA) events sort last in BOTH date views — so reverse the value order, not the
+        // whole comparator (bySoonest.reversed() would flip nullsLast and float TBA events to the top).
         Comparator<EventRow> bySoonest = Comparator.comparing(EventRow::startsAt,
                 Comparator.nullsLast(Comparator.naturalOrder()));
+        Comparator<EventRow> byLatest = Comparator.comparing(EventRow::startsAt,
+                Comparator.nullsLast(Comparator.reverseOrder()));
         return switch (sort) {
-            case "Date · latest" -> bySoonest.reversed();
+            case "Date · latest" -> byLatest;
             case "Price · low to high" -> Comparator.comparingInt(EventRow::priceCents);
             case "Price · high to low" -> Comparator.comparingInt(EventRow::priceCents).reversed();
             case "Popularity" -> Comparator.comparing(EventRow::id);

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
@@ -1,11 +1,12 @@
 package com.ticketing.system.Presentation.views.catalog;
 
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
 import com.ticketing.system.Core.Application.dto.InventoryZoneDTO;
-import com.ticketing.system.Core.Application.dto.VenueMapDTO;
-import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkCol;
@@ -15,6 +16,7 @@ import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
 import com.ticketing.system.Presentation.components.venue.VkVenueMap;
 import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresenter;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -26,6 +28,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -35,24 +38,29 @@ import java.util.Locale;
 @AnonymousAllowed
 public class EventDetailsView extends LkPage implements BeforeEnterObserver {
 
-    private final CatalogService catalogService;
+    private static final DateTimeFormatter DATE_FMT =
+            DateTimeFormatter.ofPattern("EEE, d MMM yyyy · HH:mm", Locale.US);
+
+    private final EventDetailsPresenter presenter;
     private final SessionIdentity sessionIdentity;
 
     private int eventId;
+    private EventDetailDTO detail;
     private List<InventoryZoneDTO> zones = List.of();
     private int gridRows = 3;
     private int gridCols = 3;
     private Integer selectedZoneId = null;
 
+    private final Div bodyHolder = new Div();
     private final Div mapContainer = new Div();
     private final Div zonesCardHolder = new Div();
     private Span selectedLine;
+    private LkBtn chooseBtn;
 
-    public EventDetailsView(CatalogService catalogService, SessionIdentity sessionIdentity) {
-        this.catalogService = catalogService;
+    public EventDetailsView(EventDetailsPresenter presenter, SessionIdentity sessionIdentity) {
+        this.presenter = presenter;
         this.sessionIdentity = sessionIdentity;
-        add(buildHero());
-        add(buildSplit());
+        add(bodyHolder);
     }
 
     @Override
@@ -60,32 +68,37 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         this.eventId = event.getRouteParameters().get("eventId")
                 .map(s -> { try { return Integer.parseInt(s); } catch (NumberFormatException e) { return 0; } })
                 .orElse(0);
-        loadVenue();
+        loadAndBuild();
     }
 
-    private void loadVenue() {
+    private void loadAndBuild() {
+        bodyHolder.removeAll();
+        this.detail = null;
+        this.zones = List.of();
+        this.selectedZoneId = null;
+
         if (eventId <= 0) {
+            bodyHolder.add(infoBanner("This event isn't available."));
             return;
         }
-        try {
-            VenueMapDTO map = catalogService.getEventVenueMap(sessionIdentity.credential(), eventId);
-            this.zones = map.inventoryZones();
-            this.gridRows = map.gridRows();
-            this.gridCols = map.gridCols();
-            this.selectedZoneId = firstSelectableZoneId();
-            refreshMap();
-            refreshZonesCard();
-            updateSelectedLine();
-        } catch (RuntimeException ex) {
-            // No (accessible) venue map — leave the placeholders; the rail shows a hint.
-            this.zones = List.of();
-            refreshMap();
-            refreshZonesCard();
-            updateSelectedLine();
+
+        switch (presenter.load(sessionIdentity.credential(), eventId)) {
+            case EventDetailsPresenter.Outcome.Success s -> {
+                this.detail = s.event();
+                this.zones = s.zones();
+                this.gridRows = s.gridRows();
+                this.gridCols = s.gridCols();
+                this.selectedZoneId = firstSelectableZoneId();
+                bodyHolder.add(buildHero(), buildSplit());
+            }
+            case EventDetailsPresenter.Outcome.NotFound nf ->
+                bodyHolder.add(infoBanner(nf.message()));
+            case EventDetailsPresenter.Outcome.Failure f ->
+                bodyHolder.add(infoBanner(f.message()));
         }
     }
 
-    // -------- hero (event metadata — static placeholder; no public single-event read exists yet) --------
+    // -------- hero (real event metadata: header, lineup, schedule, description, status badge) --------
 
     private Component buildHero() {
         Div hero = new Div();
@@ -94,22 +107,43 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         Div poster = new Div();
         poster.addClassName("bz-evt-hero-poster");
         poster.getStyle().set("background", "linear-gradient(135deg, #8b5cf6, #ec4899)");
-        poster.setText("EVENT");
+        poster.setText(posterText(detail.name()));
 
         Div meta = new Div();
         meta.addClassName("bz-evt-hero-meta");
 
         LkRow badges = new LkRow().gap(8);
-        badges.add(new LkBadge("ON SALE", LkBadge.Tone.success).small());
+        badges.add(statusBadge(detail.status()));
+        if (detail.category() != null) {
+            badges.add(new LkBadge(prettify(detail.category().toString()), LkBadge.Tone.muted).small());
+        }
 
         Div title = new Div();
         title.addClassName("bz-evt-title");
-        title.setText("Event detail");
+        title.setText(detail.name());
 
-        Span sub = Lk.muted("Pick your area below to choose seats or quantity");
-        sub.getStyle().set("font-size", "15px");
+        meta.add(badges, title);
 
-        meta.add(badges, title, sub);
+        String lineup = detail.artistsNames() == null ? "" : String.join(" · ", detail.artistsNames());
+        if (!lineup.isBlank()) {
+            Span artists = new Span(lineup);
+            artists.getStyle().set("font-size", "15px").set("font-weight", "600");
+            meta.add(artists);
+        }
+
+        String when = scheduleLine();
+        if (when != null) {
+            Span schedule = Lk.muted(when);
+            schedule.getStyle().set("font-size", "14px");
+            meta.add(schedule);
+        }
+
+        if (detail.description() != null && !detail.description().isBlank()) {
+            Span desc = Lk.muted(detail.description());
+            desc.getStyle().set("font-size", "15px");
+            meta.add(desc);
+        }
+
         hero.add(poster, meta);
         return hero;
     }
@@ -124,6 +158,7 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
             .subtitle("Tap a zone to choose seats or quantity")
             .pad(16);
 
+        mapContainer.removeAll();
         mapContainer.add(renderMap());
         mapCard.add(mapContainer);
 
@@ -241,18 +276,40 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         selectedLine = new Span();
         updateSelectedLine();
 
-        LkBtn choose = new LkBtn("Choose tickets →")
+        chooseBtn = new LkBtn("Choose tickets →")
             .variant(LkBtn.Variant.primary)
             .size(LkBtn.Size.l)
             .full()
             .onClick(e -> openPicker());
-        choose.getStyle().set("margin-top", "10px");
+        chooseBtn.getStyle().set("margin-top", "10px");
         Span hint = Lk.muted("Seats lock for 10 min once selected");
         hint.getStyle()
             .set("display", "block").set("margin-top", "8px")
             .set("text-align", "center").set("font-size", "12.5px");
-        card.add(selectedLine, choose, hint);
+        card.add(selectedLine, chooseBtn, hint);
+        updateReserveState();
         return card;
+    }
+
+    /** Disable + relabel 'Choose tickets' for non-purchasable events (cancelled / ended / sold out). */
+    private void updateReserveState() {
+        if (chooseBtn == null) {
+            return;
+        }
+        EventStatus status = detail == null ? null : detail.status();
+        if (status == EventStatus.CANCELED) {
+            chooseBtn.setEnabled(false);
+            chooseBtn.label("Event cancelled");
+        } else if (status == EventStatus.COMPLETED) {
+            chooseBtn.setEnabled(false);
+            chooseBtn.label("Event ended");
+        } else if (status == EventStatus.SOLD_OUT || firstSelectableZoneId() == null) {
+            chooseBtn.setEnabled(false);
+            chooseBtn.label("Sold out");
+        } else {
+            chooseBtn.setEnabled(true);
+            chooseBtn.label("Choose tickets →");
+        }
     }
 
     private void openPicker() {
@@ -282,6 +339,58 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         int row = Math.min((idx / Math.max(gridCols, 1)) + 1, gridRows);
         int col = (idx % Math.max(gridCols, 1)) + 1;
         return new GridPlacementDTO(row, col, 1, 1);
+    }
+
+    private static String posterText(String name) {
+        if (name == null || name.isBlank()) {
+            return "EVENT";
+        }
+        return name.trim().substring(0, 1).toUpperCase(Locale.US);
+    }
+
+    private static LkBadge statusBadge(EventStatus status) {
+        if (status == null) {
+            return new LkBadge("—", LkBadge.Tone.muted).small();
+        }
+        return switch (status) {
+            case ON_SALE   -> new LkBadge("ON SALE", LkBadge.Tone.success).small();
+            case SOLD_OUT  -> new LkBadge("SOLD OUT", LkBadge.Tone.warning).small();
+            case CANCELED  -> new LkBadge("CANCELLED", LkBadge.Tone.error).small();
+            case COMPLETED -> new LkBadge("PAST", LkBadge.Tone.muted).small();
+            default        -> new LkBadge(prettify(status.toString()), LkBadge.Tone.muted).small();
+        };
+    }
+
+    private static String prettify(String enumName) {
+        if (enumName == null || enumName.isBlank()) {
+            return "";
+        }
+        String lower = enumName.replace('_', ' ').toLowerCase(Locale.US);
+        return Character.toUpperCase(lower.charAt(0)) + lower.substring(1);
+    }
+
+    private String scheduleLine() {
+        StringBuilder sb = new StringBuilder();
+        if (detail.showDates() != null && !detail.showDates().isEmpty()
+                && detail.showDates().get(0).getStartTime() != null) {
+            sb.append(DATE_FMT.format(detail.showDates().get(0).getStartTime()));
+        }
+        var loc = detail.location();
+        if (loc != null) {
+            if (sb.length() > 0) {
+                sb.append(" · ");
+            }
+            sb.append(loc.city()).append(", ").append(loc.country());
+        }
+        return sb.length() == 0 ? null : sb.toString();
+    }
+
+    private Component infoBanner(String message) {
+        LkBanner banner = new LkBanner();
+        banner.tone(LkBanner.Tone.info);
+        banner.setIcon(new LkIcon("info", 18));
+        banner.setBody(new Span(message));
+        return banner;
     }
 
     private static String pct(double v) {

--- a/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
@@ -1,0 +1,66 @@
+package com.ticketing.system.Presentation.views.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the pure filter-mapping helpers of {@link BrowseEventsView} (#271) — the UI
+ * category label → enum-name mapping and the date-range preset → concrete window. Lives in the
+ * view's package to reach the package-private static helpers; needs no Vaadin/Spring.
+ */
+class BrowseEventsFilterTest {
+
+    @Test
+    void categoryFilterValue_mapsLabelsToEnumNames() {
+        assertEquals("CONCERT",  BrowseEventsView.categoryFilterValue("Concerts"));
+        assertEquals("SPORTS",   BrowseEventsView.categoryFilterValue("Sports"));
+        assertEquals("THEATER",  BrowseEventsView.categoryFilterValue("Theatre"));
+        assertEquals("FESTIVAL", BrowseEventsView.categoryFilterValue("Festivals"));
+        assertEquals("COMEDY",   BrowseEventsView.categoryFilterValue("Comedy"));
+    }
+
+    @Test
+    void categoryFilterValue_allOrUnknownOrNull_isNull() {
+        assertNull(BrowseEventsView.categoryFilterValue("All categories"));
+        assertNull(BrowseEventsView.categoryFilterValue("Nonsense"));
+        assertNull(BrowseEventsView.categoryFilterValue(null));
+    }
+
+    @Test
+    void dateWindow_anyTimeOrNull_isOpen() {
+        assertEquals(new BrowseEventsView.DateWindow(null, null),
+                BrowseEventsView.dateWindow("Any time", LocalDate.of(2026, 6, 24)));
+        assertEquals(new BrowseEventsView.DateWindow(null, null),
+                BrowseEventsView.dateWindow(null, LocalDate.of(2026, 6, 24)));
+    }
+
+    @Test
+    void dateWindow_relativePresets_resolveAgainstToday() {
+        LocalDate today = LocalDate.of(2026, 6, 24);
+        assertEquals(new BrowseEventsView.DateWindow(today, today),
+                BrowseEventsView.dateWindow("Today", today));
+        assertEquals(new BrowseEventsView.DateWindow(today, today.plusDays(7)),
+                BrowseEventsView.dateWindow("Next 7 days", today));
+        assertEquals(new BrowseEventsView.DateWindow(today, today.plusDays(30)),
+                BrowseEventsView.dateWindow("Next 30 days", today));
+        assertEquals(new BrowseEventsView.DateWindow(today, today.plusMonths(3)),
+                BrowseEventsView.dateWindow("Next 3 months", today));
+        assertEquals(new BrowseEventsView.DateWindow(today, LocalDate.of(2026, 6, 30)),
+                BrowseEventsView.dateWindow("This month", today));
+    }
+
+    @Test
+    void dateWindow_thisWeekend_isUpcomingSaturdayToSunday() {
+        LocalDate today = LocalDate.of(2026, 6, 24); // a Wednesday
+        BrowseEventsView.DateWindow w = BrowseEventsView.dateWindow("This weekend", today);
+        assertEquals(DayOfWeek.SATURDAY, w.from().getDayOfWeek());
+        assertEquals(w.from().plusDays(1), w.to());          // Saturday → Sunday
+        assertFalse(w.from().isBefore(today));               // upcoming, not in the past
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +20,7 @@ import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
+import com.ticketing.system.Core.Application.dto.SearchResultDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapDTO;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.CatalogService;
@@ -648,6 +650,111 @@ class CatalogServiceTest {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    // -------------------------------------------------------------------------
+    // V2-SEARCH-01 (#281): top-bar search across events + artists + venues
+    // -------------------------------------------------------------------------
+
+    // A minimal ON_SALE event for search: name, company, artists, and a venue at LOCATION
+    // ("Brussels, Belgium"). search() never reads status/rating/category, so we leave those unstubbed.
+    private Event searchEvent(int id, int companyId, String name, List<String> artists) {
+        Event e = mock(Event.class);
+        when(e.getId()).thenReturn(id);
+        when(e.getName()).thenReturn(name);
+        when(e.getCompanyId()).thenReturn(companyId);
+        when(e.getArtistsNames()).thenReturn(artists);
+        when(e.getVenueMap()).thenReturn(new VenueMap(id, LOCATION, List.of()));
+        return e;
+    }
+
+    @Test
+    void givenInvalidCredential_whenSearch_thenThrowsInvalidTokenException() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(false);
+
+        assertThrows(InvalidTokenException.class,
+                () -> catalogService.search(VALID_TOKEN, "coldplay", 8));
+    }
+
+    @Test
+    void givenBlankQuery_whenSearch_thenReturnsEmpty() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+
+        assertTrue(catalogService.search(VALID_TOKEN, "   ", 8).isEmpty());
+    }
+
+    @Test
+    void givenEventNameMatch_whenSearch_thenEventRowReturned() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        Event e = searchEvent(1, 10, "Coldplay Live", List.of("Coldplay"));
+        ProductionCompany company = createMockCompany("Live Nation", 4.5);
+        when(mockEventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        List<SearchResultDTO> results = catalogService.search(VALID_TOKEN, "coldplay live", 8);
+
+        assertEquals(1, results.size());
+        assertEquals("EVENT", results.get(0).type());
+        assertEquals("Coldplay Live", results.get(0).title());
+        assertEquals(1, results.get(0).eventId());
+    }
+
+    @Test
+    void givenArtistMatch_whenSearch_thenArtistRowReturned() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        Event e = searchEvent(2, 10, "Mystery Show", List.of("Coldplay", "Support Act"));
+        ProductionCompany company = createMockCompany("Live Nation", 4.5);
+        when(mockEventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        List<SearchResultDTO> results = catalogService.search(VALID_TOKEN, "coldplay", 8);
+
+        assertEquals(1, results.size());
+        assertEquals("ARTIST", results.get(0).type());
+        assertEquals("Coldplay", results.get(0).title());
+        assertEquals(2, results.get(0).eventId());
+    }
+
+    @Test
+    void givenVenueMatch_whenSearch_thenVenueRowReturned() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        Event e = searchEvent(3, 10, "Some Gig", List.of("Nobody"));
+        ProductionCompany company = createMockCompany("Live Nation", 4.5);
+        when(mockEventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        List<SearchResultDTO> results = catalogService.search(VALID_TOKEN, "brussels", 8);
+
+        assertEquals(1, results.size());
+        assertEquals("VENUE", results.get(0).type());
+        assertEquals("Brussels, Belgium", results.get(0).title());
+        assertEquals(3, results.get(0).eventId());
+    }
+
+    @Test
+    void givenInactiveCompany_whenSearch_thenEventExcluded() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        Event e = searchEvent(1, 10, "Coldplay Live", List.of("Coldplay"));
+        when(mockEventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+        ProductionCompany inactive = mock(ProductionCompany.class);
+        when(inactive.getStatus()).thenReturn(CompanyStatus.INACTIVE);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(inactive);
+
+        assertTrue(catalogService.search(VALID_TOKEN, "coldplay", 8).isEmpty());
+    }
+
+    @Test
+    void givenManyMatches_whenSearch_thenCappedToLimit() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        List<Event> many = new ArrayList<>();
+        for (int i = 1; i <= 10; i++) {
+            many.add(searchEvent(i, 10, "Show " + i, List.of()));
+        }
+        ProductionCompany company = createMockCompany("Live Nation", 4.5);
+        when(mockEventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(many);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        assertEquals(3, catalogService.search(VALID_TOKEN, "show", 3).size());
+    }
 
     private CatalogSearchFiltersDTO emptyFilters() {
         return new CatalogSearchFiltersDTO(

--- a/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapDTO;
@@ -35,6 +36,7 @@ import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Domain.events.StandingZone;
 import com.ticketing.system.Core.Domain.events.Location;
 import com.ticketing.system.Core.Domain.events.VenueMap;
+import com.ticketing.system.Core.Domain.exceptions.CompanyClosedException;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Core.Domain.exceptions.NullVenueMapException;
@@ -509,6 +511,93 @@ class CatalogServiceTest {
 
     
     // -------------------------------------------------------------------------
+    // #272 / UC-8: getEventDetail (public single-event read for the buyer page)
+    // -------------------------------------------------------------------------
+
+    // getEventDetail returns the full detail (incl. lineup) for an ON_SALE event of an active company.
+    @Test
+    void givenValidCredentialAndOnSaleEvent_whenGetEventDetail_thenReturnsDetailWithLineup() {
+        Event event = detailEvent(EVENT_ID, 10, EventStatus.ON_SALE);
+        ProductionCompany company = createMockCompany("Acme Live", 4.5);
+
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        when(mockEventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        EventDetailDTO result = catalogService.getEventDetail(VALID_TOKEN, EVENT_ID);
+
+        assertNotNull(result);
+        assertEquals("Event " + EVENT_ID, result.name());
+        assertEquals(EventStatus.ON_SALE, result.status());
+        assertEquals("Acme Live", result.companyName());
+        assertEquals(List.of("Artist A", "Artist B"), result.artistsNames());
+        assertEquals("Brussels", result.location().city());
+    }
+
+    // A SOLD_OUT event is still publicly viewable (the page shows a badge + disabled purchase).
+    @Test
+    void givenSoldOutEvent_whenGetEventDetail_thenReturnsDetail() {
+        Event event = detailEvent(EVENT_ID, 10, EventStatus.SOLD_OUT);
+        ProductionCompany company = createMockCompany("Acme Live", 4.5);
+
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        when(mockEventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        EventDetailDTO result = catalogService.getEventDetail(VALID_TOKEN, EVENT_ID);
+
+        assertEquals(EventStatus.SOLD_OUT, result.status());
+    }
+
+    // Invalid/expired credential is rejected before any lookup.
+    @Test
+    void givenInvalidCredential_whenGetEventDetail_thenThrowsInvalidTokenException() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(false);
+
+        assertThrows(InvalidTokenException.class,
+                () -> catalogService.getEventDetail(VALID_TOKEN, EVENT_ID));
+    }
+
+    // A missing event yields EventNotFoundException.
+    @Test
+    void givenNonExistentEvent_whenGetEventDetail_thenThrowsEventNotFoundException() {
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        when(mockEventRepository.findById(EVENT_ID)).thenReturn(null);
+
+        assertThrows(EventNotFoundException.class,
+                () -> catalogService.getEventDetail(VALID_TOKEN, EVENT_ID));
+    }
+
+    // Events of a closed/inactive company are hidden.
+    @Test
+    void givenInactiveCompany_whenGetEventDetail_thenThrowsCompanyClosedException() {
+        Event event = detailEvent(EVENT_ID, 10, EventStatus.ON_SALE);
+        ProductionCompany company = mock(ProductionCompany.class);
+        when(company.getStatus()).thenReturn(CompanyStatus.INACTIVE);
+
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        when(mockEventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        assertThrows(CompanyClosedException.class,
+                () -> catalogService.getEventDetail(VALID_TOKEN, EVENT_ID));
+    }
+
+    // DRAFT / SCHEDULED events are not yet public — treated as not found.
+    @Test
+    void givenDraftEvent_whenGetEventDetail_thenThrowsEventNotFoundException() {
+        Event event = detailEvent(EVENT_ID, 10, EventStatus.DRAFT);
+        ProductionCompany company = createMockCompany("Acme Live", 4.5);
+
+        when(mockSessionManager.validateCredential(VALID_TOKEN)).thenReturn(true);
+        when(mockEventRepository.findById(EVENT_ID)).thenReturn(event);
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(company);
+
+        assertThrows(EventNotFoundException.class,
+                () -> catalogService.getEventDetail(VALID_TOKEN, EVENT_ID));
+    }
+
+    // -------------------------------------------------------------------------
     // V2-LANDING-01: featured / upcomingOnSale (guest-facing landing rows)
     // -------------------------------------------------------------------------
 
@@ -586,6 +675,23 @@ class CatalogServiceTest {
         when(mockCompany.getRating()).thenReturn(rating);
         when(mockCompany.getStatus()).thenReturn(CompanyStatus.ACTIVE);
         return mockCompany;
+    }
+
+    // A fully-stubbed event for getEventDetail tests (mapper reads name/desc/rating/category/
+    // lineup/location/showDates/status).
+    private Event detailEvent(int id, int companyId, EventStatus status) {
+        Event mockEvent = mock(Event.class);
+        when(mockEvent.getId()).thenReturn(id);
+        when(mockEvent.getName()).thenReturn("Event " + id);
+        when(mockEvent.getStatus()).thenReturn(status);
+        when(mockEvent.getRating()).thenReturn(4.5);
+        when(mockEvent.getDescription()).thenReturn("Description for event " + id);
+        when(mockEvent.getCategory()).thenReturn(EventCategory.MUSIC);
+        when(mockEvent.getCompanyId()).thenReturn(companyId);
+        when(mockEvent.getArtistsNames()).thenReturn(List.of("Artist A", "Artist B"));
+        when(mockEvent.getVenueMap()).thenReturn(new VenueMap(id, LOCATION, List.of()));
+        when(mockEvent.getShowDates()).thenReturn(List.of());
+        return mockEvent;
     }
 
     // An ON_SALE event with an explicit rating (for featured ordering). No show dates needed —

--- a/src/test/java/com/ticketing/system/unit/application/MemberAccountServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/MemberAccountServiceTest.java
@@ -14,6 +14,9 @@ import com.ticketing.system.Core.Domain.Tickets.Ticket;
 import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
 import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 
@@ -25,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class MemberAccountServiceTest {
@@ -115,5 +119,81 @@ class MemberAccountServiceTest {
 
     @Test @Disabled("UC-16 + II.3.5.2: history reflects price-at-purchase, not current price")
     void givenPriceChangedAfterSale_whenViewMyHistory_thenOriginalPriceShown() {
+    }
+
+    // ---- viewMyReceipt (#276): single member-owned receipt; throws instead of degrading ----
+
+    static final int RECEIPT_ID = 7;
+    static final int OTHER_USER = 99;
+
+    private static OrderReceipt memberReceipt(int receiptId, int userId) {
+        LocalDateTime t = LocalDateTime.of(2026, 6, 1, 12, 0);
+        ReceiptLine line = new ReceiptLine(101, 150.00, 2, 1, "15", t);
+        return OrderReceipt.forMember(receiptId, userId, 150.00, List.of(line));
+    }
+
+    @Test
+    void givenOwnReceipt_whenViewMyReceipt_thenRecordReturned() {
+        OrderReceipt own = memberReceipt(RECEIPT_ID, USER_ID);
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(RECEIPT_ID)).thenReturn(Optional.of(own));
+        Mockito.when(ticketRepository.findByOrderReceiptId(RECEIPT_ID)).thenReturn(List.of());
+        Mockito.when(eventRepository.findById(2)).thenReturn(null);
+
+        PurchaseRecordDTO record = service.viewMyReceipt(VALID_TOKEN, RECEIPT_ID);
+
+        assertThat(record.orderReceiptId()).isEqualTo(RECEIPT_ID);
+        assertThat(record.buyerUserId()).isEqualTo(USER_ID);
+        assertThat(record.totalPaid()).isEqualByComparingTo(150.00);
+        assertThat(record.tickets()).hasSize(1);
+        assertThat(record.tickets().getFirst().ticketId()).isEqualTo(101);
+    }
+
+    @Test
+    void givenInvalidToken_whenViewMyReceipt_thenInvalidTokenThrown() {
+        Mockito.when(authenticationService.validateToken(INVALID_TOKEN)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.viewMyReceipt(INVALID_TOKEN, RECEIPT_ID))
+                .isInstanceOf(InvalidTokenException.class);
+
+        Mockito.verify(orderReceiptRepository, Mockito.never()).findByOrderReceiptId(Mockito.anyInt());
+    }
+
+    @Test
+    void givenMissingReceipt_whenViewMyReceipt_thenEntityNotFoundThrown() {
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(RECEIPT_ID)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.viewMyReceipt(VALID_TOKEN, RECEIPT_ID))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void givenAnotherMembersReceipt_whenViewMyReceipt_thenUnauthorizedThrown() {
+        OrderReceipt someoneElses = memberReceipt(RECEIPT_ID, OTHER_USER);
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(RECEIPT_ID)).thenReturn(Optional.of(someoneElses));
+
+        assertThatThrownBy(() -> service.viewMyReceipt(VALID_TOKEN, RECEIPT_ID))
+                .isInstanceOf(UnauthorizedActionException.class);
+
+        // ownership rejected before any enrichment work
+        Mockito.verify(ticketRepository, Mockito.never()).findByOrderReceiptId(Mockito.anyInt());
+    }
+
+    @Test
+    void givenGuestReceipt_whenViewMyReceipt_thenUnauthorizedThrown() {
+        LocalDateTime t = LocalDateTime.of(2026, 6, 1, 12, 0);
+        ReceiptLine line = new ReceiptLine(101, 150.00, 2, 1, "15", t);
+        OrderReceipt guestReceipt = OrderReceipt.forGuest("g@example.com", "guest-sess-1", RECEIPT_ID, 150.00, List.of(line));
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(RECEIPT_ID)).thenReturn(Optional.of(guestReceipt));
+
+        assertThatThrownBy(() -> service.viewMyReceipt(VALID_TOKEN, RECEIPT_ID))
+                .isInstanceOf(UnauthorizedActionException.class);
     }
 }

--- a/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
@@ -1,0 +1,152 @@
+package com.ticketing.system.unit.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.RefundService;
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+import com.ticketing.system.Core.Domain.orders.ReceiptLine;
+import com.ticketing.system.Core.Domain.orders.TransactionRecord;
+
+@ExtendWith(MockitoExtension.class)
+class RefundServiceTest {
+
+    @Mock AuthenticationService authenticationService;
+    @Mock IOrderReceiptRepository orderReceiptRepository;
+    @Mock ITicketRepository ticketRepository;
+    @Mock IPaymentGateway paymentGateway;
+    @Mock Ticket ticket;
+
+    RefundService service;
+
+    static final String VALID_TOKEN   = "valid-token";
+    static final String INVALID_TOKEN = "bad-token";
+    static final int    USER_ID       = 42;
+    static final int    OTHER_USER    = 99;
+    static final int    ORDER_ID      = 7;
+    static final int    PAYMENT_TX    = 555;
+    static final double TOTAL         = 150.00;
+    static final LocalDateTime WHEN   = LocalDateTime.of(2026, 6, 1, 12, 0);
+
+    @BeforeEach
+    void setUp() {
+        service = new RefundService(authenticationService, orderReceiptRepository, ticketRepository, paymentGateway);
+    }
+
+    private static OrderReceipt memberReceiptWithCharge(int userId) {
+        ReceiptLine line = new ReceiptLine(101, TOTAL, 2, 1, "15", WHEN);
+        TransactionRecord charge = TransactionRecord.paymentCharge(PAYMENT_TX, "stub", TOTAL, "ILS", WHEN);
+        return OrderReceipt.forMember(ORDER_ID, userId, TOTAL, List.of(line), List.of(charge));
+    }
+
+    private static RefundResultDTO gatewayResult() {
+        return new RefundResultDTO("refund-1", String.valueOf(PAYMENT_TX), TOTAL, WHEN, List.of(), List.of());
+    }
+
+    @Test
+    void givenOwnPaidOrder_whenRequestRefund_thenReceiptAndTicketsRefunded() {
+        OrderReceipt receipt = memberReceiptWithCharge(USER_ID);
+        RefundResultDTO result = gatewayResult();
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(java.util.Optional.of(receipt));
+        Mockito.when(paymentGateway.refund(PAYMENT_TX, TOTAL)).thenReturn(result);
+        Mockito.when(paymentGateway.getId()).thenReturn("stub");
+        Mockito.when(ticketRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(List.of(ticket));
+        Mockito.when(ticket.getStatus()).thenReturn(TicketStatus.PAID);
+
+        RefundResultDTO returned = service.requestRefund(VALID_TOKEN, ORDER_ID, "Can't attend");
+
+        assertThat(returned).isSameAs(result);
+        assertThat(receipt.wasRefunded()).isTrue();
+        Mockito.verify(paymentGateway).refund(PAYMENT_TX, TOTAL);
+        Mockito.verify(ticket).markRefunded();
+        Mockito.verify(ticketRepository).save(ticket);
+        Mockito.verify(orderReceiptRepository).save(receipt);
+    }
+
+    @Test
+    void givenInvalidToken_whenRequestRefund_thenInvalidTokenThrown() {
+        Mockito.when(authenticationService.validateToken(INVALID_TOKEN)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.requestRefund(INVALID_TOKEN, ORDER_ID, "x"))
+                .isInstanceOf(InvalidTokenException.class);
+
+        Mockito.verify(paymentGateway, Mockito.never()).refund(Mockito.anyInt(), Mockito.anyDouble());
+    }
+
+    @Test
+    void givenMissingOrder_whenRequestRefund_thenEntityNotFoundThrown() {
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(java.util.Optional.empty());
+
+        assertThatThrownBy(() -> service.requestRefund(VALID_TOKEN, ORDER_ID, "x"))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    @Test
+    void givenAnotherMembersOrder_whenRequestRefund_thenUnauthorizedThrown() {
+        OrderReceipt receipt = memberReceiptWithCharge(OTHER_USER);
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(java.util.Optional.of(receipt));
+
+        assertThatThrownBy(() -> service.requestRefund(VALID_TOKEN, ORDER_ID, "x"))
+                .isInstanceOf(UnauthorizedActionException.class);
+
+        Mockito.verify(paymentGateway, Mockito.never()).refund(Mockito.anyInt(), Mockito.anyDouble());
+    }
+
+    @Test
+    void givenAlreadyRefundedOrder_whenRequestRefund_thenNotEligibleThrown() {
+        OrderReceipt receipt = memberReceiptWithCharge(USER_ID);
+        receipt.markRefunded();
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(java.util.Optional.of(receipt));
+
+        assertThatThrownBy(() -> service.requestRefund(VALID_TOKEN, ORDER_ID, "x"))
+                .isInstanceOf(BusinessRuleViolationException.class);
+
+        Mockito.verify(paymentGateway, Mockito.never()).refund(Mockito.anyInt(), Mockito.anyDouble());
+    }
+
+    @Test
+    void givenGatewayFailure_whenRequestRefund_thenRefundFailedPropagatesAndNoStateChange() {
+        OrderReceipt receipt = memberReceiptWithCharge(USER_ID);
+        Mockito.when(authenticationService.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(authenticationService.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        Mockito.when(orderReceiptRepository.findByOrderReceiptId(ORDER_ID)).thenReturn(java.util.Optional.of(receipt));
+        Mockito.when(paymentGateway.refund(PAYMENT_TX, TOTAL))
+                .thenThrow(new RefundFailedException(ORDER_ID, "gateway down"));
+
+        assertThatThrownBy(() -> service.requestRefund(VALID_TOKEN, ORDER_ID, "x"))
+                .isInstanceOf(RefundFailedException.class);
+
+        assertThat(receipt.wasRefunded()).isFalse();
+        Mockito.verify(orderReceiptRepository, Mockito.never()).save(Mockito.any());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/BrowseEventsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/BrowseEventsPresenterTest.java
@@ -1,0 +1,55 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
+import com.ticketing.system.Core.Application.dto.EventSummaryDTO;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
+
+class BrowseEventsPresenterTest {
+
+    private static final String CRED = "cred";
+
+    private CatalogService catalogService;
+    private BrowseEventsPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        catalogService = mock(CatalogService.class);
+        presenter = new BrowseEventsPresenter(catalogService);
+    }
+
+    private static EventSummaryDTO summary() {
+        return new EventSummaryDTO(1, "Coldplay", "ON_SALE", 4.8, "Live Nation",
+                "CONCERT", "Tel Aviv, Israel", List.of(), 90.0, 250.0, false);
+    }
+
+    @Test
+    void search_delegatesToSearchGlobalAndReturnsResults() {
+        CatalogSearchFiltersDTO filters = CatalogSearchFiltersDTO.empty();
+        List<EventSummaryDTO> events = List.of(summary());
+        when(catalogService.searchGlobal(eq(CRED), eq(filters))).thenReturn(events);
+
+        List<EventSummaryDTO> result = presenter.search(CRED, filters);
+
+        assertSame(events, result);
+    }
+
+    @Test
+    void search_onServiceFailure_returnsEmpty() {
+        when(catalogService.searchGlobal(eq(CRED), any())).thenThrow(new RuntimeException("boom"));
+
+        assertTrue(presenter.search(CRED, CatalogSearchFiltersDTO.empty()).isEmpty());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
@@ -1,0 +1,114 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.InventoryZoneDTO;
+import com.ticketing.system.Core.Application.dto.LocationDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapDTO;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.exceptions.CompanyClosedException;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.NullVenueMapException;
+import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresenter;
+
+class EventDetailsPresenterTest {
+
+    private static final String CRED = "cred";
+    private static final int EVENT_ID = 1;
+
+    private CatalogService catalogService;
+    private EventDetailsPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        catalogService = mock(CatalogService.class);
+        presenter = new EventDetailsPresenter(catalogService);
+    }
+
+    private static EventDetailDTO detail() {
+        return new EventDetailDTO("1", "Coldplay", 4.8, "Music of the Spheres",
+                EventCategory.MUSIC, new Location("Israel", "Tel Aviv"), "10", "Live Nation",
+                EventStatus.ON_SALE, List.of(), List.of("Coldplay"));
+    }
+
+    private static VenueMapDTO venueMap() {
+        InventoryZoneDTO zone = new InventoryZoneDTO(
+                1, "Floor", "STANDING", 100, 80, 0, 0, 90.0, List.of(), null);
+        return new VenueMapDTO(5, new LocationDTO("Israel", "Tel Aviv"), 4, 4, List.of(zone));
+    }
+
+    @Test
+    void load_success_carriesEventAndZones() {
+        EventDetailDTO detail = detail();
+        when(catalogService.getEventDetail(CRED, EVENT_ID)).thenReturn(detail);
+        when(catalogService.getEventVenueMap(CRED, EVENT_ID)).thenReturn(venueMap());
+
+        EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
+
+        EventDetailsPresenter.Outcome.Success ok =
+                assertInstanceOf(EventDetailsPresenter.Outcome.Success.class, outcome);
+        assertSame(detail, ok.event());
+        assertEquals(1, ok.zones().size());
+        assertEquals(4, ok.gridRows());
+        assertEquals(4, ok.gridCols());
+    }
+
+    @Test
+    void load_eventNotFound_returnsNotFound() {
+        when(catalogService.getEventDetail(CRED, EVENT_ID)).thenThrow(new EventNotFoundException("nope"));
+
+        EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
+
+        assertInstanceOf(EventDetailsPresenter.Outcome.NotFound.class, outcome);
+    }
+
+    @Test
+    void load_companyClosed_returnsNotFound() {
+        when(catalogService.getEventDetail(CRED, EVENT_ID)).thenThrow(new CompanyClosedException("closed"));
+
+        EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
+
+        assertInstanceOf(EventDetailsPresenter.Outcome.NotFound.class, outcome);
+    }
+
+    @Test
+    void load_invalidToken_returnsFailure() {
+        when(catalogService.getEventDetail(CRED, EVENT_ID)).thenThrow(new InvalidTokenException());
+
+        EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
+
+        assertInstanceOf(EventDetailsPresenter.Outcome.Failure.class, outcome);
+    }
+
+    // An event with no (accessible) venue map still shows its detail — zones fall back to empty.
+    @Test
+    void load_venueMapMissing_stillSuccessWithEmptyZones() {
+        EventDetailDTO detail = detail();
+        when(catalogService.getEventDetail(CRED, EVENT_ID)).thenReturn(detail);
+        when(catalogService.getEventVenueMap(CRED, EVENT_ID)).thenThrow(new NullVenueMapException(EVENT_ID));
+
+        EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
+
+        EventDetailsPresenter.Outcome.Success ok =
+                assertInstanceOf(EventDetailsPresenter.Outcome.Success.class, outcome);
+        assertSame(detail, ok.event());
+        assertTrue(ok.zones().isEmpty());
+        assertEquals(3, ok.gridRows());
+        assertEquals(3, ok.gridCols());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/ReceiptPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/ReceiptPresenterTest.java
@@ -1,0 +1,80 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
+import com.ticketing.system.Core.Application.services.MemberAccountService;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+import com.ticketing.system.Presentation.presenters.account.ReceiptPresenter;
+
+class ReceiptPresenterTest {
+
+    private static final String TOKEN = "member-token";
+    private static final int RECEIPT_ID = 7;
+
+    private MemberAccountService memberAccountService;
+    private ReceiptPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        memberAccountService = mock(MemberAccountService.class);
+        presenter = new ReceiptPresenter(memberAccountService);
+    }
+
+    private static PurchaseRecordDTO record() {
+        return new PurchaseRecordDTO(RECEIPT_ID, 42, null,
+                java.time.LocalDateTime.of(2026, 6, 1, 12, 0), 150.00, false,
+                List.of(), List.of(), "member42");
+    }
+
+    @Test
+    void load_success_carriesReceipt() {
+        PurchaseRecordDTO record = record();
+        when(memberAccountService.viewMyReceipt(TOKEN, RECEIPT_ID)).thenReturn(record);
+
+        ReceiptPresenter.Outcome outcome = presenter.load(TOKEN, RECEIPT_ID);
+
+        ReceiptPresenter.Outcome.Success ok =
+                assertInstanceOf(ReceiptPresenter.Outcome.Success.class, outcome);
+        assertSame(record, ok.receipt());
+    }
+
+    @Test
+    void load_missingReceipt_returnsNotFound() {
+        when(memberAccountService.viewMyReceipt(TOKEN, RECEIPT_ID))
+                .thenThrow(new EntityNotFoundException("OrderReceipt", RECEIPT_ID));
+
+        ReceiptPresenter.Outcome outcome = presenter.load(TOKEN, RECEIPT_ID);
+
+        assertInstanceOf(ReceiptPresenter.Outcome.NotFound.class, outcome);
+    }
+
+    @Test
+    void load_otherMembersReceipt_returnsForbidden() {
+        when(memberAccountService.viewMyReceipt(TOKEN, RECEIPT_ID))
+                .thenThrow(new UnauthorizedActionException("view receipt " + RECEIPT_ID, 42));
+
+        ReceiptPresenter.Outcome outcome = presenter.load(TOKEN, RECEIPT_ID);
+
+        assertInstanceOf(ReceiptPresenter.Outcome.Forbidden.class, outcome);
+    }
+
+    @Test
+    void load_invalidToken_returnsFailure() {
+        when(memberAccountService.viewMyReceipt(TOKEN, RECEIPT_ID)).thenThrow(new InvalidTokenException());
+
+        ReceiptPresenter.Outcome outcome = presenter.load(TOKEN, RECEIPT_ID);
+
+        assertInstanceOf(ReceiptPresenter.Outcome.Failure.class, outcome);
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/RefundPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/RefundPresenterTest.java
@@ -1,0 +1,84 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.services.RefundService;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
+import com.ticketing.system.Core.Domain.exceptions.EntityNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+import com.ticketing.system.Presentation.presenters.account.RefundPresenter;
+
+class RefundPresenterTest {
+
+    private static final String TOKEN = "member-token";
+    private static final int ORDER_ID = 7;
+
+    private RefundService refundService;
+    private RefundPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        refundService = mock(RefundService.class);
+        presenter = new RefundPresenter(refundService);
+    }
+
+    @Test
+    void requestRefund_success_carriesReferenceAndAmount() {
+        RefundResultDTO result = new RefundResultDTO(
+                "refund-1", "555", 150.00, LocalDateTime.of(2026, 6, 1, 12, 0), List.of(), List.of());
+        when(refundService.requestRefund(TOKEN, ORDER_ID, "reason")).thenReturn(result);
+
+        RefundPresenter.Outcome outcome = presenter.requestRefund(TOKEN, ORDER_ID, "reason");
+
+        RefundPresenter.Outcome.Success ok =
+                assertInstanceOf(RefundPresenter.Outcome.Success.class, outcome);
+        assertEquals("refund-1", ok.reference());
+        assertEquals(150.00, ok.amount());
+    }
+
+    @Test
+    void requestRefund_alreadyRefunded_returnsNotEligible() {
+        when(refundService.requestRefund(TOKEN, ORDER_ID, "reason"))
+                .thenThrow(new BusinessRuleViolationException("already refunded"));
+
+        assertInstanceOf(RefundPresenter.Outcome.NotEligible.class,
+                presenter.requestRefund(TOKEN, ORDER_ID, "reason"));
+    }
+
+    @Test
+    void requestRefund_missingOrder_returnsNotFound() {
+        when(refundService.requestRefund(TOKEN, ORDER_ID, "reason"))
+                .thenThrow(new EntityNotFoundException("OrderReceipt", ORDER_ID));
+
+        assertInstanceOf(RefundPresenter.Outcome.NotFound.class,
+                presenter.requestRefund(TOKEN, ORDER_ID, "reason"));
+    }
+
+    @Test
+    void requestRefund_otherMembersOrder_returnsForbidden() {
+        when(refundService.requestRefund(TOKEN, ORDER_ID, "reason"))
+                .thenThrow(new UnauthorizedActionException("refund order " + ORDER_ID, 42));
+
+        assertInstanceOf(RefundPresenter.Outcome.Forbidden.class,
+                presenter.requestRefund(TOKEN, ORDER_ID, "reason"));
+    }
+
+    @Test
+    void requestRefund_invalidToken_returnsFailure() {
+        when(refundService.requestRefund(TOKEN, ORDER_ID, "reason")).thenThrow(new InvalidTokenException());
+
+        assertInstanceOf(RefundPresenter.Outcome.Failure.class,
+                presenter.requestRefund(TOKEN, ORDER_ID, "reason"));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/SearchPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SearchPresenterTest.java
@@ -1,0 +1,63 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.SearchResultDTO;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Presentation.presenters.catalog.SearchPresenter;
+
+class SearchPresenterTest {
+
+    private static final String CRED = "cred";
+
+    private CatalogService catalogService;
+    private SearchPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        catalogService = mock(CatalogService.class);
+        presenter = new SearchPresenter(catalogService);
+    }
+
+    @Test
+    void search_delegatesToCatalogAndReturnsRows() {
+        List<SearchResultDTO> rows = List.of(new SearchResultDTO("EVENT", "Coldplay", "Live Nation", 1));
+        when(catalogService.search(eq(CRED), eq("coldplay"), anyInt())).thenReturn(rows);
+
+        List<SearchResultDTO> result = presenter.search(CRED, "coldplay");
+
+        assertSame(rows, result);
+    }
+
+    @Test
+    void search_onServiceFailure_returnsEmpty() {
+        when(catalogService.search(eq(CRED), eq("coldplay"), anyInt()))
+                .thenThrow(new RuntimeException("boom"));
+
+        assertTrue(presenter.search(CRED, "coldplay").isEmpty());
+    }
+
+    @Test
+    void recents_withNoVaadinSession_returnsEmpty() {
+        // No live VaadinSession in a plain unit test — RecentSearches degrades to empty without throwing.
+        assertEquals(List.of(), presenter.recents());
+    }
+
+    @Test
+    void record_withNoVaadinSession_isNoOp() {
+        // Should not throw even though there is no session to store into.
+        presenter.record("coldplay");
+        assertEquals(List.of(), presenter.recents());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -27,10 +27,13 @@ import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.ticketing.system.Presentation.views.company.CompanyInquiryInboxView;
 import com.ticketing.system.Presentation.views.company.ManagerListView;
 import com.ticketing.system.Presentation.views.company.OwnerDashboardView;
+import com.ticketing.system.Presentation.views.account.MyAccountView;
 import com.ticketing.system.Presentation.views.account.MyInvitationsView;
 import com.ticketing.system.Presentation.views.account.ReceiptView;
 import com.ticketing.system.Presentation.views.account.SupportInboxView;
+import com.ticketing.system.Presentation.presenters.account.MyAccountPresenter;
 import com.ticketing.system.Presentation.presenters.account.ReceiptPresenter;
+import com.ticketing.system.Presentation.presenters.account.RefundPresenter;
 import com.ticketing.system.Presentation.views.landing.LandingView;
 import com.ticketing.system.Presentation.views.messaging.SubmitComplaintView;
 import com.ticketing.system.Presentation.presenters.company.ManagerListPresenter;
@@ -43,6 +46,7 @@ import com.ticketing.system.Presentation.presenters.landing.LandingPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SubmitComplaintPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SupportInboxPresenter;
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.MessageDTO;
 import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
@@ -159,13 +163,26 @@ class VaadinSmokeTest {
 
     @Test
     void receiptViewInstantiates() {
-        // Member receipt page wired to a presenter (#276). The constructor only adds the
-        // bodyHolder shell — load + render happen in beforeEnter — so bare mocks exercise the
+        // Member receipt page wired to presenters (#276 + refund #284). The constructor only adds
+        // the bodyHolder shell — load + render happen in beforeEnter — so bare mocks exercise the
         // construction path.
         ReceiptPresenter presenter = mock(ReceiptPresenter.class);
+        RefundPresenter refundPresenter = mock(RefundPresenter.class);
         SessionIdentity sessionIdentity = mock(SessionIdentity.class);
-        assertDoesNotThrow(() -> new ReceiptView(presenter, sessionIdentity),
+        assertDoesNotThrow(() -> new ReceiptView(presenter, refundPresenter, sessionIdentity),
             "ReceiptView failed to construct");
+    }
+
+    @Test
+    void myAccountViewInstantiates() {
+        // Member account page (#284 refund affordance). It builds in the constructor, so the
+        // presenter must return a (here empty) history; bare mocks for the rest.
+        MyAccountPresenter presenter = mock(MyAccountPresenter.class);
+        when(presenter.loadHistory()).thenReturn(new PurchaseHistoryDTO(List.of()));
+        RefundPresenter refundPresenter = mock(RefundPresenter.class);
+        SessionIdentity sessionIdentity = mock(SessionIdentity.class);
+        assertDoesNotThrow(() -> new MyAccountView(presenter, refundPresenter, sessionIdentity),
+            "MyAccountView failed to construct");
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -19,8 +19,11 @@ import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
 import com.ticketing.system.Presentation.views.admin.GlobalHistoryView;
 import com.ticketing.system.Presentation.views.admin.OrganizationalTreeView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
+import com.ticketing.system.Presentation.views.catalog.EventDetailsView;
 import com.ticketing.system.Presentation.presenters.admin.GlobalHistoryPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
+import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresenter;
+import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.ticketing.system.Presentation.views.company.CompanyInquiryInboxView;
 import com.ticketing.system.Presentation.views.company.ManagerListView;
 import com.ticketing.system.Presentation.views.company.OwnerDashboardView;
@@ -139,6 +142,17 @@ class VaadinSmokeTest {
         assertDoesNotThrow(
             () -> new GlobalHistoryView(context.getBean(GlobalHistoryPresenter.class)),
             "GlobalHistoryView (admin route) failed to construct");
+    }
+
+    @Test
+    void eventDetailsViewInstantiates() {
+        // Buyer event page wired to a presenter (#272). The constructor only builds the
+        // bodyHolder shell — load + page build happen in beforeEnter — so bare mocks exercise
+        // the construction path (a canary for kit-API breakage at wiring time).
+        EventDetailsPresenter presenter = mock(EventDetailsPresenter.class);
+        SessionIdentity sessionIdentity = mock(SessionIdentity.class);
+        assertDoesNotThrow(() -> new EventDetailsView(presenter, sessionIdentity),
+            "EventDetailsView failed to construct");
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -28,7 +28,9 @@ import com.ticketing.system.Presentation.views.company.CompanyInquiryInboxView;
 import com.ticketing.system.Presentation.views.company.ManagerListView;
 import com.ticketing.system.Presentation.views.company.OwnerDashboardView;
 import com.ticketing.system.Presentation.views.account.MyInvitationsView;
+import com.ticketing.system.Presentation.views.account.ReceiptView;
 import com.ticketing.system.Presentation.views.account.SupportInboxView;
+import com.ticketing.system.Presentation.presenters.account.ReceiptPresenter;
 import com.ticketing.system.Presentation.views.landing.LandingView;
 import com.ticketing.system.Presentation.views.messaging.SubmitComplaintView;
 import com.ticketing.system.Presentation.presenters.company.ManagerListPresenter;
@@ -153,6 +155,17 @@ class VaadinSmokeTest {
         SessionIdentity sessionIdentity = mock(SessionIdentity.class);
         assertDoesNotThrow(() -> new EventDetailsView(presenter, sessionIdentity),
             "EventDetailsView failed to construct");
+    }
+
+    @Test
+    void receiptViewInstantiates() {
+        // Member receipt page wired to a presenter (#276). The constructor only adds the
+        // bodyHolder shell — load + render happen in beforeEnter — so bare mocks exercise the
+        // construction path.
+        ReceiptPresenter presenter = mock(ReceiptPresenter.class);
+        SessionIdentity sessionIdentity = mock(SessionIdentity.class);
+        assertDoesNotThrow(() -> new ReceiptView(presenter, sessionIdentity),
+            "ReceiptView failed to construct");
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -144,7 +144,8 @@ class VaadinSmokeTest {
         // cheap canary for kit-API breakage. Both now take an injected
         // presenter, so resolve it from the Spring context.
         assertDoesNotThrow(
-            () -> new BrowseEventsView(context.getBean(BrowseEventsPresenter.class)),
+            () -> new BrowseEventsView(context.getBean(BrowseEventsPresenter.class),
+                context.getBean(SessionIdentity.class)),
             "BrowseEventsView (root route) failed to construct");
         assertDoesNotThrow(
             () -> new GlobalHistoryView(context.getBean(GlobalHistoryPresenter.class)),

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -6,6 +6,7 @@ import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkConfirm;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
+import com.ticketing.system.Presentation.components.kit.LkSearchPanel;
 import com.ticketing.system.Presentation.components.venue.VkQuantitySelector;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
@@ -338,6 +339,9 @@ class VaadinSmokeTest {
         assertDoesNotThrow(() -> new LkBtn("Sign in"),    "LkBtn failed");
         assertDoesNotThrow(() -> new LkCard("Card"),      "LkCard failed");
         assertDoesNotThrow(() -> new LkBadge("OK"),       "LkBadge failed");
+        // Live top-bar search panel (#281) — debounced input + search-fn callback, no DI needed.
+        assertDoesNotThrow(() -> new LkSearchPanel(List.of("Coldplay"), q -> List.of()),
+            "live LkSearchPanel failed");
         // Domain components used by the venue / seat picker views.
         assertDoesNotThrow(() -> new VkSeat(VkSeat.State.free, "1"), "VkSeat failed");
         assertDoesNotThrow(VkSeatLegend::new,             "VkSeatLegend failed");


### PR DESCRIPTION
## Summary

Wires five V2 buyer/member catalog + account views through the **View → Presenter → Service**
convention (presenters are Vaadin-free and return sealed `Outcome`s / plain lists; views never call
services or use `try/catch`). Each issue is its own commit; this PR bundles them for `dev`.

| # | Issue | Commit |
|---|-------|--------|
| #272 | `[V2-WIRE-BUYER-EVENT]` Wire `EventDetailsView` to real event detail + inventory | `9747fe7` |
| #276 | `[V2-WIRE-MEMBER-RECEIPT]` Wire `ReceiptView` to a real member receipt | `b59275b` |
| #284 | `[V2-WIRE-MEMBER-REFUND]` Member-initiated order refund from `ReceiptView` / `MyAccountView` | `93af69b` |
| #281 | `[V2-SEARCH-01]` Top-bar search backed by the catalog search | `ef67c5d` |
| #271 | `[V2-WIRE-BUYER-BROWSE]` Server-side filter round-trip for `BrowseEventsView` | `dd42b44` |

## What changed

### #272 — EventDetailsView → real detail + inventory
- `CatalogService.getEventDetail(credential, eventId)` — guest-facing single-event read (hides
  DRAFT/SCHEDULED and closed-company events; keeps CANCELED/SOLD_OUT/COMPLETED viewable).
- `EventDetailDTO` gains the `artistsNames` lineup; all construction centralised in
  `EventMapper.toEventDetailDTO`.
- New `EventDetailsPresenter` (sealed `Outcome`); `EventDetailsView` renders real
  name/description/lineup/schedule/status badge, keeps the zone preview, disables "Choose tickets"
  for cancelled/sold-out.

### #276 — ReceiptView → real member receipt
- `MemberAccountService.viewMyReceipt(token, receiptId)` — throwing single-receipt read so the
  presenter can distinguish invalid token / not found / **403** (receipt belongs to another member).
  Reuses `OrderReceiptMapper`; no new DTO.
- New `ReceiptPresenter` (`Success`/`NotFound`/`Forbidden`/`Failure`); `ReceiptView` renders items +
  per-ticket barcodes + payment + total from the real receipt, with a real **Print** (`window.print()`).

### #284 — Member refund flow
- New `RefundService.requestRefund(token, orderId, reason)` — mirrors the existing
  `cancelEventAndRefund` mechanics scoped to one member-owned order: auth → ownership (403) →
  eligibility → gateway refund first, then flip the receipt + its PAID/ISSUED tickets to refunded.
  Whole-order and immediate (no request lifecycle exists in the domain); throws typed exceptions.
- New `RefundPresenter`; `BzRefundDialog` rebuilt as a reusable `LkConfirm` (V2-DLG-01) with a reason
  field; order-level "Request refund" affordance on eligible orders in **ReceiptView** and the
  **MyAccountView** orders grid, plus a Requested→Processing→Refunded indicator once refunded.

### #281 — Top-bar search
- New `SearchResultDTO` + `CatalogService.search(credential, query, limit)` across events, artists
  (deduped) and venues (deduped), round-robined and capped.
- `LkSearchPanel` gains a live constructor: a `TextField` with a **200ms debounce**, recents / empty
  / zero-results states, and a kit-local row model (kept DTO-free). `MainLayout` injects a
  `SearchPresenter`; recents are stored per-session (`RecentSearches`). Every row opens the
  representative event's detail page.

### #271 — BrowseEventsView server-side filters
- Was partial: the list was real but the chips filtered **client-side** over a once-loaded list and
  the date filter was fabricated (`dayOfYear == 177`). Now every chip/select rebuilds a
  `CatalogSearchFiltersDTO` and re-queries `CatalogService.searchGlobal` (category → enum, region →
  location, price → min/max, date presets → real `LocalDate` windows). Sort stays client-side; the
  `?category=` deep-link now drives the server filter.

## Scope notes
- **Pagination:** service queries return plain `List` (team convention), not `Page` — the idealised
  `Page<...>` / `findById` names in the tickets map onto the real `CatalogService` / list APIs.
- **Refunds** are immediate and whole-order (matches the existing cancel-refund); inventory is not
  returned to stock (consistent with cancel-refund) and **no notification is dispatched** —
  real-time notifications (I.5) are a Grade ג' V2 exemption, which also keeps the flow clear of the
  notification-stub blocker (#304).
- **Search:** popular/trending searches omitted (no query-frequency tracking yet); recents are
  per-session only.
- Known nuance: the `EventCategory` enum has redundant `MUSIC`/`CONCERT`; seed concerts use
  `CONCERT`, so the "Concerts" chip targets `CONCERT` (consolidating the enum is separate).

## Testing
`./mvnw -B -Pno-vaadin clean verify` → **BUILD SUCCESS, 1029 tests, 0 failures** (67 pre-existing
`@Disabled` skips). Added service tests (`CatalogServiceTest`, `MemberAccountServiceTest`,
`RefundServiceTest`), presenter tests (`EventDetails`, `Receipt`, `Refund`, `Search`,
`BrowseEvents`), a pure-helper test (`BrowseEventsFilterTest`), and `VaadinSmokeTest` construction
canaries for the new/changed views.

Closes #272, #276, #284, #281, #271.
