### PR TITLE
feat(UC-32): market lifecycle + sales gate + logging hygiene

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/MarketControlRequestDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/MarketControlRequestDTO.java
@@ -1,8 +1,11 @@
 package com.ticketing.system.Core.Application.dto;
 
 // Input to SystemAdminService.openMarket() / closeMarket() (UC-32).
-// 'reason' is recorded for the audit log (no Close UC explicitly defined; see open question).
+// 'reason' is recorded for the audit log (no Close UC explicitly defined).
+// 'token' carries the requesting admin's session credential — the service
+// authorizes the toggle via requireSystemAdmin(token).
 public record MarketControlRequestDTO(
     String action,                       // "OPEN" / "CLOSE"
-    String reason
+    String reason,
+    String token
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -41,6 +41,7 @@ import com.ticketing.system.Core.Domain.exceptions.IdempotencyConflictException;
 import com.ticketing.system.Core.Domain.exceptions.InsufficientInventoryException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
 import com.ticketing.system.Core.Domain.exceptions.SessionExpiredException;
 import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException;
@@ -70,6 +71,7 @@ public class CheckoutService {
     private final ISessionManager sessionManager;
     private final IUserRepository userRepository;
     private final IProductionCompanyRepository companyRepository;
+    private final SystemAdminService systemAdminService;
 
     // In-memory cache for completed checkouts to handle idempotency. Keyed by a
     // combination of buyer identity and idempotency key, since the same idempotency
@@ -97,7 +99,8 @@ public class CheckoutService {
             INotificationService notificationService,
             ISessionManager sessionManager,
             IUserRepository userRepository,
-            IProductionCompanyRepository companyRepository) {
+            IProductionCompanyRepository companyRepository,
+            SystemAdminService systemAdminService) {
         this.activeOrderRepository = activeOrderRepository;
         this.eventRepository = eventRepository;
         this.ticketRepository = ticketRepository;
@@ -108,6 +111,18 @@ public class CheckoutService {
         this.sessionManager = sessionManager;
         this.userRepository = userRepository;
         this.companyRepository = companyRepository;
+        this.systemAdminService = systemAdminService;
+    }
+
+    // UC-32 / I.2.1 — no money moves while the trading market is closed. This is a
+    // platform-wide gate, orthogonal to the per-event ON_SALE check enforced later
+    // in Phase 3 (validateEventsStillOnSale). Called as a guard clause before the
+    // checkout try-block so it propagates cleanly instead of being wrapped as a
+    // generic checkout failure.
+    private void requireMarketOpen() {
+        if (!systemAdminService.isMarketOpen()) {
+            throw new MarketNotOpenException();
+        }
     }
 
     // The checkoutMember and checkoutGuest methods follow a similar flow but have
@@ -129,6 +144,7 @@ public class CheckoutService {
     // confirm inventory sale, persist, mark bought.
     public CheckoutResultDTO checkoutMember(String token, String idempotencyKey, String currency,
             String paymentMethodToken) {
+        requireMarketOpen();
         int userId = -1;
         ActiveOrder order = null;
         PaymentResultDTO paymentResult = null;
@@ -291,6 +307,7 @@ public class CheckoutService {
     // See checkoutMember for the 3-phase description.
     public CheckoutResultDTO checkoutGuest(String guestSessionId, String guestEmail, String idempotencyKey,
             String currency, String paymentMethodToken, int buyerAge) {
+        requireMarketOpen();
         ActiveOrder order = null;
         PaymentResultDTO paymentResult = null;
         double totalPrice = 0.0;

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
@@ -47,12 +47,12 @@ public class MemberAccountService {
     // user.
     public PurchaseHistoryDTO viewMyHistory(AuthTokenDTO authToken) {
         try {
-            log.info("Received request to view purchase history with authToken: {}", authToken.token());
+            log.debug("Received request to view purchase history.");
             if (!authenticationService.validateToken(authToken.token())) {
                 throw new SecurityException("Invalid auth token");
             }
             int userId = authenticationService.extractUserId(authToken.token());
-            System.out.println("User " + userId + " requested purchase history.");
+            log.debug("User {} requested purchase history.", userId);
             List<OrderReceipt> receipts = orderReceiptRepository.findByHolderUserId(userId);
             List<PurchaseRecordDTO> purchaseRecords = new ArrayList<>();
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -27,6 +27,7 @@ import com.ticketing.system.Core.Domain.users.User;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchaseContext;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchaseStage;
 import com.ticketing.system.Core.Domain.events.InventoryZone;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 
 
 @Service
@@ -38,6 +39,7 @@ public class ReservationService {
     private final INotificationService notificationService;
     private final IProductionCompanyRepository companyRepository;
     private final IUserRepository userRepository;
+    private final SystemAdminService systemAdminService;
 
     @Value("${constants.ticket-reservation-duration}")
     private int reservationTimeoutMinutes;
@@ -48,13 +50,15 @@ public class ReservationService {
             ISessionManager iSessionManager,
             INotificationService notificationService,
             IProductionCompanyRepository companyRepository,
-            IUserRepository userRepository) {
+            IUserRepository userRepository,
+            SystemAdminService systemAdminService) {
         this.eventRepository = eventRepository;
         this.activeOrderRepository = activeOrderRepository;
         this.iSessionManager = iSessionManager;
         this.notificationService = notificationService;
         this.companyRepository = companyRepository;
         this.userRepository = userRepository;
+        this.systemAdminService = systemAdminService;
     }
 
     // ---------------------------------------------------------------------
@@ -94,6 +98,13 @@ public class ReservationService {
                 selection == null ? null : selection.getSeatNumbers());
 
         validateReservationArguments(eventId, zoneId, selection);
+
+        // UC-32 / I.2.1 — no tickets may be held while the trading market is closed.
+        // Checked before any locks are acquired. (Removing items from an existing
+        // cart is intentionally NOT gated.)
+        if (!systemAdminService.isMarketOpen()) {
+            throw new MarketNotOpenException();
+        }
 
         Event event = null;
         ActiveOrder activeOrder = null;

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -23,6 +23,8 @@ import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
 import com.ticketing.system.Core.Domain.exceptions.InitializationIntegrityException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 import com.ticketing.system.Core.Domain.exceptions.MissingDefaultAdminException;
 import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
@@ -60,6 +62,7 @@ public class SystemAdminService {
     private enum PlatformStatus { UNINITIALIZED, READY, OPEN, CLOSED }
     private volatile PlatformStatus status = PlatformStatus.UNINITIALIZED;
     private volatile LocalDateTime lastInitializedAt;
+    private volatile LocalDateTime lastOpenedAt;
 
     public SystemAdminService(
             ISessionManager sessionManager,
@@ -103,15 +106,8 @@ public class SystemAdminService {
             return;
         }
 
-        // I.1.2 — at least one payment service must be reachable.
-        if (paymentGateways.stream().noneMatch(this::isReachable)) {
-            throw new ExternalServiceUnavailableException("no reachable payment service");
-        }
-
-        // I.1.3 — at least one ticket-issuance service must be reachable.
-        if (ticketIssuers.stream().noneMatch(this::isReachable)) {
-            throw new ExternalServiceUnavailableException("no reachable ticket issuance service");
-        }
+        // I.1.2 / I.1.3 — at least one payment service and one ticket-issuance service reachable.
+        requireExternalServicesReachable();
 
         // I.1.4 — guarantee at least one System Admin (auto-create a default if none).
         createDefaultAdminIfMissing();
@@ -153,23 +149,109 @@ public class SystemAdminService {
         }
     }
 
-    // UC-32 — open the trading market after re-verifying gateways/issuers/admin.
-    public MarketStateDTO openMarket(MarketControlRequestDTO request) {
-        throw new UnsupportedOperationException("UC-32: not implemented");
+    // UC-32 (#9, I.2.1) — open the trading market so transactions can begin.
+    // Admin-only. Re-verifies both external services (I.2.2) and the structural
+    // invariants before flipping to OPEN. Idempotent on an already-open market;
+    // opens from READY or re-opens from CLOSED, never from UNINITIALIZED. Sales
+    // are gated on this state (see isMarketOpen()).
+    public synchronized MarketStateDTO openMarket(MarketControlRequestDTO request) {
+        requireSystemAdmin(tokenOf(request));
+
+        if (status == PlatformStatus.OPEN) {
+            log.info("Market already open; ignoring open request.");
+            return buildMarketState();
+        }
+        if (status == PlatformStatus.UNINITIALIZED) {
+            throw new MarketNotOpenException("platform not initialized");
+        }
+
+        // I.2.2 — re-verify both external services at open time; don't flip state if either is down.
+        requireExternalServicesReachable();
+
+        // I.2.1 — re-assert structural invariants (>=1 admin + system-wide integrity) before going live.
+        if (!adminRepository.existsAny()) {
+            throw new InitializationIntegrityException("no System Admin present");
+        }
+        integrityVerifier.verify();
+
+        this.status = PlatformStatus.OPEN;
+        this.lastOpenedAt = LocalDateTime.now();
+        log.info("Market opened.");
+        return buildMarketState();
     }
 
-    // (No closeMarket UC defined; defensive method for ops/incident response.)
-    public MarketStateDTO closeMarket(MarketControlRequestDTO request) {
-        throw new UnsupportedOperationException("not implemented (no UC defined; admin/ops use)");
+    // UC-32 — close the trading market (admin/ops incident control; no dedicated
+    // UC). Admin-only. Idempotent on an already-closed market; rejects a close
+    // when the market was never opened.
+    public synchronized MarketStateDTO closeMarket(MarketControlRequestDTO request) {
+        requireSystemAdmin(tokenOf(request));
+
+        if (status == PlatformStatus.CLOSED) {
+            log.info("Market already closed; ignoring close request.");
+            return buildMarketState();
+        }
+        if (status != PlatformStatus.OPEN) {
+            throw new InvalidStateTransitionException("market is not open; cannot close");
+        }
+
+        this.status = PlatformStatus.CLOSED;
+        log.info("Market closed (reason: {}).", reasonOrDefault(request));
+        return buildMarketState();
     }
 
-    // Health snapshot for admin dashboards.
+    // Read-only market/health snapshot for admin dashboards. No token — the admin
+    // route is already access-gated and this exposes no sensitive data.
     public MarketStateDTO viewMarketState() {
-        throw new UnsupportedOperationException("not implemented");
+        return buildMarketState();
+    }
+
+    // Read boundary for the private status enum: the sales gate
+    // (ReservationService / CheckoutService) blocks transactions while the market
+    // is not OPEN. (I.2.1 / UC-32)
+    public boolean isMarketOpen() {
+        return status == PlatformStatus.OPEN;
+    }
+
+    // *HELPER* — single builder for the market snapshot so health probing lives in one place.
+    private MarketStateDTO buildMarketState() {
+        boolean paymentHealthy = paymentGateways.stream().anyMatch(this::isReachable);
+        boolean issuerHealthy = ticketIssuers.stream().anyMatch(this::isReachable);
+        boolean adminPresent = adminRepository.existsAny();
+        return new MarketStateDTO(
+                status.name(),
+                lastInitializedAt,
+                lastOpenedAt,
+                paymentHealthy,
+                issuerHealthy,
+                adminPresent);
+    }
+
+    // *HELPER* — null-safe accessors for the optional control request.
+    private static String tokenOf(MarketControlRequestDTO request) {
+        return request == null ? null : request.token();
+    }
+
+    private static String reasonOrDefault(MarketControlRequestDTO request) {
+        if (request == null || request.reason() == null || request.reason().isBlank()) {
+            return "unspecified";
+        }
+        return request.reason();
     }
 
 
 
+
+    // *HELPER* — I.1.2/I.1.3 & I.2.2 external-service quorum: at least one payment
+    // gateway and one ticket issuer must be reachable. Shared by initialize and
+    // openMarket so the "service down" failure is identical in both paths.
+    private void requireExternalServicesReachable() {
+        if (paymentGateways.stream().noneMatch(this::isReachable)) {
+            throw new ExternalServiceUnavailableException("no reachable payment service");
+        }
+        if (ticketIssuers.stream().noneMatch(this::isReachable)) {
+            throw new ExternalServiceUnavailableException("no reachable ticket issuance service");
+        }
+    }
 
     // *HELPER* — UC-1 step 4 / I.1.1: re-assert the platform post-conditions as a single gate.
     // Defensive against an external service dropping between the initial check and this point.

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/DevMarketOpener.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/DevMarketOpener.java
@@ -1,0 +1,63 @@
+package com.ticketing.system.Infrastructure.dev;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Opens the trading market automatically in the {@code dev} profile so the app —
+ * and the demo seeders' purchase flows — work out of the box without an admin
+ * manually opening it. Production never runs this: a real operator opens the
+ * market through UC-32 once the platform has been verified.
+ *
+ * <p>Ordering matters now that reserve/checkout are gated on an OPEN market:
+ * {@code @Order(1)} places this after {@code PlatformInitializationRunner}
+ * (@Order(0), which brings the platform to READY) and before the purchasing
+ * {@code DemoDataSeeder} (@Order(2)). The market is therefore OPEN before the
+ * seeder attempts any reservation or checkout.
+ */
+@Component
+@Profile("dev")
+@Order(1)
+@Slf4j
+public class DevMarketOpener implements ApplicationRunner {
+
+    // Mirrors SystemAdminService.DEFAULT_ADMIN_ID — the default admin minted during init.
+    private static final int DEFAULT_ADMIN_ID = 1;
+
+    private final SystemAdminService systemAdminService;
+    private final ISessionManager sessionManager;
+    private final String adminUsername;
+
+    public DevMarketOpener(SystemAdminService systemAdminService,
+                           ISessionManager sessionManager,
+                           @Value("${platform.admin.username}") String adminUsername) {
+        this.systemAdminService = systemAdminService;
+        this.sessionManager = sessionManager;
+        this.adminUsername = adminUsername;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        try {
+            // Mint a short-lived admin session for the default admin and open the market
+            // through the real authorization path (requireSystemAdmin).
+            String adminToken = sessionManager.generateAdminToken(DEFAULT_ADMIN_ID, adminUsername);
+            systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "dev auto-open", adminToken));
+            log.info("[dev] Trading market auto-opened for development.");
+        } catch (RuntimeException e) {
+            // Non-fatal: if the platform never reached READY (e.g. a stubbed service was
+            // toggled unreachable), leave the market closed and let the dev open it manually.
+            log.warn("[dev] Could not auto-open the market (platform may not be initialized): {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/external/SensitiveDataMasker.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/SensitiveDataMasker.java
@@ -1,0 +1,84 @@
+package com.ticketing.system.Infrastructure.external;
+
+/**
+ * Masks sensitive values before they reach a log sink.
+ *
+ * <p>External-service calls (payment, ticket issuance) carry card numbers, CVVs,
+ * payment tokens and JWTs. None of those may ever appear in full in a log
+ * record. These helpers turn a secret into a short, non-reversible hint that is
+ * safe to log while still useful for correlation (last-4 of a card, a token
+ * prefix + length).
+ *
+ * <p>Pure and stateless; every method is null- and short-input-safe and never
+ * echoes a value it cannot safely truncate.
+ *
+ * <p>Pick the right helper for the value:
+ * <ul>
+ *   <li>{@link #mask(String)} — a raw card number / PAN (keeps last 4).</li>
+ *   <li>{@link #maskToken(String)} — an opaque secret: payment token, JWT,
+ *       API key (keeps a short prefix + length, never the body).</li>
+ *   <li>{@link #truncId(String, int)} — a non-secret identifier (barcode,
+ *       transaction id) that is merely long.</li>
+ * </ul>
+ */
+public final class SensitiveDataMasker {
+
+    private static final String REDACTED = "****";
+
+    private SensitiveDataMasker() {
+    }
+
+    /**
+     * Masks a raw card number / PAN to its last 4 digits, e.g.
+     * {@code "4111 1111 1111 1234"} → {@code "**** **** **** 1234"}.
+     * Non-digit separators are ignored when locating the last 4. A {@code null}
+     * value, or one with fewer than 4 digits, is fully redacted to
+     * {@code "****"} so a short/invalid value is never echoed.
+     */
+    public static String mask(String card) {
+        if (card == null) {
+            return REDACTED;
+        }
+        String digits = card.replaceAll("\\D", "");
+        if (digits.length() < 4) {
+            return REDACTED;
+        }
+        return "**** **** **** " + digits.substring(digits.length() - 4);
+    }
+
+    /**
+     * Masks an opaque secret (payment token, JWT, API key) to a short prefix
+     * plus its total length, so two records can be correlated without exposing
+     * the secret: {@code "tok_4111111111111234"} → {@code "tok_...(20)"}. A
+     * {@code null} value, or one too short to reveal a prefix safely (≤ 8
+     * chars), is fully redacted.
+     */
+    public static String maskToken(String token) {
+        if (token == null) {
+            return REDACTED;
+        }
+        int len = token.length();
+        if (len <= 8) {
+            return REDACTED;
+        }
+        return token.substring(0, 4) + "...(" + len + ")";
+    }
+
+    /**
+     * Keeps a readable prefix of a non-secret identifier (barcode, transaction
+     * id) and ellipsizes the rest, so long issuance payloads don't bloat logs:
+     * {@code truncId("QR-7-1c2f...e9", 8)} → {@code "QR-7-1c2..."}. A
+     * {@code null} value renders as the literal {@code "null"}; a value already
+     * no longer than {@code keep} is returned unchanged.
+     */
+    public static String truncId(String id, int keep) {
+        if (id == null) {
+            return "null";
+        }
+        int cut = Math.max(0, keep);
+        if (id.length() <= cut) {
+            return id;
+        }
+        return id.substring(0, cut) + "...";
+    }
+}

--- a/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
@@ -6,6 +6,7 @@ import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Application.services.CheckoutService;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.ActiveOrder.*;
 import com.ticketing.system.Core.Domain.Tickets.*;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
@@ -43,6 +44,7 @@ public class CheckoutServiceAcceptanceTest {
     private IUserRepository userRepository;
 
     private CheckoutService checkoutService;
+    private SystemAdminService systemAdminService;
 
     @Autowired private AuthenticationService authService;
     @Autowired private CompanyManagementService companyService;
@@ -101,6 +103,9 @@ public class CheckoutServiceAcceptanceTest {
         notificationService = mock(INotificationService.class);
         sessionManager = mock(ISessionManager.class);
 
+        systemAdminService = mock(SystemAdminService.class);
+        when(systemAdminService.isMarketOpen()).thenReturn(true);
+
         checkoutService = new CheckoutService(
                 activeOrderRepository,
                 eventRepository,
@@ -111,7 +116,8 @@ public class CheckoutServiceAcceptanceTest {
                 notificationService,
                 sessionManager,
                 userRepository,
-                companyRepository
+                companyRepository,
+                systemAdminService
         );
 
         event1 = mock(Event.class);
@@ -916,7 +922,8 @@ public class CheckoutServiceAcceptanceTest {
                 notificationService,
                 sessionManager,
                 userRepository,
-                companyRepository
+                companyRepository,
+                systemAdminService
         );
     }
 

--- a/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
+++ b/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
@@ -49,13 +50,17 @@ public class ReservationAcceptanceTests {
         sessionManager = mock(ISessionManager.class);
         notificationService = mock(INotificationService.class);
 
+        SystemAdminService systemAdminService = mock(SystemAdminService.class);
+        when(systemAdminService.isMarketOpen()).thenReturn(true);
+
         reservationService = new ReservationService(
                 eventRepository,
                 activeOrderRepository,
                 sessionManager,
                 notificationService,
                 mock(IProductionCompanyRepository.class),
-                mock(IUserRepository.class)
+                mock(IUserRepository.class),
+                systemAdminService
         );
 
         event = mock(Event.class, RETURNS_DEEP_STUBS);

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -39,6 +39,7 @@ import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 import com.ticketing.system.Core.Application.services.CheckoutService;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
@@ -82,6 +83,7 @@ class CheckoutServiceTest {
     private INotificationService mockNotificationService;
     private ISessionManager mockiSessionManager;
     private IUserRepository mockUserRepository;
+    private SystemAdminService mockSystemAdminService;
 
     private CheckoutService checkoutService;
 
@@ -135,7 +137,7 @@ class CheckoutServiceTest {
           when(mockUserRepository.getUserById(USER_ID)).thenReturn(mockUser); 
         
 
-        SystemAdminService mockSystemAdminService = mock(SystemAdminService.class);
+        mockSystemAdminService = mock(SystemAdminService.class);
         when(mockSystemAdminService.isMarketOpen()).thenReturn(true);
 
         checkoutService = new CheckoutService(
@@ -191,6 +193,27 @@ class CheckoutServiceTest {
 
         when(mockOrder.isCheckoutInProgress()).thenReturn(true);
         when(mockOrder.getOrderKey()).thenReturn("mock-order-key");
+    }
+
+    // --- UC-32 / I.2.1: sales gated on an OPEN market ---
+
+    @Test
+    void GivenMarketClosed_WhenCheckoutMember_ThenThrowsAndNoCharge() {
+        // Events are ON_SALE (see setUp) and the order is valid — the closed market
+        // is the only thing blocking the sale, and it blocks before any charge.
+        when(mockSystemAdminService.isMarketOpen()).thenReturn(false);
+        assertThrows(MarketNotOpenException.class, () ->
+                checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN));
+        verify(mockPaymentGateway, never()).charge(any());
+    }
+
+    @Test
+    void GivenMarketClosed_WhenCheckoutGuest_ThenThrowsAndNoCharge() {
+        when(mockSystemAdminService.isMarketOpen()).thenReturn(false);
+        assertThrows(MarketNotOpenException.class, () ->
+                checkoutService.checkoutGuest("guest-session", "guest@test.com",
+                        IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN, 30));
+        verify(mockPaymentGateway, never()).charge(any());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -38,6 +38,7 @@ import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 import com.ticketing.system.Core.Application.services.CheckoutService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
@@ -134,6 +135,9 @@ class CheckoutServiceTest {
           when(mockUserRepository.getUserById(USER_ID)).thenReturn(mockUser); 
         
 
+        SystemAdminService mockSystemAdminService = mock(SystemAdminService.class);
+        when(mockSystemAdminService.isMarketOpen()).thenReturn(true);
+
         checkoutService = new CheckoutService(
                 mockActiveOrderRepo,
                 mockEventRepo,
@@ -144,7 +148,8 @@ class CheckoutServiceTest {
                 mockNotificationService,
                 mockiSessionManager,
                 mockUserRepository,
-                mock(IProductionCompanyRepository.class)
+                mock(IProductionCompanyRepository.class),
+                mockSystemAdminService
         );
 
         mockOrder = mock(ActiveOrder.class);

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
@@ -57,6 +58,7 @@ public class ReservationServiceTest {
     private IActiveOrderRepository activeOrderRepository;
     private ISessionManager sessionManager;
     private INotificationService notificationService;
+    private SystemAdminService systemAdminService;
 
     private ReservationService reservationService;
 
@@ -81,7 +83,7 @@ public class ReservationServiceTest {
         zone = mock(InventoryZone.class);
         activeOrder = mock(ActiveOrder.class);
 
-        SystemAdminService systemAdminService = mock(SystemAdminService.class);
+        systemAdminService = mock(SystemAdminService.class);
         when(systemAdminService.isMarketOpen()).thenReturn(true);
 
         reservationService = new ReservationService(
@@ -93,6 +95,19 @@ public class ReservationServiceTest {
                 mock(IUserRepository.class),
                 systemAdminService
         );
+    }
+
+    // --- UC-32 / I.2.1: holding tickets gated on an OPEN market ---
+
+    @Test
+    void GivenMarketClosed_WhenReserveForMember_ThenThrows() {
+        when(sessionManager.validateToken(VALID_TOKEN)).thenReturn(true);
+        when(sessionManager.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        when(systemAdminService.isMarketOpen()).thenReturn(false);
+
+        assertThrows(MarketNotOpenException.class, () ->
+                reservationService.reserveForMember(VALID_TOKEN, EVENT_ID, ZONE_ID,
+                        InventorySelectionDTO.standing(QUANTITY)));
     }
 
     

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -4,6 +4,7 @@ import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.events.Event;
@@ -80,13 +81,17 @@ public class ReservationServiceTest {
         zone = mock(InventoryZone.class);
         activeOrder = mock(ActiveOrder.class);
 
+        SystemAdminService systemAdminService = mock(SystemAdminService.class);
+        when(systemAdminService.isMarketOpen()).thenReturn(true);
+
         reservationService = new ReservationService(
                 eventRepository,
                 activeOrderRepository,
                 sessionManager,
                 notificationService,
                 mock(IProductionCompanyRepository.class),
-                mock(IUserRepository.class)
+                mock(IUserRepository.class),
+                systemAdminService
         );
     }
 

--- a/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
@@ -2,6 +2,8 @@ package com.ticketing.system.unit.application;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,6 +22,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.dto.MarketStateDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
@@ -36,7 +40,11 @@ import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.exceptions.ExternalServiceUnavailableException;
+import com.ticketing.system.Core.Domain.exceptions.InitializationIntegrityException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
 import com.ticketing.system.Core.Domain.exceptions.MissingDefaultAdminException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 import com.ticketing.system.Core.Domain.orders.ReceiptLine;
@@ -136,8 +144,124 @@ class SystemAdminServiceTest {
         assertDoesNotThrow(svc::initializePlatform);
     }
 
-    @Test @Disabled("UC-32: openMarket re-runs all verifications + flips state")
-    void givenInitializedPlatform_whenOpenMarket_thenStateOpen() {}
+    // --- UC-32: market lifecycle (open / close / view) ---
+
+    @Test
+    void givenInitializedPlatform_whenOpenMarket_thenStateOpen() {
+        SystemAdminService svc = readyService();
+        MarketStateDTO state = svc.openMarket(openRequest());
+        assertEquals("OPEN", state.currentStatus());
+        assertNotNull(state.lastOpenedAt());
+        assertTrue(svc.isMarketOpen());
+    }
+
+    @Test
+    void givenUninitializedPlatform_whenOpenMarket_thenThrowsMarketNotOpen() {
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        assertThrows(MarketNotOpenException.class, () -> svc.openMarket(openRequest()));
+    }
+
+    @Test
+    void givenPaymentDownAtOpen_whenOpenMarket_thenThrowsAndStaysReady() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        IPaymentGateway gateway = reachablePayment();
+        SystemAdminService svc = serviceWith(List.of(gateway), List.of(reachableIssuer()));
+        svc.initializePlatform();                          // READY
+        when(gateway.verifyConnection()).thenReturn(false); // gateway drops before open
+        assertThrows(ExternalServiceUnavailableException.class, () -> svc.openMarket(openRequest()));
+        assertEquals("READY", svc.viewMarketState().currentStatus());
+    }
+
+    @Test
+    void givenIssuerDownAtOpen_whenOpenMarket_thenThrowsAndStaysReady() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        ITicketIssuer issuer = reachableIssuer();
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(issuer));
+        svc.initializePlatform();                          // READY
+        when(issuer.verifyConnection()).thenReturn(false);  // issuer drops before open
+        assertThrows(ExternalServiceUnavailableException.class, () -> svc.openMarket(openRequest()));
+        assertEquals("READY", svc.viewMarketState().currentStatus());
+    }
+
+    @Test
+    void givenNoAdminAtOpen_whenOpenMarket_thenThrowsAndStaysReady() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        svc.initializePlatform();                          // READY
+        when(adminRepository.existsAny()).thenReturn(false); // admin removed before open
+        assertThrows(InitializationIntegrityException.class, () -> svc.openMarket(openRequest()));
+        assertEquals("READY", svc.viewMarketState().currentStatus());
+    }
+
+    @Test
+    void givenNonAdminToken_whenOpenMarket_thenRejected() {
+        when(sessionManager.validateToken("member-token")).thenReturn(true);
+        when(sessionManager.isAdminToken("member-token")).thenReturn(false);
+        SystemAdminService svc = readyService();
+        MarketControlRequestDTO request = new MarketControlRequestDTO("OPEN", "x", "member-token");
+        assertThrows(UnauthorizedActionException.class, () -> svc.openMarket(request));
+    }
+
+    @Test
+    void givenOpenMarket_whenOpenAgain_thenStillOpenNoError() {
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        MarketStateDTO state = assertDoesNotThrow(() -> svc.openMarket(openRequest()));
+        assertEquals("OPEN", state.currentStatus());
+    }
+
+    @Test
+    void givenOpenMarket_whenCloseMarket_thenStateClosed() {
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        MarketStateDTO state = svc.closeMarket(closeRequest());
+        assertEquals("CLOSED", state.currentStatus());
+        assertFalse(svc.isMarketOpen());
+    }
+
+    @Test
+    void givenClosedMarket_whenCloseAgain_thenStillClosedNoError() {
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        svc.closeMarket(closeRequest());
+        MarketStateDTO state = assertDoesNotThrow(() -> svc.closeMarket(closeRequest()));
+        assertEquals("CLOSED", state.currentStatus());
+    }
+
+    @Test
+    void givenClosedMarket_whenOpenMarket_thenReopens() {
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        svc.closeMarket(closeRequest());
+        MarketStateDTO state = svc.openMarket(openRequest());
+        assertEquals("OPEN", state.currentStatus());
+    }
+
+    @Test
+    void givenNeverOpened_whenCloseMarket_thenThrows() {
+        SystemAdminService svc = readyService(); // READY, never opened
+        assertThrows(InvalidStateTransitionException.class, () -> svc.closeMarket(closeRequest()));
+    }
+
+    @Test
+    void givenNonAdminToken_whenCloseMarket_thenRejected() {
+        when(sessionManager.validateToken("member-token")).thenReturn(true);
+        when(sessionManager.isAdminToken("member-token")).thenReturn(false);
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        MarketControlRequestDTO request = new MarketControlRequestDTO("CLOSE", "x", "member-token");
+        assertThrows(UnauthorizedActionException.class, () -> svc.closeMarket(request));
+    }
+
+    @Test
+    void givenInitializedPlatform_whenViewMarketState_thenReportsHealth() {
+        SystemAdminService svc = readyService();
+        MarketStateDTO state = svc.viewMarketState();
+        assertEquals("READY", state.currentStatus());
+        assertTrue(state.paymentGatewayHealthy());
+        assertTrue(state.ticketIssuerHealthy());
+        assertTrue(state.defaultAdminPresent());
+    }
 
     @Test @Disabled("UC-31: viewGlobalHistory admin-only RBAC")
     void givenNonAdmin_whenViewGlobalHistory_thenRejected() {}
@@ -247,6 +371,23 @@ class SystemAdminServiceTest {
 
 
     // --- helpers ---
+
+    // An initialized (READY) service with one reachable gateway + issuer and an
+    // existing admin — the precondition for opening the market.
+    private SystemAdminService readyService() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        svc.initializePlatform();
+        return svc;
+    }
+
+    private MarketControlRequestDTO openRequest() {
+        return new MarketControlRequestDTO("OPEN", "test open", ADMIN_TOKEN);
+    }
+
+    private MarketControlRequestDTO closeRequest() {
+        return new MarketControlRequestDTO("CLOSE", "test close", ADMIN_TOKEN);
+    }
 
     private SystemAdminService serviceWith(List<IPaymentGateway> gateways, List<ITicketIssuer> issuers) {
         return new SystemAdminService(

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/SensitiveDataMaskerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/SensitiveDataMaskerTest.java
@@ -1,0 +1,75 @@
+package com.ticketing.system.unit.infrastructure.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Infrastructure.external.SensitiveDataMasker;
+
+class SensitiveDataMaskerTest {
+
+    private static final String FULL_PAN = "4111111111111234";
+
+    @Test
+    void mask_keepsOnlyLastFourDigits() {
+        assertEquals("**** **** **** 1234", SensitiveDataMasker.mask(FULL_PAN));
+    }
+
+    @Test
+    void mask_ignoresSeparatorsWhenLocatingLastFour() {
+        assertEquals("**** **** **** 1234", SensitiveDataMasker.mask("4111 1111 1111 1234"));
+    }
+
+    @Test
+    void mask_neverEchoesTheFullPan() {
+        assertFalse(SensitiveDataMasker.mask(FULL_PAN).contains(FULL_PAN));
+    }
+
+    @Test
+    void mask_redactsNullOrTooShort() {
+        assertEquals("****", SensitiveDataMasker.mask(null));
+        assertEquals("****", SensitiveDataMasker.mask("12"));
+        assertEquals("****", SensitiveDataMasker.mask(""));
+    }
+
+    @Test
+    void maskToken_keepsShortPrefixAndLengthOnly() {
+        // tok_<pan> is how the checkout builds the payment token — the prefix is
+        // safe, the embedded PAN must not survive masking.
+        String token = "tok_" + FULL_PAN; // length 20
+        assertEquals("tok_...(20)", SensitiveDataMasker.maskToken(token));
+        assertFalse(SensitiveDataMasker.maskToken(token).contains(FULL_PAN));
+    }
+
+    @Test
+    void maskToken_neverEchoesTheBodyOfAJwt() {
+        String jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.s3cr3tS1gnatureV4lue";
+        String masked = SensitiveDataMasker.maskToken(jwt);
+        assertTrue(masked.startsWith("eyJh"));
+        assertFalse(masked.contains("s3cr3tS1gnatureV4lue"));
+        assertFalse(masked.contains(jwt));
+    }
+
+    @Test
+    void maskToken_redactsNullOrTooShort() {
+        assertEquals("****", SensitiveDataMasker.maskToken(null));
+        assertEquals("****", SensitiveDataMasker.maskToken("12345678"));
+    }
+
+    @Test
+    void truncId_keepsPrefixAndEllipsizesTheRest() {
+        assertEquals("QR-7-...", SensitiveDataMasker.truncId("QR-7-abcdef-uuid", 5));
+    }
+
+    @Test
+    void truncId_returnsShortValueUnchanged() {
+        assertEquals("QR-7", SensitiveDataMasker.truncId("QR-7", 8));
+    }
+
+    @Test
+    void truncId_rendersNullLiteral() {
+        assertEquals("null", SensitiveDataMasker.truncId(null, 8));
+    }
+}


### PR DESCRIPTION
## What

Implements the platform **market lifecycle (UC-32)**, gates ticket sales on an open market (**I.2.1**), and fixes a logging-hygiene leak (**V2-LOG-02**). Branch off `dev`; in-memory repos, Tier C.

### Market lifecycle — #59, #60, UC-32 (#9 / #307)
- `SystemAdminService.openMarket` / `closeMarket` / `viewMarketState` were throwing stubs; now implemented on the existing `UNINITIALIZED → READY → OPEN ↔ CLOSED` state machine.
- `openMarket` is admin-gated, re-verifies **both** external services (I.2.2) and the structural invariants (≥1 admin + integrity) before flipping to OPEN, is idempotent when already open, and is rejected from UNINITIALIZED.
- `closeMarket` OPEN→CLOSED (admin/ops), idempotent, rejects close-before-open. `viewMarketState` is a read-only health snapshot.
- The admin token travels in `MarketControlRequestDTO` (new field) and is checked via the existing `requireSystemAdmin`. Reuses `MarketNotOpenException`, `ExternalServiceUnavailableException`, and the `isReachable` probes — no new exceptions.

### Sales gate — I.2.1
- `ReservationService.reserve` and `CheckoutService.checkoutMember` / `checkoutGuest` now block when the market is not OPEN (`MarketNotOpenException`), **in addition to** the existing per-event `ON_SALE` checks — money never moves while the market is closed.

### Dev profile
- `DevMarketOpener` (`@Profile("dev")`, `@Order(1)`) auto-opens the market after init so the demo seeder's purchase flow works out of the box. Production opens via UC-32.

### Logging hygiene — V2-LOG-02 (#236)
- `MemberAccountService.viewMyHistory` no longer logs the raw JWT, and the `System.out.println` is gone.
- Adds `SensitiveDataMasker` (last-4 card / token-prefix / id-trunc) — the foundation for masked logging in the upcoming real WSEP HTTP adapter, where `pay` carries a raw PAN + CVV.

## Tests
- `SystemAdminServiceTest`: +13 market cases (open/close/view, auth, service-down stays READY, no-admin, idempotency, reopen).
- `CheckoutServiceTest` / `ReservationServiceTest`: closed market blocks checkout (and never reaches the gateway) and blocks reserve.
- Full suite green: **1002 run, 0 failures, 66 skipped** (pre-existing).

## Follow-up
- The real WSEP HTTP adapter (`Wsep*`) is a separate task, built strictly to the documented spec and gated behind a property so the stubs stay default in dev/test.

Closes #59, #60, #9, #307
