### PR TITLE
feat(UC-33/UC-34): real WSEP payment + ticket HTTP adapter

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/CardDetailsDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/CardDetailsDTO.java
@@ -1,0 +1,34 @@
+package com.ticketing.system.Core.Application.dto;
+
+// Raw card details captured at checkout and carried to the payment gateway.
+// The real WSEP `pay` action needs all of these on the wire (card_number, cvv,
+// month, year, holder); the in-process stub only looks at the card number.
+//
+// toString() is overridden so the PAN and CVV can never leak through an
+// accidental log/{}-interpolation of this record (or of a PaymentRequestDTO
+// that holds it) — only the last 4 of the card are ever rendered, never the cvv.
+public record CardDetailsDTO(
+    String cardNumber,
+    String cvv,
+    int expiryMonth,
+    int expiryYear,
+    String holderName
+) {
+    @Override
+    public String toString() {
+        return "CardDetailsDTO[holder=" + holderName
+                + ", card=" + maskedCard()
+                + ", exp=" + expiryMonth + "/" + expiryYear + "]";
+    }
+
+    private String maskedCard() {
+        if (cardNumber == null) {
+            return "****";
+        }
+        String digits = cardNumber.replaceAll("\\D", "");
+        if (digits.length() < 4) {
+            return "****";
+        }
+        return "**** **** **** " + digits.substring(digits.length() - 4);
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Application/dto/CheckoutResultDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/CheckoutResultDTO.java
@@ -8,5 +8,18 @@ public record CheckoutResultDTO(
     double totalCharged,
     int orderReceiptId,
     int paymentTransactionId,
-    List<Integer> issuedTicketIds
-) {}
+    List<IssuedTicketDTO> issuedTickets
+) {
+    // One issued ticket: the issuer-assigned id plus the barcode VALUE the payment/
+    // issuance provider actually returned (the real WSEP TIX code, or the stub's
+    // code) — so the confirmation can show the true barcode instead of fabricating
+    // one from the id.
+    public record IssuedTicketDTO(int ticketId, String barcode) {}
+
+    // Convenience for callers/tests that only need the ids.
+    public List<Integer> issuedTicketIds() {
+        return issuedTickets == null
+                ? List.of()
+                : issuedTickets.stream().map(IssuedTicketDTO::ticketId).toList();
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Application/dto/PaymentRequestDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/PaymentRequestDTO.java
@@ -10,7 +10,7 @@ public record PaymentRequestDTO(
     String idempotencyKey,
     double amount,
     String currency,
-    String paymentMethodToken,           // tokenized card ref — never raw PAN
+    CardDetailsDTO card,                  // raw card details — the gateway (WSEP `pay`) needs them
     Integer buyerUserId,
     String buyerEmail
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
 import com.ticketing.system.Core.Application.dto.CheckoutResultDTO;
 import com.ticketing.system.Core.Application.dto.IssuanceRequestDTO;
 import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
@@ -143,7 +144,7 @@ public class CheckoutService {
     // order,
     // confirm inventory sale, persist, mark bought.
     public CheckoutResultDTO checkoutMember(String token, String idempotencyKey, String currency,
-            String paymentMethodToken) {
+            CardDetailsDTO card) {
         requireMarketOpen();
         int userId = -1;
         ActiveOrder order = null;
@@ -163,7 +164,7 @@ public class CheckoutService {
 
         try {
             userId = authenticateAndGetUserId(token);
-            validatePaymentInput(idempotencyKey, currency, paymentMethodToken, userId);
+            validatePaymentInput(idempotencyKey, currency, card, userId);
 
             String buyerKey = memberBuyerKey(userId);
 
@@ -210,7 +211,7 @@ public class CheckoutService {
             List<PricedCartLine> pricedItems = priceItemsOnce(snapshotItems);
             totalPrice = sumPrices(pricedItems);
 
-            paymentResult = chargePayment(userId, null, totalPrice, idempotencyKey, currency, paymentMethodToken);
+            paymentResult = chargePayment(userId, null, totalPrice, idempotencyKey, currency, card);
             validatePaymentResult(paymentResult, totalPrice, currency);
 
             IssuanceResultDTO issuanceResult = issueTickets(userId, null, snapshotItems);
@@ -306,7 +307,7 @@ public class CheckoutService {
     //
     // See checkoutMember for the 3-phase description.
     public CheckoutResultDTO checkoutGuest(String guestSessionId, String guestEmail, String idempotencyKey,
-            String currency, String paymentMethodToken, int buyerAge) {
+            String currency, CardDetailsDTO card, int buyerAge) {
         requireMarketOpen();
         ActiveOrder order = null;
         PaymentResultDTO paymentResult = null;
@@ -319,7 +320,7 @@ public class CheckoutService {
 
         try {
             validateGuestCheckoutIdentity(guestSessionId, guestEmail);
-            validatePaymentInput(idempotencyKey, currency, paymentMethodToken, null);
+            validatePaymentInput(idempotencyKey, currency, card, null);
 
             String buyerKey = guestBuyerKey(guestSessionId, guestEmail);
 
@@ -356,7 +357,7 @@ public class CheckoutService {
             List<PricedCartLine> pricedItems = priceItemsOnce(snapshotItems);
             totalPrice = sumPrices(pricedItems);
 
-            paymentResult = chargePayment(null, guestEmail, totalPrice, idempotencyKey, currency, paymentMethodToken);
+            paymentResult = chargePayment(null, guestEmail, totalPrice, idempotencyKey, currency, card);
             validatePaymentResult(paymentResult, totalPrice, currency);
 
             IssuanceResultDTO issuanceResult = issueTickets(null, guestEmail, snapshotItems);
@@ -485,7 +486,7 @@ public class CheckoutService {
     // reference to the payment method that the user wants to use for the
     // transaction. If any of these validations fail, we throw an exception to
     // prevent the checkout from proceeding with invalid payment information.
-    private void validatePaymentInput(String idempotencyKey, String currency, String paymentMethodToken,
+    private void validatePaymentInput(String idempotencyKey, String currency, CardDetailsDTO card,
             Integer userId) {
         if (idempotencyKey == null || idempotencyKey.isBlank()) {
             throw new IllegalArgumentException("Missing idempotency key");
@@ -495,8 +496,8 @@ public class CheckoutService {
             throw new IllegalArgumentException("Missing currency");
         }
 
-        if (paymentMethodToken == null || paymentMethodToken.isBlank()) {
-            throw new IllegalArgumentException("Missing payment method token");
+        if (card == null || card.cardNumber() == null || card.cardNumber().isBlank()) {
+            throw new IllegalArgumentException("Missing card details");
         }
     }
 
@@ -616,12 +617,12 @@ public class CheckoutService {
     // the payment gateway will be validated to ensure that the charge was
     // successful and that the amount and currency match what we expected.
     private PaymentResultDTO chargePayment(Integer buyerUserId, String buyerEmail, double totalPrice,
-            String idempotencyKey, String currency, String paymentMethodToken) {
+            String idempotencyKey, String currency, CardDetailsDTO card) {
         PaymentRequestDTO requestToPay = new PaymentRequestDTO(
                 idempotencyKey,
                 totalPrice,
                 currency,
-                paymentMethodToken,
+                card,
                 buyerUserId,
                 buyerEmail);
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -1048,7 +1048,8 @@ public class CheckoutService {
                 paymentResult.paymentTransactionId(),
                 issuanceResult.barcodes()
                         .stream()
-                        .map(barcode -> barcode.ticketId())
+                        .map(barcode -> new CheckoutResultDTO.IssuedTicketDTO(
+                                barcode.ticketId(), barcode.barcodeValue()))
                         .toList());
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoOrders.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoOrders.java
@@ -22,9 +22,10 @@ import java.util.Map;
  * showcase — selections are spread across these so demo dashboards
  * have varied per-event sales.
  *
- * <p>{@link com.ticketing.system.Infrastructure.external.StubPaymentGateway}
- * accepts any payment-method token, so the seed never requires
- * external credentials.
+ * <p>In the {@code dev} profile these run through the real
+ * {@link com.ticketing.system.Infrastructure.external.WsepPaymentGateway} /
+ * {@link com.ticketing.system.Infrastructure.external.WsepTicketIssuer}, so the
+ * seeded tickets carry real WSEP barcodes (boot depends on the endpoint being up).
  */
 public final class DemoOrders {
 

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoOrders.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/DemoOrders.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Infrastructure.dev.seed;
 
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.services.CheckoutService;
@@ -85,7 +86,8 @@ public final class DemoOrders {
             InventorySelectionDTO.standing(quantity));
 
         String idem = "demo-" + buyerKey + "-" + eventName.hashCode();
-        checkoutService.checkoutMember(token, idem, "ILS", "demo-card-" + buyerKey);
+        checkoutService.checkoutMember(token, idem, "ILS",
+            new CardDetailsDTO("4111111111111111", "123", 12, 2030, "Demo " + buyerKey));
     }
 
     private void reservePending(String buyerKey, String eventName, int zoneId, int quantity) {

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
@@ -8,7 +8,7 @@ import com.ticketing.system.Core.Domain.exceptions.IdempotencyConflictException;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -17,11 +17,12 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-// Default in-process payment gateway. Selected unless external.payment-gateway=wsep,
-// which activates WsepPaymentGateway instead (keeps the singular IPaymentGateway
-// injection in CheckoutService unambiguous).
+// In-process payment gateway for TESTS ONLY (@Profile("test")). Every real run
+// (default/prod + the dev profile) uses WsepPaymentGateway instead; the profile
+// keeps the singular IPaymentGateway injection in CheckoutService unambiguous —
+// exactly one gateway bean exists per profile.
 @Component
-@ConditionalOnProperty(name = "external.payment-gateway", havingValue = "stub", matchIfMissing = true)
+@Profile("test")
 public class StubPaymentGateway implements IPaymentGateway {
     //*Note: changed from not implemented to what's below here, can change however wanted though, it's a stub for our needs */
     private static final String GATEWAY_ID = "stub-payment-gateway";

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
@@ -129,8 +129,8 @@ public class StubPaymentGateway implements IPaymentGateway {
             throw new PaymentGatewayException("currency is required");
         }
 
-        if (request.paymentMethodToken() == null || request.paymentMethodToken().isBlank()) {
-            throw new PaymentGatewayException("payment method token is required");
+        if (request.card() == null || request.card().cardNumber() == null || request.card().cardNumber().isBlank()) {
+            throw new PaymentGatewayException("card details are required");
         }
 
         boolean memberBuyer = request.buyerUserId() != null;
@@ -150,7 +150,7 @@ public class StubPaymentGateway implements IPaymentGateway {
     private boolean samePaymentRequest(PaymentRequestDTO a, PaymentRequestDTO b) {
         return Double.compare(a.amount(), b.amount()) == 0
                 && Objects.equals(a.currency(), b.currency())
-                && Objects.equals(a.paymentMethodToken(), b.paymentMethodToken())
+                && Objects.equals(a.card(), b.card())
                 && Objects.equals(a.buyerUserId(), b.buyerUserId())
                 && Objects.equals(a.buyerEmail(), b.buyerEmail());
     }

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubPaymentGateway.java
@@ -8,6 +8,7 @@ import com.ticketing.system.Core.Domain.exceptions.IdempotencyConflictException;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -16,7 +17,11 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+// Default in-process payment gateway. Selected unless external.payment-gateway=wsep,
+// which activates WsepPaymentGateway instead (keeps the singular IPaymentGateway
+// injection in CheckoutService unambiguous).
 @Component
+@ConditionalOnProperty(name = "external.payment-gateway", havingValue = "stub", matchIfMissing = true)
 public class StubPaymentGateway implements IPaymentGateway {
     //*Note: changed from not implemented to what's below here, can change however wanted though, it's a stub for our needs */
     private static final String GATEWAY_ID = "stub-payment-gateway";

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
@@ -6,7 +6,7 @@ import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -15,10 +15,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-// Default in-process ticket issuer. Selected unless external.ticket-issuer=wsep,
-// which activates WsepTicketIssuer instead.
+// In-process ticket issuer for TESTS ONLY (@Profile("test")). Every real run
+// (default/prod + the dev profile) uses WsepTicketIssuer instead.
 @Component
-@ConditionalOnProperty(name = "external.ticket-issuer", havingValue = "stub", matchIfMissing = true)
+@Profile("test")
 public class StubTicketIssuer implements ITicketIssuer {
     //* can change to be however wanted, this is a stub so we can do what we need with it */
     private static final String ISSUER_ID = "stub-ticket-issuer";

--- a/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/StubTicketIssuer.java
@@ -6,6 +6,7 @@ import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
 import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
 import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
@@ -14,7 +15,10 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+// Default in-process ticket issuer. Selected unless external.ticket-issuer=wsep,
+// which activates WsepTicketIssuer instead.
 @Component
+@ConditionalOnProperty(name = "external.ticket-issuer", havingValue = "stub", matchIfMissing = true)
 public class StubTicketIssuer implements ITicketIssuer {
     //* can change to be however wanted, this is a stub so we can do what we need with it */
     private static final String ISSUER_ID = "stub-ticket-issuer";

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepCommunicationException.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepCommunicationException.java
@@ -1,0 +1,14 @@
+package com.ticketing.system.Infrastructure.external;
+
+/**
+ * Signals that a call to the WSEP endpoint could not complete at the transport
+ * level (connection refused, timeout, I/O error) — distinct from a well-formed
+ * {@code "-1"} business failure, which the adapters map to the relevant domain
+ * exception. The adapters translate this into the right domain exception per
+ * action (e.g. a payment-gateway failure or "unreachable" for a handshake).
+ */
+public class WsepCommunicationException extends RuntimeException {
+    public WsepCommunicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Component;
  * provider — the adapters that use it are property-gated, not this helper.
  */
 @Component
+@Profile("!test")
 public class WsepHttpClient {
 
     private final String baseUrl;

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
@@ -1,0 +1,89 @@
+package com.ticketing.system.Infrastructure.external;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Thin HTTP client for the WSEP external-systems endpoint. Every operation is a
+ * single {@code application/x-www-form-urlencoded} POST to one URL, dispatched
+ * by the {@code action_type} field; the server replies with a tiny plain-text
+ * body where {@code "-1"} is the universal failure sentinel (callers interpret
+ * the body).
+ *
+ * <p>Shared by {@link WsepPaymentGateway} and {@link WsepTicketIssuer}. Always a
+ * bean (it is lightweight) even when the in-process stubs are the active
+ * provider — the adapters that use it are property-gated, not this helper.
+ */
+@Component
+public class WsepHttpClient {
+
+    private final String baseUrl;
+    private final HttpClient http;
+
+    public WsepHttpClient(@Value("${wsep.base-url:https://damp-lynna-wsep-1984852e.koyeb.app/}") String baseUrl) {
+        this.baseUrl = baseUrl;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /** Starts an ordered form body with {@code action_type} first. */
+    public static Form action(String actionType) {
+        return new Form().add("action_type", actionType);
+    }
+
+    /** A tiny ordered form builder (insertion order preserved for readable request logs). */
+    public static final class Form {
+        private final Map<String, String> fields = new LinkedHashMap<>();
+
+        public Form add(String key, Object value) {
+            fields.put(key, value == null ? "" : String.valueOf(value));
+            return this;
+        }
+
+        private String encoded() {
+            return fields.entrySet().stream()
+                    .map(e -> enc(e.getKey()) + "=" + enc(e.getValue()))
+                    .collect(Collectors.joining("&"));
+        }
+
+        private static String enc(String s) {
+            return URLEncoder.encode(s, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * POSTs the form and returns the trimmed plain-text body. Throws
+     * {@link WsepCommunicationException} on any transport-level failure, so a
+     * caller can tell "couldn't reach WSEP" apart from a {@code "-1"} reply.
+     */
+    public String post(Form form) {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl))
+                .timeout(Duration.ofSeconds(20))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form.encoded(), StandardCharsets.UTF_8))
+                .build();
+        try {
+            HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.body() == null ? "" : response.body().trim();
+        } catch (IOException e) {
+            throw new WsepCommunicationException("WSEP request failed: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new WsepCommunicationException("WSEP request interrupted", e);
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
@@ -53,6 +53,11 @@ public class WsepHttpClient {
             return this;
         }
 
+        /** Read-only copy of the fields — lets adapters/tests inspect the request without re-encoding. */
+        public Map<String, String> fields() {
+            return Map.copyOf(fields);
+        }
+
         private String encoded() {
             return fields.entrySet().stream()
                     .map(e -> enc(e.getKey()) + "=" + enc(e.getValue()))

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
@@ -1,0 +1,152 @@
+package com.ticketing.system.Infrastructure.external;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
+import com.ticketing.system.Core.Application.dto.PaymentRequestDTO;
+import com.ticketing.system.Core.Application.dto.PaymentResultDTO;
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Real payment gateway backed by the WSEP external system. Active only when
+ * {@code external.payment-gateway=wsep}; otherwise {@link StubPaymentGateway} is
+ * used. Each method is one WSEP action exactly per the documented contract:
+ * {@code handshake} → {@link #verifyConnection()}, {@code pay} → {@link #charge},
+ * {@code refund} → {@link #refund}. {@code "-1"} is the universal failure reply
+ * and is translated into the matching domain exception.
+ *
+ * <p>DEBUG logs are masked: the card number shows only its last 4 and the CVV /
+ * expiry / holder are never logged (they are still sent on the wire — WSEP
+ * requires them — just never recorded).
+ */
+@Component
+@ConditionalOnProperty(name = "external.payment-gateway", havingValue = "wsep")
+@Slf4j
+public class WsepPaymentGateway implements IPaymentGateway {
+
+    private static final String GATEWAY_ID = "wsep-payment-gateway";
+    private static final String FAILURE = "-1";
+
+    private final WsepHttpClient http;
+
+    public WsepPaymentGateway(WsepHttpClient http) {
+        this.http = http;
+    }
+
+    @Override
+    public String getId() {
+        return GATEWAY_ID;
+    }
+
+    @Override
+    public boolean verifyConnection() {
+        try {
+            boolean ok = "OK".equalsIgnoreCase(http.post(WsepHttpClient.action("handshake")));
+            log.debug("wsep handshake: reachable={}", ok);
+            return ok;
+        } catch (RuntimeException e) {
+            log.debug("wsep handshake failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public PaymentResultDTO charge(PaymentRequestDTO request) {
+        CardDetailsDTO card = request.card();
+        if (card == null || card.cardNumber() == null || card.cardNumber().isBlank()) {
+            throw new PaymentGatewayException("card details are required");
+        }
+
+        long start = System.nanoTime();
+        log.debug("wsep pay -> amount={} {} card={}",
+                request.amount(), request.currency(), SensitiveDataMasker.mask(card.cardNumber()));
+
+        WsepHttpClient.Form form = WsepHttpClient.action("pay")
+                .add("amount", request.amount())
+                .add("currency", request.currency())
+                .add("card_number", card.cardNumber())
+                .add("month", card.expiryMonth())
+                .add("year", card.expiryYear())
+                .add("holder", card.holderName())
+                .add("cvv", card.cvv())
+                .add("id", request.buyerUserId() != null ? request.buyerUserId() : 0);
+
+        String body;
+        try {
+            body = http.post(form);
+        } catch (WsepCommunicationException e) {
+            throw new PaymentGatewayException("payment gateway unreachable: " + e.getMessage());
+        }
+
+        if (FAILURE.equals(body)) {
+            log.debug("wsep pay declined ({} ms)", msSince(start));
+            throw new PaymentGatewayException("payment declined by gateway");
+        }
+
+        int transactionId = parsePositiveInt(body, "pay");
+        log.debug("wsep pay ok: txnId={} ({} ms)", transactionId, msSince(start));
+        return new PaymentResultDTO(
+                transactionId,
+                GATEWAY_ID,
+                request.amount(),
+                request.currency(),
+                LocalDateTime.now());
+    }
+
+    @Override
+    public RefundResultDTO refund(int paymentTransactionId, double amount) {
+        if (paymentTransactionId <= 0) {
+            throw new RefundFailedException(paymentTransactionId, "paymentTransactionId must be positive");
+        }
+
+        long start = System.nanoTime();
+        log.debug("wsep refund -> txnId={}", paymentTransactionId);
+
+        String body;
+        try {
+            body = http.post(WsepHttpClient.action("refund").add("transaction_id", paymentTransactionId));
+        } catch (WsepCommunicationException e) {
+            throw new RefundFailedException(paymentTransactionId, "refund gateway unreachable: " + e.getMessage());
+        }
+
+        // WSEP refund reverses the whole charge by id and returns 1/-1 — there is no partial-refund amount.
+        if (!"1".equals(body)) {
+            log.debug("wsep refund failed: body={} ({} ms)", body, msSince(start));
+            throw new RefundFailedException(paymentTransactionId, "refund rejected by gateway");
+        }
+
+        log.debug("wsep refund ok: txnId={} ({} ms)", paymentTransactionId, msSince(start));
+        return new RefundResultDTO(
+                "wsep-refund-" + paymentTransactionId,
+                String.valueOf(paymentTransactionId),
+                amount,
+                LocalDateTime.now(),
+                List.of(),
+                List.of());
+    }
+
+    private int parsePositiveInt(String body, String action) {
+        try {
+            int value = Integer.parseInt(body == null ? "" : body.trim());
+            if (value <= 0) {
+                throw new PaymentGatewayException("wsep " + action + " returned non-positive value: " + value);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            throw new PaymentGatewayException("wsep " + action + " returned an unparseable response");
+        }
+    }
+
+    private static long msSince(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
@@ -3,7 +3,7 @@ package com.ticketing.system.Infrastructure.external;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
@@ -17,9 +17,9 @@ import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Real payment gateway backed by the WSEP external system. Active only when
- * {@code external.payment-gateway=wsep}; otherwise {@link StubPaymentGateway} is
- * used. Each method is one WSEP action exactly per the documented contract:
+ * Real payment gateway backed by the WSEP external system. Active in every real
+ * run ({@code @Profile("!test")}); the test suite uses {@link StubPaymentGateway}
+ * instead. Each method is one WSEP action exactly per the documented contract:
  * {@code handshake} → {@link #verifyConnection()}, {@code pay} → {@link #charge},
  * {@code refund} → {@link #refund}. {@code "-1"} is the universal failure reply
  * and is translated into the matching domain exception.
@@ -29,7 +29,7 @@ import lombok.extern.slf4j.Slf4j;
  * requires them — just never recorded).
  */
 @Component
-@ConditionalOnProperty(name = "external.payment-gateway", havingValue = "wsep")
+@Profile("!test")
 @Slf4j
 public class WsepPaymentGateway implements IPaymentGateway {
 

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.BarcodeDTO;
@@ -18,9 +18,9 @@ import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Real ticket issuer backed by the WSEP external system. Active only when
- * {@code external.ticket-issuer=wsep}; otherwise {@link StubTicketIssuer} is
- * used. {@code handshake} → {@link #verifyConnection()} and {@code issue_ticket}
+ * Real ticket issuer backed by the WSEP external system. Active in every real
+ * run ({@code @Profile("!test")}); the test suite uses {@link StubTicketIssuer}
+ * instead. {@code handshake} → {@link #verifyConnection()} and {@code issue_ticket}
  * → {@link #issue}.
  *
  * <p>WSEP {@code issue_ticket} returns ONE ticket code per call, while a
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
  * the checkout's refund/rollback path.
  */
 @Component
-@ConditionalOnProperty(name = "external.ticket-issuer", havingValue = "wsep")
+@Profile("!test")
 @Slf4j
 public class WsepTicketIssuer implements ITicketIssuer {
 

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
@@ -1,0 +1,111 @@
+package com.ticketing.system.Infrastructure.external;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.BarcodeDTO;
+import com.ticketing.system.Core.Application.dto.IssuanceRequestDTO;
+import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
+import com.ticketing.system.Core.Application.interfaces.ITicketIssuer;
+import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Real ticket issuer backed by the WSEP external system. Active only when
+ * {@code external.ticket-issuer=wsep}; otherwise {@link StubTicketIssuer} is
+ * used. {@code handshake} → {@link #verifyConnection()} and {@code issue_ticket}
+ * → {@link #issue}.
+ *
+ * <p>WSEP {@code issue_ticket} returns ONE ticket code per call, while a
+ * purchase needs one barcode per ticket, so this issues one ticket per item
+ * (GA, {@code quantity=1}) and assembles the list. A per-ticket positive id is
+ * synthesized locally (WSEP returns only the {@code TIX-…} code), matching the
+ * stub's contract. Any {@code "-1"} reply fails the whole issuance, which drives
+ * the checkout's refund/rollback path.
+ */
+@Component
+@ConditionalOnProperty(name = "external.ticket-issuer", havingValue = "wsep")
+@Slf4j
+public class WsepTicketIssuer implements ITicketIssuer {
+
+    private static final String ISSUER_ID = "wsep-ticket-issuer";
+    private static final String FAILURE = "-1";
+
+    private final WsepHttpClient http;
+    private final AtomicInteger ticketIds = new AtomicInteger(1);
+
+    public WsepTicketIssuer(WsepHttpClient http) {
+        this.http = http;
+    }
+
+    @Override
+    public String getId() {
+        return ISSUER_ID;
+    }
+
+    @Override
+    public boolean verifyConnection() {
+        try {
+            boolean ok = "OK".equalsIgnoreCase(http.post(WsepHttpClient.action("handshake")));
+            log.debug("wsep handshake (issuer): reachable={}", ok);
+            return ok;
+        } catch (RuntimeException e) {
+            log.debug("wsep handshake (issuer) failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    @Override
+    public IssuanceResultDTO issue(IssuanceRequestDTO request) {
+        if (request == null || request.items() == null || request.items().isEmpty()) {
+            throw new TicketIssuanceFailedException("cannot issue zero tickets");
+        }
+
+        long start = System.nanoTime();
+        String customerId = request.buyerUserId() != null ? String.valueOf(request.buyerUserId()) : "guest";
+
+        List<BarcodeDTO> barcodes = new ArrayList<>();
+        for (IssuanceRequestDTO.TicketIssuanceItemDTO item : request.items()) {
+            WsepHttpClient.Form form = WsepHttpClient.action("issue_ticket")
+                    .add("customer_id", customerId)
+                    .add("event_id", item.eventId())
+                    .add("zone", item.zoneId())
+                    .add("quantity", 1);
+
+            String code;
+            try {
+                code = http.post(form);
+            } catch (WsepCommunicationException e) {
+                throw new TicketIssuanceFailedException("ticket issuer unreachable: " + e.getMessage());
+            }
+
+            if (code == null || code.isBlank() || FAILURE.equals(code)) {
+                throw new TicketIssuanceFailedException("ticket issuance rejected by WSEP for event " + item.eventId());
+            }
+
+            barcodes.add(new BarcodeDTO(ticketIds.getAndIncrement(), code, "QR"));
+        }
+
+        log.debug("wsep issue_ticket ok: count={} firstCode={} ({} ms)",
+                barcodes.size(),
+                SensitiveDataMasker.truncId(barcodes.get(0).barcodeValue(), 8),
+                msSince(start));
+
+        return new IssuanceResultDTO(
+                "wsep-issuance-" + UUID.randomUUID(),
+                ISSUER_ID,
+                LocalDateTime.now(),
+                barcodes);
+    }
+
+    private static long msSince(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
 import com.ticketing.system.Core.Application.dto.CheckoutResultDTO;
 import com.ticketing.system.Core.Application.events.OrderExpiredEvent;
 import com.ticketing.system.Core.Application.services.CheckoutService;
@@ -86,15 +87,17 @@ public class CheckoutPresenter {
 
     // ---- pay ------------------------------------------------------------
 
-        public PayOutcome payAsMember(String memberToken, String idempotencyKey, String rawCardNumber) {
-        return runPay(() -> checkoutService.checkoutMember(
-            memberToken, idempotencyKey, CURRENCY, paymentToken(rawCardNumber)));
+    public PayOutcome payAsMember(String memberToken, String idempotencyKey,
+                                  String cardNumber, String cvc, String expiry, String holder) {
+        CardDetailsDTO card = buildCard(cardNumber, cvc, expiry, holder);
+        return runPay(() -> checkoutService.checkoutMember(memberToken, idempotencyKey, CURRENCY, card));
     }
 
-    public PayOutcome payAsGuest(String sessionId, String guestEmail, int guestAge,
-                                 String idempotencyKey, String rawCardNumber) {
+    public PayOutcome payAsGuest(String sessionId, String guestEmail, int guestAge, String idempotencyKey,
+                                 String cardNumber, String cvc, String expiry, String holder) {
+        CardDetailsDTO card = buildCard(cardNumber, cvc, expiry, holder);
         return runPay(() -> checkoutService.checkoutGuest(
-            sessionId, guestEmail, idempotencyKey, CURRENCY, paymentToken(rawCardNumber), guestAge));
+            sessionId, guestEmail, idempotencyKey, CURRENCY, card, guestAge));
     }
 
     private interface Charge { CheckoutResultDTO run(); }
@@ -114,8 +117,33 @@ public class CheckoutPresenter {
         }
     }
 
-    private static String paymentToken(String cardNumber) {
-        return "tok_" + cardNumber.replaceAll("\\s+", "");
+    // Builds the gateway card payload from the raw checkout-form inputs. Parses the
+    // "MM / YY" expiry into month + 4-digit year; malformed parts fall back to 0 so
+    // the gateway, not the presenter, is the single source of a decline.
+    private static CardDetailsDTO buildCard(String cardNumber, String cvc, String expiry, String holder) {
+        int month = 0;
+        int year = 0;
+        if (expiry != null && expiry.contains("/")) {
+            String[] parts = expiry.split("/");
+            month = parseIntOrZero(parts[0].trim());
+            int yy = parts.length > 1 ? parseIntOrZero(parts[1].trim()) : 0;
+            year = (yy > 0 && yy < 100) ? 2000 + yy : yy;
+        }
+        String digits = cardNumber == null ? "" : cardNumber.replaceAll("\\s+", "");
+        return new CardDetailsDTO(
+            digits,
+            cvc == null ? "" : cvc.trim(),
+            month,
+            year,
+            holder == null ? "" : holder.trim());
+    }
+
+    private static int parseIntOrZero(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     // ---- session --------------------------------------------------------

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -464,9 +464,10 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
         try {
             String idempotencyKey = currentIdempotencyKey();
             CheckoutPresenter.PayOutcome outcome = isMember
-                ? presenter.payAsMember(memberToken, idempotencyKey, cardNumber.getValue())
-                : presenter.payAsGuest(sessionId, guestEmail.getValue().trim(),
-                                       guestAge.getValue(), idempotencyKey, cardNumber.getValue());
+                ? presenter.payAsMember(memberToken, idempotencyKey,
+                                        cardNumber.getValue(), cvc.getValue(), expiry.getValue(), cardholder.getValue())
+                : presenter.payAsGuest(sessionId, guestEmail.getValue().trim(), guestAge.getValue(), idempotencyKey,
+                                       cardNumber.getValue(), cvc.getValue(), expiry.getValue(), cardholder.getValue());
 
             switch (outcome) {
                 case CheckoutPresenter.PayOutcome.Success ok -> {

--- a/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
@@ -77,8 +77,11 @@ public class OrderConfirmationView extends LkPage implements BeforeEnterObserver
         String totalDisplay = (result != null)
             ? Money.format(Money.toCents(result.totalCharged()))
             : "$0.00";
+        // The real gateway transaction id (what WSEP `pay` returned), shown as-is so
+        // it matches the receipt's "Transaction <externalTransactionId>" — not a
+        // hex-mangled derivative.
         String transactionDisplay = (result != null)
-            ? String.format("%04x", result.paymentTransactionId())
+            ? String.valueOf(result.paymentTransactionId())
             : "—";
 
         Span sub = new Span(receiptDisplay + " · Transaction " + transactionDisplay

--- a/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
@@ -47,12 +47,16 @@ public class OrderConfirmationView extends LkPage implements BeforeEnterObserver
             event.rerouteTo(BrowseEventsView.class);
             return;
         }
-    }
-
-    public OrderConfirmationView() {
+        // Build the page here, not in the constructor: the constructor runs before
+        // beforeEnter, when `result` is still null — building there would render an
+        // empty receipt (no tickets, "—" ids/barcodes).
         add(buildConfirmHero());
         add(buildTicketsCard());
         add(buildActions());
+    }
+
+    public OrderConfirmationView() {
+        // Intentionally empty — content is built in beforeEnter once `result` is set.
     }
 
     private Component buildConfirmHero() {
@@ -93,12 +97,12 @@ public class OrderConfirmationView extends LkPage implements BeforeEnterObserver
             .col("Ticket ID",  "ticketId")
             .col("Barcode",    "barcode");
 
-        if (result != null && result.issuedTicketIds() != null && !result.issuedTicketIds().isEmpty()) {
-            for (int ticketId : result.issuedTicketIds()) {
-                ticketRow(grid, ticketId);
+        if (result != null && result.issuedTickets() != null && !result.issuedTickets().isEmpty()) {
+            for (CheckoutResultDTO.IssuedTicketDTO ticket : result.issuedTickets()) {
+                ticketRow(grid, ticket.ticketId(), ticket.barcode());
             }
         } else {
-            ticketRow(grid, 0);
+            ticketRow(grid, 0, null);
         }
 
         grid.build();
@@ -106,19 +110,22 @@ public class OrderConfirmationView extends LkPage implements BeforeEnterObserver
         return card;
     }
 
-    private void ticketRow(LkGrid grid, int ticketId) {
+    private void ticketRow(LkGrid grid, int ticketId, String barcodeValue) {
         Map<String, Object> row = new LinkedHashMap<>();
-        
+
         if (ticketId > 0) {
             row.put("ticketId", String.valueOf(ticketId));
-            Span barcode = Lk.mono("▮▯▮▯▮ " + String.format("%04X-%04X", ticketId >> 16, ticketId & 0xFFFF));
+            // Show the barcode the issuer actually returned (real WSEP TIX code / stub code),
+            // not a value fabricated from the ticket id.
+            String value = (barcodeValue != null && !barcodeValue.isBlank()) ? barcodeValue : "Not yet issued";
+            Span barcode = Lk.mono(value);
             barcode.addClassName("bz-barcode");
             row.put("barcode", barcode);
         } else {
             row.put("ticketId", "—");
             row.put("barcode", "—");
         }
-        
+
         grid.row(row);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,13 +67,9 @@ platform:
     username: ${PLATFORM_ADMIN_USERNAME:admin}
     password: ${PLATFORM_ADMIN_PASSWORD:admin}
 
-# External systems (UC-33 payment / UC-34 issuance). Selects which adapter backs
-# IPaymentGateway / ITicketIssuer: "stub" = in-process fake (default; used in
-# dev/test, never touches the network), "wsep" = the real WSEP HTTP adapter.
-external:
-  payment-gateway: ${EXTERNAL_PAYMENT_GATEWAY:stub}
-  ticket-issuer: ${EXTERNAL_TICKET_ISSUER:stub}
-
-# WSEP external-systems endpoint — used only when an adapter above is "wsep".
+# WSEP external systems (UC-33 payment / UC-34 issuance). WsepPaymentGateway /
+# WsepTicketIssuer back IPaymentGateway / ITicketIssuer in every real run
+# (@Profile("!test")); the test profile swaps in the in-process stubs. base-url is
+# the single koyeb endpoint both adapters POST to.
 wsep:
   base-url: ${WSEP_BASE_URL:https://damp-lynna-wsep-1984852e.koyeb.app/}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,3 +66,14 @@ platform:
   admin:
     username: ${PLATFORM_ADMIN_USERNAME:admin}
     password: ${PLATFORM_ADMIN_PASSWORD:admin}
+
+# External systems (UC-33 payment / UC-34 issuance). Selects which adapter backs
+# IPaymentGateway / ITicketIssuer: "stub" = in-process fake (default; used in
+# dev/test, never touches the network), "wsep" = the real WSEP HTTP adapter.
+external:
+  payment-gateway: ${EXTERNAL_PAYMENT_GATEWAY:stub}
+  ticket-issuer: ${EXTERNAL_TICKET_ISSUER:stub}
+
+# WSEP external-systems endpoint — used only when an adapter above is "wsep".
+wsep:
+  base-url: ${WSEP_BASE_URL:https://damp-lynna-wsep-1984852e.koyeb.app/}

--- a/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
@@ -75,7 +75,8 @@ public class CheckoutServiceAcceptanceTest {
     private static final String INVALID_TOKEN = "invalid-token";
     private static final String IDEMPOTENCY_KEY = "idem-123";
     private static final String CURRENCY = "ILS";
-    private static final String PAYMENT_METHOD_TOKEN = "pay-token";
+    private static final CardDetailsDTO PAYMENT_METHOD_TOKEN =
+            new CardDetailsDTO("4111111111111234", "123", 12, 2030, "Test Holder");
 
     private static final int USER_ID = 1;
     private static final int EVENT_ID_1 = 10;
@@ -407,11 +408,12 @@ public class CheckoutServiceAcceptanceTest {
     }
 
     @Test
-    void GivenBlankPaymentMethodToken_WhenCheckout_ThenThrowException() {
+    void GivenBlankCard_WhenCheckout_ThenThrowException() {
         validSession();
 
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
-                checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, " ")
+                checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY,
+                        new CardDetailsDTO(" ", "123", 12, 2030, "X"))
         );
 
         assertEquals("Checkout failed, tickets returned to stock", exception.getMessage());

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -826,7 +826,7 @@ void GivenValidCheckout_WhenCheckout_ThenReturnCheckoutResultAndSaveTicketAndRec
                         100.0,
                         1,
                     PAYMENT_TRANSACTION_ID,
-                    List.of(TICKET_ID_1)
+                    List.of(new CheckoutResultDTO.IssuedTicketDTO(TICKET_ID_1, "barcode-value-1"))
             ),
             result
     );
@@ -969,7 +969,9 @@ void GivenMultipleTicketsFromDifferentZonesSameEvent_WhenCheckout_ThenBuyAllTick
                                     250.0,
                                     1,
                     PAYMENT_TRANSACTION_ID,
-                    List.of(TICKET_ID_1, TICKET_ID_2)
+                    List.of(
+                            new CheckoutResultDTO.IssuedTicketDTO(TICKET_ID_1, "barcode-zone-1"),
+                            new CheckoutResultDTO.IssuedTicketDTO(TICKET_ID_2, "barcode-zone-2"))
             ),
             result
     );
@@ -1057,7 +1059,9 @@ void GivenMultipleTicketsFromDifferentZonesSameEvent_WhenCheckout_ThenBuyAllTick
                                            300.0,
                                            1,
                                            PAYMENT_TRANSACTION_ID,
-                                           List.of(TICKET_ID_1, TICKET_ID_3)),
+                                           List.of(
+                                                   new CheckoutResultDTO.IssuedTicketDTO(TICKET_ID_1, "barcode-event-1"),
+                                                   new CheckoutResultDTO.IssuedTicketDTO(TICKET_ID_3, "barcode-event-2"))),
                            result);
 
            ArgumentCaptor<Ticket> ticketCaptor = ArgumentCaptor.forClass(Ticket.class);

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.ticketing.system.Core.Application.dto.BarcodeDTO;
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
 import com.ticketing.system.Core.Application.dto.CheckoutResultDTO;
 import com.ticketing.system.Core.Application.dto.IssuanceRequestDTO;
 import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
@@ -108,7 +109,8 @@ class CheckoutServiceTest {
 
     private final String IDEMPOTENCY_KEY = "idem-key-1";
     private final String CURRENCY = "ILS";
-    private final String PAYMENT_METHOD_TOKEN = "payment-token";
+    private final CardDetailsDTO PAYMENT_METHOD_TOKEN =
+            new CardDetailsDTO("4111111111111234", "123", 12, 2030, "Test Holder");
 
     private ActiveOrder mockOrder;
     private CartLineItem itemEvent1Zone1;

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
@@ -1,0 +1,138 @@
+package com.ticketing.system.unit.infrastructure.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
+import com.ticketing.system.Core.Application.dto.PaymentRequestDTO;
+import com.ticketing.system.Core.Application.dto.PaymentResultDTO;
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
+import com.ticketing.system.Infrastructure.external.WsepCommunicationException;
+import com.ticketing.system.Infrastructure.external.WsepHttpClient;
+import com.ticketing.system.Infrastructure.external.WsepPaymentGateway;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+class WsepPaymentGatewayTest {
+
+    private static final String FULL_PAN = "4111111111119999";
+    private static final String CVV = "777";
+
+    private final WsepHttpClient http = mock(WsepHttpClient.class);
+    private final WsepPaymentGateway gateway = new WsepPaymentGateway(http);
+
+    private PaymentRequestDTO request() {
+        CardDetailsDTO card = new CardDetailsDTO(FULL_PAN, CVV, 11, 2031, "Jane Holder");
+        return new PaymentRequestDTO("idem-1", 100.0, "USD", card, 42, null);
+    }
+
+    @Test
+    void verifyConnection_trueOnOk_falseOtherwise_falseOnTransportError() {
+        when(http.post(any())).thenReturn("OK");
+        assertTrue(gateway.verifyConnection());
+
+        when(http.post(any())).thenReturn("down");
+        assertFalse(gateway.verifyConnection());
+
+        when(http.post(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
+        assertFalse(gateway.verifyConnection());
+    }
+
+    @Test
+    void charge_mapsEveryPayParamAndReturnsTransactionId() {
+        when(http.post(any())).thenReturn("54321");
+
+        PaymentResultDTO result = gateway.charge(request());
+
+        assertEquals(54321, result.paymentTransactionId());
+        assertEquals("wsep-payment-gateway", result.gatewayName());
+        assertEquals(100.0, result.chargedAmount());
+        assertEquals("USD", result.currency());
+
+        ArgumentCaptor<WsepHttpClient.Form> captor = ArgumentCaptor.forClass(WsepHttpClient.Form.class);
+        verify(http).post(captor.capture());
+        Map<String, String> sent = captor.getValue().fields();
+        assertEquals("pay", sent.get("action_type"));
+        assertEquals("100.0", sent.get("amount"));
+        assertEquals("USD", sent.get("currency"));
+        assertEquals(FULL_PAN, sent.get("card_number"));
+        assertEquals("11", sent.get("month"));
+        assertEquals("2031", sent.get("year"));
+        assertEquals("Jane Holder", sent.get("holder"));
+        assertEquals(CVV, sent.get("cvv"));      // cvv IS sent to WSEP (required)...
+        assertEquals("42", sent.get("id"));
+    }
+
+    @Test
+    void charge_minusOneIsDeclined() {
+        when(http.post(any())).thenReturn("-1");
+        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+    }
+
+    @Test
+    void charge_unparseableBodyThrows() {
+        when(http.post(any())).thenReturn("not-a-number");
+        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+    }
+
+    @Test
+    void charge_transportFailureBecomesPaymentGatewayException() {
+        when(http.post(any())).thenThrow(new WsepCommunicationException("refused", new RuntimeException()));
+        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+    }
+
+    @Test
+    void refund_oneIsSuccess_minusOneFails() {
+        when(http.post(any())).thenReturn("1");
+        RefundResultDTO ok = gateway.refund(54321, 100.0);
+        assertEquals("54321", ok.orderReceiptId());
+
+        when(http.post(any())).thenReturn("-1");
+        assertThrows(RefundFailedException.class, () -> gateway.refund(54321, 100.0));
+    }
+
+    @Test
+    void charge_neverLogsFullPanOrCvv() {
+        Logger logger = (Logger) LoggerFactory.getLogger(WsepPaymentGateway.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        Level original = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        try {
+            when(http.post(any())).thenReturn("54321");
+            gateway.charge(request());
+
+            boolean anyLogged = false;
+            for (ILoggingEvent event : appender.list) {
+                String msg = event.getFormattedMessage();
+                assertFalse(msg.contains(FULL_PAN), "full PAN leaked: " + msg);
+                assertFalse(msg.contains(CVV), "cvv leaked: " + msg);
+                if (msg.contains("9999")) {
+                    anyLogged = true; // last 4 is fine to show
+                }
+            }
+            assertTrue(anyLogged, "expected a masked card debug line");
+        } finally {
+            logger.setLevel(original);
+            logger.detachAppender(appender);
+        }
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepTicketIssuerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepTicketIssuerTest.java
@@ -1,0 +1,91 @@
+package com.ticketing.system.unit.infrastructure.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.ticketing.system.Core.Application.dto.IssuanceRequestDTO;
+import com.ticketing.system.Core.Application.dto.IssuanceResultDTO;
+import com.ticketing.system.Core.Domain.exceptions.TicketIssuanceFailedException;
+import com.ticketing.system.Infrastructure.external.WsepCommunicationException;
+import com.ticketing.system.Infrastructure.external.WsepHttpClient;
+import com.ticketing.system.Infrastructure.external.WsepTicketIssuer;
+
+class WsepTicketIssuerTest {
+
+    private final WsepHttpClient http = mock(WsepHttpClient.class);
+    private final WsepTicketIssuer issuer = new WsepTicketIssuer(http);
+
+    private IssuanceRequestDTO twoTicketRequest() {
+        return new IssuanceRequestDTO(42, null, List.of(
+                new IssuanceRequestDTO.TicketIssuanceItemDTO(10, "Concert", 5, null),
+                new IssuanceRequestDTO.TicketIssuanceItemDTO(10, "Concert", 5, null)));
+    }
+
+    @Test
+    void verifyConnection_trueOnOk_falseOtherwise() {
+        when(http.post(any())).thenReturn("OK");
+        assertTrue(issuer.verifyConnection());
+
+        when(http.post(any())).thenReturn("down");
+        assertFalse(issuer.verifyConnection());
+
+        when(http.post(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
+        assertFalse(issuer.verifyConnection());
+    }
+
+    @Test
+    void issue_oneCallPerTicket_collectsCodesIntoBarcodes() {
+        when(http.post(any())).thenReturn("TIX-aaaa-1111", "TIX-bbbb-2222");
+
+        IssuanceResultDTO result = issuer.issue(twoTicketRequest());
+
+        assertEquals("wsep-ticket-issuer", result.issuerName());
+        assertNotNull(result.issuanceTransactionId());
+        assertEquals(2, result.barcodes().size());
+        assertEquals("TIX-aaaa-1111", result.barcodes().get(0).barcodeValue());
+        assertEquals("TIX-bbbb-2222", result.barcodes().get(1).barcodeValue());
+        assertTrue(result.barcodes().get(0).ticketId() > 0);
+        assertTrue(result.barcodes().get(1).ticketId() > 0);
+
+        ArgumentCaptor<WsepHttpClient.Form> captor = ArgumentCaptor.forClass(WsepHttpClient.Form.class);
+        verify(http, times(2)).post(captor.capture());
+        Map<String, String> first = captor.getAllValues().get(0).fields();
+        assertEquals("issue_ticket", first.get("action_type"));
+        assertEquals("42", first.get("customer_id"));
+        assertEquals("10", first.get("event_id"));
+        assertEquals("5", first.get("zone"));
+        assertEquals("1", first.get("quantity"));
+    }
+
+    @Test
+    void issue_minusOneFailsTheWholeIssuance() {
+        when(http.post(any())).thenReturn("-1");
+        assertThrows(TicketIssuanceFailedException.class, () -> issuer.issue(twoTicketRequest()));
+    }
+
+    @Test
+    void issue_emptyItemsThrows() {
+        IssuanceRequestDTO empty = new IssuanceRequestDTO(42, null, List.of());
+        assertThrows(TicketIssuanceFailedException.class, () -> issuer.issue(empty));
+    }
+
+    @Test
+    void issue_transportFailureBecomesIssuanceFailure() {
+        when(http.post(any())).thenThrow(new WsepCommunicationException("refused", new RuntimeException()));
+        assertThrows(TicketIssuanceFailedException.class, () -> issuer.issue(twoTicketRequest()));
+    }
+}


### PR DESCRIPTION
## What

Real **WSEP external-systems HTTP adapter**, implemented behind the existing `IPaymentGateway` / `ITicketIssuer` ports — a drop-in swap **gated by a property** so the in-process stubs stay the default in dev/test (never hit the live endpoint in CI).

## Provider selection
`external.payment-gateway` / `external.ticket-issuer` = `stub` (default) | `wsep`; `wsep.base-url` defaults to the koyeb endpoint. The stubs and the `Wsep*` adapters are `@ConditionalOnProperty`-gated so exactly one of each is active — the singular gateway injection in `CheckoutService` stays unambiguous.

## Changes (4 commits)
- **`feat(UC-33)` card data end-to-end** — the checkout form already collected cardholder/expiry/CVC but discarded all but the number. A new `CardDetailsDTO` (leak-safe `toString`: masks PAN, omits CVV) replaces the opaque token on `PaymentRequestDTO` and flows view → presenter → service → gateway.
- **`infra(UC-33)` WsepHttpClient + gating + config** — one form-encoded POST per call, `action_type` dispatch, `-1` sentinel; `WsepCommunicationException` marks transport failures.
- **`feat(UC-33)` WsepPaymentGateway** — `handshake`→verifyConnection, `pay`→charge, `refund`→refund. Masked DEBUG logs (PAN last-4 only, never cvv/expiry/holder).
- **`feat(UC-34)` WsepTicketIssuer** — `handshake` + one `issue_ticket` per ticket (GA, quantity=1), assembling the returned `TIX-…` codes into one barcode per ticket; any `-1` fails the issuance (drives checkout rollback).

## Spec fidelity
Each port method maps to exactly one documented `action_type`; `-1` → the matching domain exception. Mapping notes per the spec: `refund` has no partial-amount param; `issue_ticket` returns one code per call (so we loop); our int `event_id`/`zone` are sent as strings; guest `customer_id`=`guest`, pay `id`=userId|0.

## Tests
All adapter tests run against a **mocked `WsepHttpClient`** (no live endpoint → deterministic CI): field mapping, `-1` handling, transport-failure translation, and a masking test asserting the **cvv is sent on the wire but never logged**. Full suite: **1072 run, 0 failures**.

## Follow-up
Fault tolerance (retry / timeout tuning / circuit-breaker) belongs to #155 [SLR.5].

Closes #344
