### PR TITLE
System Analytics dashboard + admin landing KPIs (UC-46 #43, #279)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/AdminOverviewDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/AdminOverviewDTO.java
@@ -1,0 +1,15 @@
+package com.ticketing.system.Core.Application.dto;
+
+/**
+ * Read-side snapshot for the admin workspace landing page (AdminDashboardView, #279).
+ *
+ * <p>Platform-wide headline counters: active production companies, live (ON_SALE)
+ * events, open (non-closed) complaints, and total non-refunded revenue over the
+ * trailing 30 days.
+ */
+public record AdminOverviewDTO(
+    int activeCompanies,
+    int liveEvents,
+    int openComplaints,
+    double revenue30d
+) {}

--- a/src/main/java/com/ticketing/system/Core/Application/dto/SystemAnalyticsDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/SystemAnalyticsDTO.java
@@ -1,0 +1,25 @@
+package com.ticketing.system.Core.Application.dto;
+
+/**
+ * Read-side snapshot for the System Analytics dashboard (UC-46 / #43, #279).
+ *
+ * <p>Market status is carried separately by {@link MarketStateDTO}; this record
+ * holds the platform performance metrics. Rates are per-minute over the trailing
+ * {@code windowMinutes}; throughput figures are totals over the trailing hour;
+ * {@code activeVisitors} is point-in-time and the {@code total*} fields are
+ * cumulative since startup.
+ */
+public record SystemAnalyticsDTO(
+    long activeVisitors,
+    double visitorEntryRatePerMin,
+    double visitorExitRatePerMin,
+    double registrationRatePerMin,
+    double reservationRatePerMin,
+    double purchaseRatePerMin,
+    long reservationThroughputHr,
+    long purchaseThroughputHr,
+    long totalVisitors,
+    long totalRegistrations,
+    long totalReservations,
+    int windowMinutes
+) {}

--- a/src/main/java/com/ticketing/system/Core/Application/interfaces/ISystemMetrics.java
+++ b/src/main/java/com/ticketing/system/Core/Application/interfaces/ISystemMetrics.java
@@ -1,0 +1,28 @@
+package com.ticketing.system.Core.Application.interfaces;
+
+import java.time.Duration;
+
+/**
+ * Outbound port for recording and reading the lightweight platform-activity
+ * counters that feed the System Analytics dashboard (UC-46 / #43, #279).
+ *
+ * <p>Write side: the auth / reservation slices (and the session sweeper) call
+ * {@link #record(MetricType)} as events occur. Read side:
+ * {@code SystemAnalyticsService} calls {@link #count(MetricType, Duration)} and
+ * {@link #total(MetricType)} to compute live rates and throughput.
+ *
+ * <p>The adapter lives in Infrastructure (V1/V2: in-memory; swappable for a
+ * durable / Micrometer-backed store in V3 without touching callers — ports &
+ * adapters).
+ */
+public interface ISystemMetrics {
+
+    /** Records one occurrence of {@code type} at the current instant. */
+    void record(MetricType type);
+
+    /** Number of {@code type} events recorded within the trailing {@code within} window. */
+    long count(MetricType type, Duration within);
+
+    /** Cumulative number of {@code type} events recorded since startup. */
+    long total(MetricType type);
+}

--- a/src/main/java/com/ticketing/system/Core/Application/interfaces/MetricType.java
+++ b/src/main/java/com/ticketing/system/Core/Application/interfaces/MetricType.java
@@ -1,0 +1,15 @@
+package com.ticketing.system.Core.Application.interfaces;
+
+/**
+ * The platform-activity events tracked for the System Analytics dashboard
+ * (UC-46). Purchases are intentionally absent — they are derived from the
+ * immutable {@code OrderReceipt} history rather than recorded as live counters.
+ *
+ * @see ISystemMetrics
+ */
+public enum MetricType {
+    VISITOR_ENTRY,
+    VISITOR_EXIT,
+    REGISTRATION,
+    RESERVATION
+}

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -25,6 +25,8 @@ import com.ticketing.system.Core.Application.dto.RefreshTokenRequestDTO;
 import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
 import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
@@ -67,6 +69,7 @@ public class AuthenticationService {
     private final NotificationDispatchService notificationDispatchService; // for UC-37 notification flush
     private final ISessionRepository sessionRepository;
     private final IActiveOrderRepository activeOrderRepository;
+    private final ISystemMetrics systemMetrics;
     private final Clock clock;
     private final long guestIdleMinutes;
     private final long memberTtlMinutes;
@@ -88,6 +91,7 @@ public class AuthenticationService {
             NotificationDispatchService notificationDispatchService,
             ISessionRepository sessionRepository,
             IActiveOrderRepository activeOrderRepository,
+            ISystemMetrics systemMetrics,
             Clock clock,
             IAdminRepository adminRepository,
             @Value("${session.guest-idle-timeout-minutes}") long guestIdleMinutes,
@@ -101,6 +105,7 @@ public class AuthenticationService {
         this.notificationDispatchService = notificationDispatchService;
         this.sessionRepository = sessionRepository;
         this.activeOrderRepository = activeOrderRepository;
+        this.systemMetrics = systemMetrics;
         this.clock = clock;
         this.adminRepository = adminRepository;
         this.guestIdleMinutes = guestIdleMinutes;
@@ -132,6 +137,7 @@ public class AuthenticationService {
         Instant expiry = now.plus(guestIdleMinutes, ChronoUnit.MINUTES);
         String sid = UUID.randomUUID().toString();
         sessionRepository.save(new Session(sid, null, now, expiry));
+        systemMetrics.record(MetricType.VISITOR_ENTRY);
         log.info("guest session started sid={}", sid);
         return new GuestSessionDTO(sid, now);
     }
@@ -145,6 +151,7 @@ public class AuthenticationService {
         if (sessionId == null || sessionId.isBlank())
             return;
         sessionRepository.delete(sessionId);
+        systemMetrics.record(MetricType.VISITOR_EXIT);
         log.info("guest session ended sid={}", sessionId);
     }
 
@@ -202,6 +209,7 @@ public class AuthenticationService {
         // 5. Session stays Guest — just touch the activity timestamp.
         session.touch(clock.instant());
         sessionRepository.save(session);
+        systemMetrics.record(MetricType.REGISTRATION);
 
         log.info("member registered: username={} id={}", user.getUsername(), user.getUserId());
     }

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -15,6 +15,8 @@ import com.ticketing.system.Core.Application.dto.BuyerContextDTO;
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
 import com.ticketing.system.Core.Domain.events.InventorySelection;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
@@ -40,6 +42,7 @@ public class ReservationService {
     private final IProductionCompanyRepository companyRepository;
     private final IUserRepository userRepository;
     private final SystemAdminService systemAdminService;
+    private final ISystemMetrics systemMetrics;
 
     @Value("${constants.ticket-reservation-duration}")
     private int reservationTimeoutMinutes;
@@ -51,7 +54,8 @@ public class ReservationService {
             INotificationService notificationService,
             IProductionCompanyRepository companyRepository,
             IUserRepository userRepository,
-            SystemAdminService systemAdminService) {
+            SystemAdminService systemAdminService,
+            ISystemMetrics systemMetrics) {
         this.eventRepository = eventRepository;
         this.activeOrderRepository = activeOrderRepository;
         this.iSessionManager = iSessionManager;
@@ -59,6 +63,7 @@ public class ReservationService {
         this.companyRepository = companyRepository;
         this.userRepository = userRepository;
         this.systemAdminService = systemAdminService;
+        this.systemMetrics = systemMetrics;
     }
 
     // ---------------------------------------------------------------------
@@ -164,6 +169,7 @@ public class ReservationService {
             activeOrderRepository.save(activeOrder);
             // Notify the member of the successful reservation. For guests, we do not have a user ID to send notifications to, so we skip this step for guests. The notification can be used to trigger email notifications, app push notifications, etc. to inform the member of their successful reservation and any details they may need (e.g. event name, zone, quantity reserved, etc.).
             notifySuccessAfterUnlock = true;
+            systemMetrics.record(MetricType.RESERVATION);
             // Return the reservation result, which includes details about the reservation such as event ID, zone ID, quantity reserved, seat numbers if applicable, and the expiration time of the reservation (based on the current time plus the configured reservation timeout). This information can be used by the frontend to show the user their current reservations and how long they have before they expire, etc.
             return buildReservationResult(eventId, zoneId, selection);
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
@@ -1,0 +1,105 @@
+package com.ticketing.system.Core.Application.services;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Read-side aggregator for the System Analytics dashboard (UC-46 / #43, #279).
+ *
+ * <p>Pure query service. Visitor / registration / reservation activity comes
+ * from the live {@link ISystemMetrics} counters; purchases are derived from the
+ * immutable {@link OrderReceipt} history (real timestamps), so no checkout
+ * instrumentation is needed. No token is taken — the admin route is
+ * access-gated, mirroring {@code SystemAdminService.viewMarketState()}. Market
+ * status itself is supplied separately by {@code SystemAdminService}.
+ */
+@Service
+@Slf4j
+public class SystemAnalyticsService {
+
+    private static final int THROUGHPUT_WINDOW_MINUTES = 60;
+
+    private final ISystemMetrics metrics;
+    private final IOrderReceiptRepository orderReceiptRepository;
+    private final Clock clock;
+    private final int windowMinutes;
+
+    public SystemAnalyticsService(
+            ISystemMetrics metrics,
+            IOrderReceiptRepository orderReceiptRepository,
+            Clock clock,
+            @Value("${analytics.rate-window-minutes:5}") int windowMinutes) {
+        this.metrics = metrics;
+        this.orderReceiptRepository = orderReceiptRepository;
+        this.clock = clock;
+        this.windowMinutes = windowMinutes > 0 ? windowMinutes : 5;
+    }
+
+    /** Builds the live analytics snapshot: rates over the trailing window, throughput over the hour. */
+    public SystemAnalyticsDTO computeAnalytics() {
+        Duration window = Duration.ofMinutes(windowMinutes);
+        Duration hour = Duration.ofMinutes(THROUGHPUT_WINDOW_MINUTES);
+
+        long entries = metrics.count(MetricType.VISITOR_ENTRY, window);
+        long exits = metrics.count(MetricType.VISITOR_EXIT, window);
+        long registrations = metrics.count(MetricType.REGISTRATION, window);
+        long reservations = metrics.count(MetricType.RESERVATION, window);
+
+        long activeVisitors = Math.max(0L,
+                metrics.total(MetricType.VISITOR_ENTRY) - metrics.total(MetricType.VISITOR_EXIT));
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        long purchasesWindow = countPurchasesSince(now.minusMinutes(windowMinutes));
+        long purchasesHour = countPurchasesSince(now.minusMinutes(THROUGHPUT_WINDOW_MINUTES));
+
+        SystemAnalyticsDTO dto = new SystemAnalyticsDTO(
+                activeVisitors,
+                perMinute(entries),
+                perMinute(exits),
+                perMinute(registrations),
+                perMinute(reservations),
+                perMinute(purchasesWindow),
+                metrics.count(MetricType.RESERVATION, hour),
+                purchasesHour,
+                metrics.total(MetricType.VISITOR_ENTRY),
+                metrics.total(MetricType.REGISTRATION),
+                metrics.total(MetricType.RESERVATION),
+                windowMinutes);
+        log.debug("System analytics snapshot: {}", dto);
+        return dto;
+    }
+
+    /** Counts immutable receipts whose purchaseTime is at or after {@code since}. */
+    private long countPurchasesSince(LocalDateTime since) {
+        // A fully-null filter matches every receipt (the date filters are LocalDate, too coarse
+        // for minute-level windows), so we count by the receipt's own purchaseTime in memory.
+        List<OrderReceipt> all = orderReceiptRepository.findGlobal(
+                new GlobalHistoryFiltersDTO(null, null, null, null, null));
+        long n = 0;
+        for (OrderReceipt receipt : all) {
+            LocalDateTime purchasedAt = receipt.getPurchaseTime();
+            if (purchasedAt != null && !purchasedAt.isBefore(since)) {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    private double perMinute(long countInWindow) {
+        return windowMinutes <= 0 ? 0.0 : (double) countInWindow / windowMinutes;
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
@@ -78,9 +78,25 @@ public class SystemAnalyticsService {
         long activeVisitors = Math.max(0L,
                 metrics.total(MetricType.VISITOR_ENTRY) - metrics.total(MetricType.VISITOR_EXIT));
 
+        // Single receipt scan per snapshot — count both the rate window and the hour throughput
+        // in one pass (this runs on the auto-refresh poll every few seconds).
         LocalDateTime now = LocalDateTime.now(clock);
-        long purchasesWindow = countPurchasesSince(now.minusMinutes(windowMinutes));
-        long purchasesHour = countPurchasesSince(now.minusMinutes(THROUGHPUT_WINDOW_MINUTES));
+        LocalDateTime windowCutoff = now.minusMinutes(windowMinutes);
+        LocalDateTime hourCutoff = now.minusMinutes(THROUGHPUT_WINDOW_MINUTES);
+        long purchasesWindow = 0;
+        long purchasesHour = 0;
+        for (OrderReceipt receipt : allReceipts()) {
+            LocalDateTime purchasedAt = receipt.getPurchaseTime();
+            if (purchasedAt == null) {
+                continue;
+            }
+            if (!purchasedAt.isBefore(windowCutoff)) {
+                purchasesWindow++;
+            }
+            if (!purchasedAt.isBefore(hourCutoff)) {
+                purchasesHour++;
+            }
+        }
 
         SystemAnalyticsDTO dto = new SystemAnalyticsDTO(
                 activeVisitors,
@@ -113,8 +129,7 @@ public class SystemAnalyticsService {
 
         LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(REVENUE_WINDOW_DAYS);
         double revenue30d = 0.0;
-        for (OrderReceipt receipt : orderReceiptRepository.findGlobal(
-                new GlobalHistoryFiltersDTO(null, null, null, null, null))) {
+        for (OrderReceipt receipt : allReceipts()) {
             LocalDateTime purchasedAt = receipt.getPurchaseTime();
             if (!receipt.wasRefunded() && purchasedAt != null && !purchasedAt.isBefore(cutoff)) {
                 revenue30d += receipt.getTotalAmount();
@@ -126,20 +141,14 @@ public class SystemAnalyticsService {
         return dto;
     }
 
-    /** Counts immutable receipts whose purchaseTime is at or after {@code since}. */
-    private long countPurchasesSince(LocalDateTime since) {
-        // A fully-null filter matches every receipt (the date filters are LocalDate, too coarse
-        // for minute-level windows), so we count by the receipt's own purchaseTime in memory.
-        List<OrderReceipt> all = orderReceiptRepository.findGlobal(
+    /**
+     * All receipts (a fully-null filter matches every receipt). The repo's date filters are
+     * {@code LocalDate} — too coarse for minute-level windows — so callers filter by the receipt's
+     * own {@code purchaseTime} in memory. Fetched once per snapshot.
+     */
+    private List<OrderReceipt> allReceipts() {
+        return orderReceiptRepository.findGlobal(
                 new GlobalHistoryFiltersDTO(null, null, null, null, null));
-        long n = 0;
-        for (OrderReceipt receipt : all) {
-            LocalDateTime purchasedAt = receipt.getPurchaseTime();
-            if (purchasedAt != null && !purchasedAt.isBefore(since)) {
-                n++;
-            }
-        }
-        return n;
     }
 
     private double perMinute(long countInWindow) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
@@ -8,10 +8,16 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
 import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
 import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
 import com.ticketing.system.Core.Application.interfaces.MetricType;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 
@@ -32,19 +38,29 @@ import lombok.extern.slf4j.Slf4j;
 public class SystemAnalyticsService {
 
     private static final int THROUGHPUT_WINDOW_MINUTES = 60;
+    private static final int REVENUE_WINDOW_DAYS = 30;
 
     private final ISystemMetrics metrics;
     private final IOrderReceiptRepository orderReceiptRepository;
+    private final IProductionCompanyRepository companyRepository;
+    private final IEventRepository eventRepository;
+    private final IConversationRepository conversationRepository;
     private final Clock clock;
     private final int windowMinutes;
 
     public SystemAnalyticsService(
             ISystemMetrics metrics,
             IOrderReceiptRepository orderReceiptRepository,
+            IProductionCompanyRepository companyRepository,
+            IEventRepository eventRepository,
+            IConversationRepository conversationRepository,
             Clock clock,
             @Value("${analytics.rate-window-minutes:5}") int windowMinutes) {
         this.metrics = metrics;
         this.orderReceiptRepository = orderReceiptRepository;
+        this.companyRepository = companyRepository;
+        this.eventRepository = eventRepository;
+        this.conversationRepository = conversationRepository;
         this.clock = clock;
         this.windowMinutes = windowMinutes > 0 ? windowMinutes : 5;
     }
@@ -80,6 +96,33 @@ public class SystemAnalyticsService {
                 metrics.total(MetricType.RESERVATION),
                 windowMinutes);
         log.debug("System analytics snapshot: {}", dto);
+        return dto;
+    }
+
+    /**
+     * Headline counters for the admin workspace landing page (#279): active companies, live
+     * (ON_SALE) events, open (non-closed) complaints, and non-refunded revenue over the trailing
+     * 30 days. No token — the admin route is access-gated, like {@link #computeAnalytics()}.
+     */
+    public AdminOverviewDTO adminOverview() {
+        int activeCompanies = companyRepository.findActive().size();
+        int liveEvents = eventRepository.findByStatus(EventStatus.ON_SALE).size();
+        int openComplaints = (int) conversationRepository.findByType(ConversationType.COMPLAINT).stream()
+                .filter(conversation -> !conversation.isClosed())
+                .count();
+
+        LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(REVENUE_WINDOW_DAYS);
+        double revenue30d = 0.0;
+        for (OrderReceipt receipt : orderReceiptRepository.findGlobal(
+                new GlobalHistoryFiltersDTO(null, null, null, null, null))) {
+            LocalDateTime purchasedAt = receipt.getPurchaseTime();
+            if (!receipt.wasRefunded() && purchasedAt != null && !purchasedAt.isBefore(cutoff)) {
+                revenue30d += receipt.getTotalAmount();
+            }
+        }
+
+        AdminOverviewDTO dto = new AdminOverviewDTO(activeCompanies, liveEvents, openComplaints, revenue30d);
+        log.debug("Admin overview snapshot: {}", dto);
         return dto;
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/metrics/InMemorySystemMetrics.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/metrics/InMemorySystemMetrics.java
@@ -1,0 +1,86 @@
+package com.ticketing.system.Infrastructure.metrics;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * In-memory {@link ISystemMetrics} adapter (V1/V2). Each {@link MetricType}
+ * keeps a time-ordered deque of event instants (for windowed rate / throughput
+ * queries) plus a cumulative counter. Instants older than {@link #RETENTION}
+ * are pruned from the head on write so the deques stay bounded.
+ *
+ * <p>Thread-safe: the per-type deques are {@link ConcurrentLinkedDeque} and the
+ * totals are {@link AtomicLong}. Counters reset on restart — acceptable for the
+ * in-memory runtime; the port boundary keeps a durable adapter a drop-in for V3.
+ */
+@Component
+@Slf4j
+public class InMemorySystemMetrics implements ISystemMetrics {
+
+    /** The longest window any caller asks for is one hour; keep slack and prune the rest. */
+    private static final Duration RETENTION = Duration.ofHours(2);
+
+    private final Clock clock;
+    private final Map<MetricType, ConcurrentLinkedDeque<Instant>> events = new EnumMap<>(MetricType.class);
+    private final Map<MetricType, AtomicLong> totals = new EnumMap<>(MetricType.class);
+
+    public InMemorySystemMetrics(Clock clock) {
+        this.clock = clock;
+        for (MetricType type : MetricType.values()) {
+            events.put(type, new ConcurrentLinkedDeque<>());
+            totals.put(type, new AtomicLong());
+        }
+    }
+
+    @Override
+    public void record(MetricType type) {
+        Instant now = clock.instant();
+        events.get(type).addLast(now);
+        totals.get(type).incrementAndGet();
+        prune(type, now);
+    }
+
+    @Override
+    public long count(MetricType type, Duration within) {
+        Instant cutoff = clock.instant().minus(within);
+        // The deque is append-ordered by time, so walk from the newest end and
+        // stop at the first instant older than the cutoff — O(window), not O(retention).
+        long n = 0;
+        Iterator<Instant> it = events.get(type).descendingIterator();
+        while (it.hasNext()) {
+            if (it.next().isBefore(cutoff)) {
+                break;
+            }
+            n++;
+        }
+        return n;
+    }
+
+    @Override
+    public long total(MetricType type) {
+        return totals.get(type).get();
+    }
+
+    /** Drops instants older than the retention window from the head of the deque. */
+    private void prune(MetricType type, Instant now) {
+        Instant cutoff = now.minus(RETENTION);
+        ConcurrentLinkedDeque<Instant> deque = events.get(type);
+        Instant head;
+        while ((head = deque.peekFirst()) != null && head.isBefore(cutoff)) {
+            deque.pollFirst();
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
@@ -13,6 +13,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.events.OrderExpiredEvent;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
@@ -56,18 +58,21 @@ public class SessionAndOrderSweeper {
     private final IEventRepository eventRepository;
     private final Clock clock;
     private final ApplicationEventPublisher eventPublisher;
+    private final ISystemMetrics systemMetrics;
 
     public SessionAndOrderSweeper(
             ISessionRepository sessionRepository,
             IActiveOrderRepository activeOrderRepository,
             IEventRepository eventRepository,
             Clock clock,
-            ApplicationEventPublisher eventPublisher) {
+            ApplicationEventPublisher eventPublisher,
+            ISystemMetrics systemMetrics) {
         this.sessionRepository = sessionRepository;
         this.activeOrderRepository = activeOrderRepository;
         this.eventRepository = eventRepository;
         this.clock = clock;
         this.eventPublisher = eventPublisher;
+        this.systemMetrics = systemMetrics;
     }
     
     @Scheduled(fixedDelayString = "${sweeper.fixed-delay-ms:60000}")
@@ -90,6 +95,11 @@ public class SessionAndOrderSweeper {
         for (Session session : expired) {
             cleanUpAttachedCart(session);
             sessionRepository.delete(session.getSessionId());
+            // A swept-out guest session is a visitor exit (analytics, UC-46). Member
+            // sessions persist their cart by userId, so they are not counted here.
+            if (!session.isMember()) {
+                systemMetrics.record(MetricType.VISITOR_EXIT);
+            }
         }
         return expired.size();
     }

--- a/src/main/java/com/ticketing/system/Presentation/components/kit/LkTopBar.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/kit/LkTopBar.java
@@ -137,6 +137,26 @@ public class LkTopBar extends Header {
         link.getElement().appendChild(new Span(label).getElement());
     }
 
+    /**
+     * Add an icon+label action into the right slot, next to the bell / account.
+     * Unlike {@link #rightLink} this adds no flex spacer, so several actions sit
+     * together at the upper-right edge (the slot is auto-margined right by CSS).
+     */
+    public LkTopBar rightAction(String label, String iconName, Class<? extends Component> target) {
+        ensureRightSlot();
+        if (target != null) {
+            RouterLink link = new RouterLink();
+            link.setRoute(target);
+            decorateRightLink(link, label, iconName);
+            rightSlot.add(link);
+        } else {
+            Span a = new Span();
+            decorateRightLink(a, label, iconName);
+            rightSlot.add(a);
+        }
+        return this;
+    }
+
     // ---------------------------------------------------------------------
     // Right slot — bell / account / guest actions
     // ---------------------------------------------------------------------

--- a/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
@@ -11,6 +11,7 @@ import com.ticketing.system.Presentation.views.admin.AdminComplaintQueueView;
 import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
 import com.ticketing.system.Presentation.views.admin.GlobalHistoryView;
 import com.ticketing.system.Presentation.views.admin.OrganizationalTreeView;
+import com.ticketing.system.Presentation.views.admin.SystemAnalyticsView;
 import com.ticketing.system.Presentation.views.auth.LoginView;
 import com.ticketing.system.Presentation.views.landing.LandingView;
 import com.vaadin.flow.component.HasElement;
@@ -36,6 +37,7 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
 
     private static final Map<Class<?>, String> ADMIN_LABELS = Map.of(
         AdminDashboardView.class,      "Admin workspace",
+        SystemAnalyticsView.class,     "System Analytics",
         GlobalHistoryView.class,       "Global History",
         OrganizationalTreeView.class,  "Organizational Tree",
         AdminAnnouncementsView.class,  "Announcements",
@@ -64,6 +66,7 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
         topBar = new LkTopBar(LkTopBar.Variant.PLATFORM)
             .brand("Event Ticket Platform", " · Admin", LandingView.class)
             .rightLink("Back to site", "arrowLeft", LandingView.class)
+            .rightAction("Analytics", "chart", SystemAnalyticsView.class)
             .bellDefault(true)
             .account(initials(name), name, buildAdminMenu(name), "#fff", "#c2410c");
         addToNavbar(topBar);
@@ -72,6 +75,7 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
     private void buildDrawerOnce() {
         adminNav = new LkSideNav("Admin").items(List.of(
             new LkSideNav.Item("building", "Admin workspace",     AdminDashboardView.class),
+            new LkSideNav.Item("chart",    "System Analytics",    SystemAnalyticsView.class),
             new LkSideNav.Item("chart",    "Global History",      GlobalHistoryView.class),
             new LkSideNav.Item("org",      "Organizational Tree", OrganizationalTreeView.class),
             new LkSideNav.Item("comment",  "Announcements",       AdminAnnouncementsView.class),
@@ -86,7 +90,7 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
     private LkAccountMenu buildAdminMenu(String name) {
         LkMenu menu = new LkMenu(
             new LkMenu.Item("gear",      "Admin settings"),
-            new LkMenu.Item("chart",     "Platform analytics"),
+            new LkMenu.Item("chart",     "Platform analytics").onClick(() -> UI.getCurrent().navigate(SystemAnalyticsView.class)),
             new LkMenu.Divider(),
             new LkMenu.Item("arrowLeft", "Back to site").onClick(() -> UI.getCurrent().navigate(LandingView.class)),
             new LkMenu.Divider(),

--- a/src/main/java/com/ticketing/system/Presentation/presenters/admin/AdminDashboardPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/admin/AdminDashboardPresenter.java
@@ -1,0 +1,38 @@
+package com.ticketing.system.Presentation.presenters.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
+import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+
+/**
+ * MVP presenter for {@code AdminDashboardView} (#279). Vaadin-free POJO that loads the platform
+ * headline counters from {@link SystemAnalyticsService#adminOverview()} and returns a sealed
+ * outcome the view switches on. Mirrors {@code GlobalHistoryPresenter} / {@code OwnerDashboardPresenter}.
+ */
+@Component
+public class AdminDashboardPresenter {
+
+    private final SystemAnalyticsService systemAnalyticsService;
+
+    @Autowired
+    public AdminDashboardPresenter(SystemAnalyticsService systemAnalyticsService) {
+        this.systemAnalyticsService = systemAnalyticsService;
+    }
+
+    /** Loads the admin landing KPIs. */
+    public Outcome load() {
+        try {
+            return new Outcome.Success(systemAnalyticsService.adminOverview());
+        } catch (RuntimeException e) {
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+
+    /** Sealed outcome the view switches on to render the KPI row. */
+    public sealed interface Outcome {
+        record Success(AdminOverviewDTO overview) implements Outcome { }
+        record Failure(String reason) implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/admin/SystemAnalyticsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/admin/SystemAnalyticsPresenter.java
@@ -1,0 +1,97 @@
+package com.ticketing.system.Presentation.presenters.admin;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.dto.MarketStateDTO;
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+
+/**
+ * MVP presenter for {@code SystemAnalyticsView} (UC-46 / #43, #279). Vaadin-free
+ * POJO: combines the market snapshot ({@link SystemAdminService#viewMarketState()})
+ * with the live platform metrics ({@link SystemAnalyticsService#computeAnalytics()})
+ * and translates market open/close calls into a sealed outcome the view switches on.
+ *
+ * <p>Mirrors {@code OwnerDashboardPresenter}, which likewise combines two
+ * application services behind one presenter.
+ */
+@Component
+public class SystemAnalyticsPresenter {
+
+    private final SystemAdminService systemAdminService;
+    private final SystemAnalyticsService systemAnalyticsService;
+    private final int refreshIntervalMs;
+
+    @Autowired
+    public SystemAnalyticsPresenter(SystemAdminService systemAdminService,
+                                    SystemAnalyticsService systemAnalyticsService,
+                                    @Value("${analytics.refresh-interval-ms:5000}") int refreshIntervalMs) {
+        this.systemAdminService = systemAdminService;
+        this.systemAnalyticsService = systemAnalyticsService;
+        this.refreshIntervalMs = refreshIntervalMs;
+    }
+
+    /** Poll cadence (ms) the view uses to auto-refresh; {@code <= 0} disables auto-refresh. */
+    public int refreshIntervalMs() {
+        return refreshIntervalMs;
+    }
+
+    /** Loads the market snapshot + live analytics for the dashboard. */
+    public Outcome load() {
+        try {
+            MarketStateDTO market = systemAdminService.viewMarketState();
+            SystemAnalyticsDTO analytics = systemAnalyticsService.computeAnalytics();
+            return new Outcome.Success(market, analytics);
+        } catch (RuntimeException e) {
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+
+    public MarketActionOutcome openMarket(String token, String reason) {
+        return marketAction(token, "OPEN", reason);
+    }
+
+    public MarketActionOutcome closeMarket(String token, String reason) {
+        return marketAction(token, "CLOSE", reason);
+    }
+
+    private MarketActionOutcome marketAction(String token, String action, String reason) {
+        if (token == null || token.isBlank()) {
+            return new MarketActionOutcome.NotAuthenticated();
+        }
+        try {
+            MarketControlRequestDTO request = new MarketControlRequestDTO(action, reason, token);
+            MarketStateDTO state = "OPEN".equals(action)
+                    ? systemAdminService.openMarket(request)
+                    : systemAdminService.closeMarket(request);
+            return new MarketActionOutcome.Success(state);
+        } catch (UnauthorizedActionException e) {
+            return new MarketActionOutcome.NotAuthenticated();
+        } catch (MarketNotOpenException | InvalidStateTransitionException e) {
+            return new MarketActionOutcome.Rejected(e.getMessage());
+        } catch (RuntimeException e) {
+            return new MarketActionOutcome.Failure(e.getMessage());
+        }
+    }
+
+    /** Sealed outcome for the dashboard load. */
+    public sealed interface Outcome {
+        record Success(MarketStateDTO market, SystemAnalyticsDTO analytics) implements Outcome { }
+        record Failure(String reason) implements Outcome { }
+    }
+
+    /** Sealed outcome for an Open/Close Market action. */
+    public sealed interface MarketActionOutcome {
+        record Success(MarketStateDTO market) implements MarketActionOutcome { }
+        record NotAuthenticated() implements MarketActionOutcome { }
+        record Rejected(String reason) implements MarketActionOutcome { }
+        record Failure(String reason) implements MarketActionOutcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminDashboardView.java
@@ -1,11 +1,13 @@
 package com.ticketing.system.Presentation.views.admin;
 
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkStat;
 import com.ticketing.system.Presentation.components.kit.LkTile;
 import com.ticketing.system.Presentation.layouts.PlatformAdminLayout;
+import com.ticketing.system.Presentation.presenters.admin.AdminDashboardPresenter;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.vaadin.flow.component.Component;
@@ -21,7 +23,11 @@ import jakarta.annotation.security.PermitAll;
 @RequireCapability(Capability.ADMIN_WORKSPACE)
 public class AdminDashboardView extends LkPage {
 
-    public AdminDashboardView() {
+    private final AdminDashboardPresenter presenter;
+
+    public AdminDashboardView(AdminDashboardPresenter presenter) {
+        this.presenter = presenter;
+
         title("Admin workspace");
         subtitle("Cross-company moderation, broadcasts, and platform analytics.");
 
@@ -32,12 +38,27 @@ public class AdminDashboardView extends LkPage {
     private Component buildStats() {
         Div row = new Div();
         row.addClassName("ow-stats");
-        row.add(
-            new LkStat("Active companies",  "42").delta("▲ 3 this week", LkStat.Tone.up),
-            new LkStat("Live events",       "118"),
-            new LkStat("Open complaints",   "7").delta("▼ 2 vs last week", LkStat.Tone.warn),
-            new LkStat("Platform revenue · 30d", "$5.8M").delta("▲ 12%", LkStat.Tone.up)
-        );
+        switch (presenter.load()) {
+            case AdminDashboardPresenter.Outcome.Success ok -> {
+                AdminOverviewDTO o = ok.overview();
+                LkStat complaints = new LkStat("Open complaints", String.format("%,d", o.openComplaints()));
+                if (o.openComplaints() > 0) {
+                    complaints.delta("needs attention", LkStat.Tone.warn);
+                }
+                row.add(
+                    new LkStat("Active companies",        String.format("%,d", o.activeCompanies())),
+                    new LkStat("Live events",             String.format("%,d", o.liveEvents())),
+                    complaints,
+                    new LkStat("Platform revenue · 30d",  "$" + String.format("%,.0f", o.revenue30d()))
+                );
+            }
+            case AdminDashboardPresenter.Outcome.Failure ignored -> row.add(
+                new LkStat("Active companies",        "—"),
+                new LkStat("Live events",             "—"),
+                new LkStat("Open complaints",         "—"),
+                new LkStat("Platform revenue · 30d",  "—")
+            );
+        }
         return row;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/SystemAnalyticsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/SystemAnalyticsView.java
@@ -1,0 +1,185 @@
+package com.ticketing.system.Presentation.views.admin;
+
+import com.ticketing.system.Core.Application.dto.MarketStateDTO;
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
+import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.components.kit.LkBadge;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
+import com.ticketing.system.Presentation.components.kit.LkBtn;
+import com.ticketing.system.Presentation.components.kit.LkCard;
+import com.ticketing.system.Presentation.components.kit.LkIcon;
+import com.ticketing.system.Presentation.components.kit.LkPage;
+import com.ticketing.system.Presentation.components.kit.LkStat;
+import com.ticketing.system.Presentation.layouts.PlatformAdminLayout;
+import com.ticketing.system.Presentation.presenters.admin.SystemAnalyticsPresenter;
+import com.ticketing.system.Presentation.security.Capability;
+import com.ticketing.system.Presentation.security.RequireCapability;
+import com.ticketing.system.Presentation.session.AuthSession;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.DetachEvent;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.Registration;
+import jakarta.annotation.security.PermitAll;
+
+/**
+ * System Analytics dashboard (UC-46 / #43, #279). Admin-only page reached from
+ * the "Analytics" link in the platform-admin top bar. Shows the trading-market
+ * status with Open / Close controls, plus live platform performance metrics
+ * (visitor entry/exit, registrations, reservation/purchase rate and throughput).
+ *
+ * <p>View → Presenter → Service: the view renders by switching on the
+ * presenter's sealed outcomes and never calls services directly. The KPI numbers
+ * refresh on open, on the manual "Refresh" button, and on a poll tick
+ * ({@link SystemAnalyticsPresenter#refreshIntervalMs()}); the Open/Close buttons
+ * are built once so a refresh never drops a click.
+ */
+@Route(value = "admin/analytics", layout = PlatformAdminLayout.class)
+@PageTitle("System Analytics · Event Ticket Platform")
+@PermitAll
+@RequireCapability(Capability.ADMIN_WORKSPACE)
+public class SystemAnalyticsView extends LkPage {
+
+    private final SystemAnalyticsPresenter presenter;
+
+    private final LkBadge statusBadge = new LkBadge("—");
+    private final Span marketDetail = new Span();
+    private final Div statsSlot = new Div();
+
+    private Registration pollRegistration;
+
+    public SystemAnalyticsView(SystemAnalyticsPresenter presenter) {
+        this.presenter = presenter;
+
+        title("System Analytics");
+        subtitle("Real-time and historical platform performance metrics.");
+        actions(
+            new LkBtn("Refresh").variant(LkBtn.Variant.secondary).onClick(e -> refreshData()),
+            new LkBtn("Back").variant(LkBtn.Variant.tertiary)
+                .icon(new LkIcon("arrowLeft", 15))
+                .onClick(e -> UI.getCurrent().navigate(AdminDashboardView.class))
+        );
+
+        add(buildMarketCard());
+        add(statsSlot);
+
+        refreshData();
+    }
+
+    // Built once so the Open/Close buttons survive every refresh/poll (no click races).
+    private Component buildMarketCard() {
+        LkBtn openBtn = new LkBtn("Open Market").variant(LkBtn.Variant.success)
+            .onClick(e -> doMarket(true));
+        LkBtn closeBtn = new LkBtn("Close Market").variant(LkBtn.Variant.error)
+            .onClick(e -> doMarket(false));
+
+        Div controls = new Div(statusBadge, openBtn, closeBtn);
+        controls.getStyle().set("display", "flex").set("align-items", "center").set("gap", "12px");
+
+        marketDetail.getStyle().set("display", "block").set("margin-top", "10px")
+            .set("color", "var(--muted, #6b7280)").set("font-size", "13px");
+
+        LkCard card = new LkCard("Market status").pad(20);
+        card.add(controls, marketDetail);
+        return card;
+    }
+
+    private void doMarket(boolean open) {
+        String token = AuthSession.token();
+        SystemAnalyticsPresenter.MarketActionOutcome outcome = open
+            ? presenter.openMarket(token, "admin dashboard")
+            : presenter.closeMarket(token, "admin dashboard");
+
+        switch (outcome) {
+            case SystemAnalyticsPresenter.MarketActionOutcome.Success ok -> {
+                Toasts.success(open ? "Market opened." : "Market closed.");
+                applyStatus(ok.market());
+            }
+            case SystemAnalyticsPresenter.MarketActionOutcome.NotAuthenticated ignored ->
+                Toasts.failure("Your admin session has expired — sign in again to control the market.");
+            case SystemAnalyticsPresenter.MarketActionOutcome.Rejected r ->
+                Toasts.failure("Cannot " + (open ? "open" : "close") + " the market: " + r.reason());
+            case SystemAnalyticsPresenter.MarketActionOutcome.Failure f ->
+                Toasts.failure("Market action failed: " + f.reason());
+        }
+    }
+
+    /** Refreshes status + KPI numbers (open, manual Refresh, and each poll tick); buttons untouched. */
+    private void refreshData() {
+        switch (presenter.load()) {
+            case SystemAnalyticsPresenter.Outcome.Success ok -> {
+                applyStatus(ok.market());
+                statsSlot.removeAll();
+                statsSlot.add(buildStats(ok.analytics()));
+            }
+            case SystemAnalyticsPresenter.Outcome.Failure f -> {
+                statsSlot.removeAll();
+                statsSlot.add(new LkBanner(LkBanner.Tone.warn, new LkIcon("warning", 18),
+                    "Could not load analytics: " + f.reason()));
+            }
+        }
+    }
+
+    private void applyStatus(MarketStateDTO market) {
+        String status = market.currentStatus();
+        statusBadge.setText(status);
+        statusBadge.tone(toneFor(status));
+        marketDetail.setText(String.format(
+            "Payment gateway: %s · Ticket issuer: %s · Default admin: %s%s",
+            market.paymentGatewayHealthy() ? "healthy" : "down",
+            market.ticketIssuerHealthy() ? "healthy" : "down",
+            market.defaultAdminPresent() ? "present" : "missing",
+            market.lastOpenedAt() == null ? "" : " · Last opened: " + market.lastOpenedAt()));
+    }
+
+    private static LkBadge.Tone toneFor(String status) {
+        if ("OPEN".equals(status)) return LkBadge.Tone.success;
+        if ("CLOSED".equals(status)) return LkBadge.Tone.error;
+        return LkBadge.Tone.warning;
+    }
+
+    private Component buildStats(SystemAnalyticsDTO a) {
+        Div row = new Div();
+        row.addClassName("ow-stats");
+        row.add(
+            new LkStat("Active visitors", String.valueOf(a.activeVisitors())),
+            new LkStat("Visitor entry · /min", rate(a.visitorEntryRatePerMin())),
+            new LkStat("Visitor exit · /min", rate(a.visitorExitRatePerMin())),
+            new LkStat("New registrations · /min", rate(a.registrationRatePerMin())),
+            new LkStat("Reservation rate · /min", rate(a.reservationRatePerMin())),
+            new LkStat("Purchase rate · /min", rate(a.purchaseRatePerMin())),
+            new LkStat("Reservation throughput · 1h", String.valueOf(a.reservationThroughputHr())),
+            new LkStat("Purchase throughput · 1h", String.valueOf(a.purchaseThroughputHr()))
+        );
+        return row;
+    }
+
+    private static String rate(double v) {
+        return String.format("%.2f", v);
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        int ms = presenter.refreshIntervalMs();
+        if (ms > 0) {
+            UI ui = attachEvent.getUI();
+            ui.setPollInterval(ms);
+            pollRegistration = ui.addPollListener(e -> refreshData());
+        }
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        if (pollRegistration != null) {
+            pollRegistration.remove();
+            pollRegistration = null;
+        }
+        detachEvent.getUI().setPollInterval(-1);
+        super.onDetach(detachEvent);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,15 @@ constants:
   order-expiration-duration: ${ORDER_EXPIRATION_DURATION:60}
 
 
+# System Analytics dashboard (UC-46 / #43, #279).
+#  - rate-window-minutes: trailing window the per-minute rates are computed over.
+#  - refresh-interval-ms: how often the dashboard auto-refreshes its KPIs in the
+#    browser (Vaadin poll). 0 disables auto-refresh (manual "Refresh" still works).
+analytics:
+  rate-window-minutes: ${ANALYTICS_RATE_WINDOW_MINUTES:5}
+  refresh-interval-ms: ${ANALYTICS_REFRESH_INTERVAL_MS:5000}
+
+
 # Actuator (SLR.8.1 telemetry / SLR.8.2 logging visibility).
 # Restrict in production by listing only the endpoints you actually want exposed.
 management:

--- a/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
+++ b/src/test/java/com/ticketing/system/acceptance/ReservationAcceptanceTests.java
@@ -4,6 +4,7 @@ import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
@@ -68,7 +69,8 @@ public class ReservationAcceptanceTests {
                 notificationService,
                 mock(IProductionCompanyRepository.class),
                 mock(IUserRepository.class),
-                systemAdminService
+                systemAdminService,
+                mock(ISystemMetrics.class)
         );
 
         event = mock(Event.class, RETURNS_DEEP_STUBS);

--- a/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/AuthenticationServiceTest.java
@@ -32,6 +32,7 @@ import com.ticketing.system.Core.Application.dto.LogoutRequestDTO;
 import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
 import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Application.services.NotificationDispatchService;
 import com.ticketing.system.Core.Application.services.ReservationService;
@@ -82,7 +83,7 @@ class AuthenticationServiceTest {
         fixedClock = Clock.fixed(T0, ZoneOffset.UTC);
         service = new AuthenticationService(
                 mockUserRepo, mockHasher, mockSessionManager, mockReservation, mockNotification,
-                mockSessionRepo, mockActiveOrderRepo,
+                mockSessionRepo, mockActiveOrderRepo, mock(ISystemMetrics.class),
                 fixedClock, mockAdminRepo, GUEST_IDLE_MINUTES, MEMBER_TTL_MINUTES, 5, 15L);
         // Default mocks: no cart for anyone. Individual D9a tests override.
         when(mockActiveOrderRepo.getBySessionId(any())).thenReturn(Optional.empty());

--- a/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/ReservationServiceTest.java
@@ -3,6 +3,7 @@ package com.ticketing.system.unit.application;
 import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
@@ -94,7 +95,8 @@ public class ReservationServiceTest {
                 notificationService,
                 mock(IProductionCompanyRepository.class),
                 mock(IUserRepository.class),
-                systemAdminService
+                systemAdminService,
+                mock(ISystemMetrics.class)
         );
     }
 

--- a/src/test/java/com/ticketing/system/unit/application/SystemAnalyticsServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAnalyticsServiceTest.java
@@ -1,0 +1,103 @@
+package com.ticketing.system.unit.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
+import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+/**
+ * Unit tests for {@link SystemAnalyticsService} (UC-46 / #43, #279). The metrics
+ * port and order-receipt repository are stubbed so the rate / throughput math
+ * and the purchase derivation are verified in isolation.
+ */
+class SystemAnalyticsServiceTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T12:00:00Z");
+    private static final int WINDOW = 5;
+
+    private ISystemMetrics metrics;
+    private IOrderReceiptRepository orderReceiptRepository;
+    private SystemAnalyticsService service;
+
+    @BeforeEach
+    void setUp() {
+        metrics = mock(ISystemMetrics.class);
+        orderReceiptRepository = mock(IOrderReceiptRepository.class);
+        Clock clock = Clock.fixed(T0, ZoneOffset.UTC);
+        service = new SystemAnalyticsService(metrics, orderReceiptRepository, clock, WINDOW);
+    }
+
+    @Test
+    void computeAnalytics_computesRatesThroughputAndDerivesPurchasesFromReceipts() {
+        when(metrics.count(MetricType.VISITOR_ENTRY, Duration.ofMinutes(WINDOW))).thenReturn(10L);
+        when(metrics.count(MetricType.VISITOR_EXIT, Duration.ofMinutes(WINDOW))).thenReturn(5L);
+        when(metrics.count(MetricType.REGISTRATION, Duration.ofMinutes(WINDOW))).thenReturn(0L);
+        when(metrics.count(MetricType.RESERVATION, Duration.ofMinutes(WINDOW))).thenReturn(15L);
+        when(metrics.count(MetricType.RESERVATION, Duration.ofMinutes(60))).thenReturn(40L);
+
+        when(metrics.total(MetricType.VISITOR_ENTRY)).thenReturn(100L);
+        when(metrics.total(MetricType.VISITOR_EXIT)).thenReturn(30L);
+        when(metrics.total(MetricType.REGISTRATION)).thenReturn(8L);
+        when(metrics.total(MetricType.RESERVATION)).thenReturn(50L);
+
+        // Two receipts inside the 5-min window, one only inside the hour. Build the stubbed
+        // receipts first — nesting receiptAt()'s own when(...) inside thenReturn(...) would
+        // trip Mockito's UnfinishedStubbing check.
+        LocalDateTime base = LocalDateTime.ofInstant(T0, ZoneOffset.UTC);
+        OrderReceipt now = receiptAt(base);
+        OrderReceipt twoMinAgo = receiptAt(base.minusMinutes(2));
+        OrderReceipt thirtyMinAgo = receiptAt(base.minusMinutes(30));
+        when(orderReceiptRepository.findGlobal(any())).thenReturn(List.of(now, twoMinAgo, thirtyMinAgo));
+
+        SystemAnalyticsDTO dto = service.computeAnalytics();
+
+        assertEquals(70L, dto.activeVisitors());
+        assertEquals(2.0, dto.visitorEntryRatePerMin(), 1e-9);   // 10 / 5
+        assertEquals(1.0, dto.visitorExitRatePerMin(), 1e-9);    // 5 / 5
+        assertEquals(0.0, dto.registrationRatePerMin(), 1e-9);
+        assertEquals(3.0, dto.reservationRatePerMin(), 1e-9);    // 15 / 5
+        assertEquals(0.4, dto.purchaseRatePerMin(), 1e-9);       // 2 receipts / 5
+        assertEquals(40L, dto.reservationThroughputHr());
+        assertEquals(3L, dto.purchaseThroughputHr());            // all three within the hour
+        assertEquals(100L, dto.totalVisitors());
+        assertEquals(8L, dto.totalRegistrations());
+        assertEquals(50L, dto.totalReservations());
+        assertEquals(WINDOW, dto.windowMinutes());
+    }
+
+    @Test
+    void computeAnalytics_clampsActiveVisitorsAtZero_whenExitsExceedEntries() {
+        when(metrics.total(MetricType.VISITOR_ENTRY)).thenReturn(3L);
+        when(metrics.total(MetricType.VISITOR_EXIT)).thenReturn(8L);
+        when(orderReceiptRepository.findGlobal(any())).thenReturn(List.of());
+
+        SystemAnalyticsDTO dto = service.computeAnalytics();
+
+        assertEquals(0L, dto.activeVisitors());
+        assertEquals(0.0, dto.purchaseRatePerMin(), 1e-9);
+        assertEquals(0L, dto.purchaseThroughputHr());
+    }
+
+    private static OrderReceipt receiptAt(LocalDateTime purchaseTime) {
+        OrderReceipt receipt = mock(OrderReceipt.class);
+        when(receipt.getPurchaseTime()).thenReturn(purchaseTime);
+        return receipt;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/SystemAnalyticsServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAnalyticsServiceTest.java
@@ -15,10 +15,19 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
 import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
 import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
 import com.ticketing.system.Core.Application.interfaces.MetricType;
 import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.messaging.Conversation;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
 import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 
@@ -34,14 +43,21 @@ class SystemAnalyticsServiceTest {
 
     private ISystemMetrics metrics;
     private IOrderReceiptRepository orderReceiptRepository;
+    private IProductionCompanyRepository companyRepository;
+    private IEventRepository eventRepository;
+    private IConversationRepository conversationRepository;
     private SystemAnalyticsService service;
 
     @BeforeEach
     void setUp() {
         metrics = mock(ISystemMetrics.class);
         orderReceiptRepository = mock(IOrderReceiptRepository.class);
+        companyRepository = mock(IProductionCompanyRepository.class);
+        eventRepository = mock(IEventRepository.class);
+        conversationRepository = mock(IConversationRepository.class);
         Clock clock = Clock.fixed(T0, ZoneOffset.UTC);
-        service = new SystemAnalyticsService(metrics, orderReceiptRepository, clock, WINDOW);
+        service = new SystemAnalyticsService(metrics, orderReceiptRepository, companyRepository,
+                eventRepository, conversationRepository, clock, WINDOW);
     }
 
     @Test
@@ -98,6 +114,51 @@ class SystemAnalyticsServiceTest {
     private static OrderReceipt receiptAt(LocalDateTime purchaseTime) {
         OrderReceipt receipt = mock(OrderReceipt.class);
         when(receipt.getPurchaseTime()).thenReturn(purchaseTime);
+        return receipt;
+    }
+
+    @Test
+    void adminOverview_countsActiveCompaniesLiveEventsOpenComplaints_andSums30dRevenue() {
+        when(companyRepository.findActive()).thenReturn(List.of(
+                mock(ProductionCompany.class), mock(ProductionCompany.class)));               // 2 active
+        when(eventRepository.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(
+                mock(Event.class), mock(Event.class), mock(Event.class)));                    // 3 live
+
+        // Build the stubbed conversations first — nesting conversation()'s own when(...) inside
+        // thenReturn(...) would trip Mockito's UnfinishedStubbing check.
+        Conversation openA = conversation(false);
+        Conversation openB = conversation(false);
+        Conversation closed = conversation(true);
+        when(conversationRepository.findByType(ConversationType.COMPLAINT))
+                .thenReturn(List.of(openA, openB, closed));                                   // 2 open, 1 closed
+
+        LocalDateTime base = LocalDateTime.ofInstant(T0, ZoneOffset.UTC);
+        OrderReceipt inWindow = receipt(base, false, 100.0);                  // counts
+        OrderReceipt alsoInWindow = receipt(base.minusDays(10), false, 50.0); // counts
+        OrderReceipt refunded = receipt(base, true, 999.0);                   // excluded: refunded
+        OrderReceipt tooOld = receipt(base.minusDays(40), false, 999.0);      // excluded: > 30d
+        when(orderReceiptRepository.findGlobal(any()))
+                .thenReturn(List.of(inWindow, alsoInWindow, refunded, tooOld));
+
+        AdminOverviewDTO dto = service.adminOverview();
+
+        assertEquals(2, dto.activeCompanies());
+        assertEquals(3, dto.liveEvents());
+        assertEquals(2, dto.openComplaints());
+        assertEquals(150.0, dto.revenue30d(), 1e-9);
+    }
+
+    private static Conversation conversation(boolean closed) {
+        Conversation conversation = mock(Conversation.class);
+        when(conversation.isClosed()).thenReturn(closed);
+        return conversation;
+    }
+
+    private static OrderReceipt receipt(LocalDateTime purchaseTime, boolean refunded, double total) {
+        OrderReceipt receipt = mock(OrderReceipt.class);
+        when(receipt.getPurchaseTime()).thenReturn(purchaseTime);
+        when(receipt.wasRefunded()).thenReturn(refunded);
+        when(receipt.getTotalAmount()).thenReturn(total);
         return receipt;
     }
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/metrics/InMemorySystemMetricsTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/metrics/InMemorySystemMetricsTest.java
@@ -1,0 +1,92 @@
+package com.ticketing.system.unit.infrastructure.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.interfaces.MetricType;
+import com.ticketing.system.Infrastructure.metrics.InMemorySystemMetrics;
+
+/**
+ * Unit tests for the in-memory {@link InMemorySystemMetrics} adapter (UC-46).
+ * A {@link MutableClock} drives time so windowed counts are deterministic.
+ */
+class InMemorySystemMetricsTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+
+    @Test
+    void countWindow_onlyCountsEventsInsideTheWindow() {
+        MutableClock clock = new MutableClock(T0);
+        InMemorySystemMetrics metrics = new InMemorySystemMetrics(clock);
+
+        metrics.record(MetricType.VISITOR_ENTRY);
+        metrics.record(MetricType.VISITOR_ENTRY);
+
+        clock.plusSeconds(600); // +10 min
+        metrics.record(MetricType.VISITOR_ENTRY);
+
+        assertEquals(3, metrics.total(MetricType.VISITOR_ENTRY));
+        assertEquals(1, metrics.count(MetricType.VISITOR_ENTRY, Duration.ofMinutes(5)));   // only the +10min one
+        assertEquals(3, metrics.count(MetricType.VISITOR_ENTRY, Duration.ofMinutes(20)));  // all three
+    }
+
+    @Test
+    void typesAreIndependent_andUnseenTypeIsZero() {
+        MutableClock clock = new MutableClock(T0);
+        InMemorySystemMetrics metrics = new InMemorySystemMetrics(clock);
+
+        metrics.record(MetricType.RESERVATION);
+
+        assertEquals(1, metrics.total(MetricType.RESERVATION));
+        assertEquals(0, metrics.total(MetricType.REGISTRATION));
+        assertEquals(0, metrics.count(MetricType.VISITOR_EXIT, Duration.ofHours(1)));
+    }
+
+    @Test
+    void longGap_windowCountReflectsOnlyRecentEvents_totalStaysCumulative() {
+        MutableClock clock = new MutableClock(T0);
+        InMemorySystemMetrics metrics = new InMemorySystemMetrics(clock);
+
+        metrics.record(MetricType.REGISTRATION);
+        clock.plusSeconds(3 * 3600); // +3h (beyond retention) then a fresh event
+        metrics.record(MetricType.REGISTRATION);
+
+        assertEquals(1, metrics.count(MetricType.REGISTRATION, Duration.ofMinutes(5)));
+        assertEquals(2, metrics.total(MetricType.REGISTRATION));
+    }
+
+    /** Minimal advanceable Clock so windowed-count assertions are deterministic. */
+    static final class MutableClock extends Clock {
+        private Instant now;
+
+        MutableClock(Instant start) {
+            this.now = start;
+        }
+
+        void plusSeconds(long seconds) {
+            this.now = this.now.plusSeconds(seconds);
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
@@ -28,6 +28,8 @@ import com.ticketing.system.Core.Domain.events.Event;
 import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.InventorySelection;
+import com.ticketing.system.Core.Application.interfaces.ISystemMetrics;
+import com.ticketing.system.Core.Application.interfaces.MetricType;
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
 import com.ticketing.system.Core.Domain.users.Session;
 import com.ticketing.system.Infrastructure.scheduling.SessionAndOrderSweeper;
@@ -55,6 +57,7 @@ class SessionAndOrderSweeperTest {
     private IEventRepository eventRepo;
     private Clock fixedClock;
     private ApplicationEventPublisher eventPublisher;
+    private ISystemMetrics systemMetrics;
     private SessionAndOrderSweeper sweeper;
 
     @BeforeEach
@@ -64,7 +67,8 @@ class SessionAndOrderSweeperTest {
         eventRepo      = mock(IEventRepository.class);
         fixedClock     = Clock.fixed(T0, ZoneOffset.UTC);
         eventPublisher = mock(ApplicationEventPublisher.class);
-        sweeper = new SessionAndOrderSweeper(sessionRepo, orderRepo, eventRepo, fixedClock, eventPublisher);
+        systemMetrics  = mock(ISystemMetrics.class);
+        sweeper = new SessionAndOrderSweeper(sessionRepo, orderRepo, eventRepo, fixedClock, eventPublisher, systemMetrics);
 
         // Defaults: nothing expired.
         when(sessionRepo.findExpiredBefore(any())).thenReturn(List.of());
@@ -122,6 +126,8 @@ class SessionAndOrderSweeperTest {
         verify(sessionRepo).delete("orphan-sid");
         verify(orderRepo, never()).delete(any());
         verify(eventRepo, never()).save(any());
+        // A swept guest session counts as a visitor exit (analytics, UC-46).
+        verify(systemMetrics).record(MetricType.VISITOR_EXIT);
     }
 
     // ---------------------------------------------------------------------
@@ -141,6 +147,8 @@ class SessionAndOrderSweeperTest {
         verify(orderRepo, never()).getBySessionId(any());
         verify(orderRepo, never()).delete(any());
         verify(eventRepo, never()).save(any());
+        // A member session expiry is NOT a visitor exit (entry was counted at guest start).
+        verify(systemMetrics, never()).record(MetricType.VISITOR_EXIT);
     }
 
     // ---------------------------------------------------------------------

--- a/src/test/java/com/ticketing/system/unit/presentation/AdminDashboardPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/AdminDashboardPresenterTest.java
@@ -1,0 +1,48 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
+import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+import com.ticketing.system.Presentation.presenters.admin.AdminDashboardPresenter;
+
+/**
+ * Unit tests for {@link AdminDashboardPresenter} (#279). The analytics service is mocked; the
+ * tests assert the sealed-outcome mapping the admin landing view switches on.
+ */
+class AdminDashboardPresenterTest {
+
+    private SystemAnalyticsService analyticsService;
+    private AdminDashboardPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        analyticsService = mock(SystemAnalyticsService.class);
+        presenter = new AdminDashboardPresenter(analyticsService);
+    }
+
+    @Test
+    void load_returnsSuccess_withOverview() {
+        AdminOverviewDTO overview = new AdminOverviewDTO(2, 3, 1, 1500.0);
+        when(analyticsService.adminOverview()).thenReturn(overview);
+
+        AdminDashboardPresenter.Outcome outcome = presenter.load();
+
+        AdminDashboardPresenter.Outcome.Success success =
+                assertInstanceOf(AdminDashboardPresenter.Outcome.Success.class, outcome);
+        assertEquals(overview, success.overview());
+    }
+
+    @Test
+    void load_returnsFailure_whenServiceThrows() {
+        when(analyticsService.adminOverview()).thenThrow(new RuntimeException("boom"));
+
+        assertInstanceOf(AdminDashboardPresenter.Outcome.Failure.class, presenter.load());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/SystemAnalyticsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SystemAnalyticsPresenterTest.java
@@ -1,0 +1,127 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.MarketStateDTO;
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Application.services.SystemAnalyticsService;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.MarketNotOpenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
+import com.ticketing.system.Presentation.presenters.admin.SystemAnalyticsPresenter;
+
+/**
+ * Unit tests for {@link SystemAnalyticsPresenter} (UC-46 / #43, #279). Both
+ * application services are mocked; the tests assert the sealed-outcome mapping
+ * the view switches on, including the null-token and domain-exception paths.
+ */
+class SystemAnalyticsPresenterTest {
+
+    private static final String TOKEN = "admin-token";
+
+    private SystemAdminService adminService;
+    private SystemAnalyticsService analyticsService;
+    private SystemAnalyticsPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        adminService = mock(SystemAdminService.class);
+        analyticsService = mock(SystemAnalyticsService.class);
+        presenter = new SystemAnalyticsPresenter(adminService, analyticsService, 5000);
+    }
+
+    @Test
+    void load_returnsSuccess_withMarketAndAnalytics() {
+        MarketStateDTO market = marketState("OPEN");
+        SystemAnalyticsDTO analytics = zeroAnalytics();
+        when(adminService.viewMarketState()).thenReturn(market);
+        when(analyticsService.computeAnalytics()).thenReturn(analytics);
+
+        SystemAnalyticsPresenter.Outcome outcome = presenter.load();
+
+        SystemAnalyticsPresenter.Outcome.Success success =
+                assertInstanceOf(SystemAnalyticsPresenter.Outcome.Success.class, outcome);
+        assertEquals(market, success.market());
+        assertEquals(analytics, success.analytics());
+    }
+
+    @Test
+    void load_returnsFailure_whenAServiceThrows() {
+        when(adminService.viewMarketState()).thenThrow(new RuntimeException("boom"));
+
+        assertInstanceOf(SystemAnalyticsPresenter.Outcome.Failure.class, presenter.load());
+    }
+
+    @Test
+    void openMarket_withNullToken_isNotAuthenticated_andDoesNotCallService() {
+        SystemAnalyticsPresenter.MarketActionOutcome outcome = presenter.openMarket(null, "x");
+
+        assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.NotAuthenticated.class, outcome);
+        verify(adminService, never()).openMarket(any());
+    }
+
+    @Test
+    void openMarket_success_returnsUpdatedState() {
+        MarketStateDTO opened = marketState("OPEN");
+        when(adminService.openMarket(any())).thenReturn(opened);
+
+        SystemAnalyticsPresenter.MarketActionOutcome outcome = presenter.openMarket(TOKEN, "go");
+
+        SystemAnalyticsPresenter.MarketActionOutcome.Success success =
+                assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.Success.class, outcome);
+        assertEquals(opened, success.market());
+    }
+
+    @Test
+    void openMarket_unauthorized_mapsToNotAuthenticated() {
+        when(adminService.openMarket(any())).thenThrow(new UnauthorizedActionException("nope"));
+
+        assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.NotAuthenticated.class,
+                presenter.openMarket(TOKEN, "go"));
+    }
+
+    @Test
+    void openMarket_marketNotOpen_mapsToRejected() {
+        when(adminService.openMarket(any())).thenThrow(new MarketNotOpenException("platform not initialized"));
+
+        assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.Rejected.class,
+                presenter.openMarket(TOKEN, "go"));
+    }
+
+    @Test
+    void closeMarket_invalidTransition_mapsToRejected() {
+        when(adminService.closeMarket(any()))
+                .thenThrow(new InvalidStateTransitionException("market is not open; cannot close"));
+
+        assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.Rejected.class,
+                presenter.closeMarket(TOKEN, "stop"));
+    }
+
+    @Test
+    void closeMarket_unexpectedError_mapsToFailure() {
+        when(adminService.closeMarket(any())).thenThrow(new RuntimeException("db down"));
+
+        assertInstanceOf(SystemAnalyticsPresenter.MarketActionOutcome.Failure.class,
+                presenter.closeMarket(TOKEN, "stop"));
+    }
+
+    private static MarketStateDTO marketState(String status) {
+        return new MarketStateDTO(status, LocalDateTime.now(), LocalDateTime.now(), true, true, true);
+    }
+
+    private static SystemAnalyticsDTO zeroAnalytics() {
+        return new SystemAnalyticsDTO(0L, 0d, 0d, 0d, 0d, 0d, 0L, 0L, 0L, 0L, 0L, 5);
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -22,6 +22,7 @@ import com.ticketing.system.Presentation.views.admin.OrganizationalTreeView;
 import com.ticketing.system.Presentation.views.admin.SystemAnalyticsView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.ticketing.system.Presentation.views.catalog.EventDetailsView;
+import com.ticketing.system.Presentation.presenters.admin.AdminDashboardPresenter;
 import com.ticketing.system.Presentation.presenters.admin.GlobalHistoryPresenter;
 import com.ticketing.system.Presentation.presenters.admin.SystemAnalyticsPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
@@ -48,6 +49,7 @@ import com.ticketing.system.Presentation.presenters.account.MyInvitationsPresent
 import com.ticketing.system.Presentation.presenters.landing.LandingPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SubmitComplaintPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SupportInboxPresenter;
+import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
 import com.ticketing.system.Core.Application.dto.MarketStateDTO;
 import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
@@ -193,10 +195,21 @@ class VaadinSmokeTest {
 
     @Test
     void platformAdminViewsInstantiate() {
-        // Every PlatformAdminLayout view. Sign-in is now the unified LoginView
-        // (which is exercised by the buyer-side construction path).
-        assertDoesNotThrow(AdminDashboardView::new,      "AdminDashboardView failed to construct");
+        // No-arg PlatformAdminLayout views. Sign-in is now the unified LoginView
+        // (which is exercised by the buyer-side construction path). AdminDashboardView
+        // now takes a presenter, so it has its own test below.
         assertDoesNotThrow(OrganizationalTreeView::new,  "OrganizationalTreeView failed to construct");
+    }
+
+    @Test
+    void adminDashboardViewInstantiates() {
+        // Admin workspace landing wired to a presenter (#279). The constructor runs an initial
+        // load() to build the KPI row, so the mock presenter returns a success outcome.
+        AdminDashboardPresenter presenter = mock(AdminDashboardPresenter.class);
+        when(presenter.load()).thenReturn(
+            new AdminDashboardPresenter.Outcome.Success(new AdminOverviewDTO(0, 0, 0, 0.0)));
+        assertDoesNotThrow(() -> new AdminDashboardView(presenter),
+            "AdminDashboardView failed to construct");
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -19,9 +19,11 @@ import com.ticketing.system.Presentation.views.admin.AdminComplaintQueueView;
 import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
 import com.ticketing.system.Presentation.views.admin.GlobalHistoryView;
 import com.ticketing.system.Presentation.views.admin.OrganizationalTreeView;
+import com.ticketing.system.Presentation.views.admin.SystemAnalyticsView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.ticketing.system.Presentation.views.catalog.EventDetailsView;
 import com.ticketing.system.Presentation.presenters.admin.GlobalHistoryPresenter;
+import com.ticketing.system.Presentation.presenters.admin.SystemAnalyticsPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresenter;
 import com.ticketing.system.Presentation.session.SessionIdentity;
@@ -47,6 +49,8 @@ import com.ticketing.system.Presentation.presenters.landing.LandingPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SubmitComplaintPresenter;
 import com.ticketing.system.Presentation.presenters.messaging.SupportInboxPresenter;
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
+import com.ticketing.system.Core.Application.dto.MarketStateDTO;
+import com.ticketing.system.Core.Application.dto.SystemAnalyticsDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.MessageDTO;
@@ -193,6 +197,21 @@ class VaadinSmokeTest {
         // (which is exercised by the buyer-side construction path).
         assertDoesNotThrow(AdminDashboardView::new,      "AdminDashboardView failed to construct");
         assertDoesNotThrow(OrganizationalTreeView::new,  "OrganizationalTreeView failed to construct");
+    }
+
+    @Test
+    void systemAnalyticsViewInstantiates() {
+        // System Analytics dashboard wired to a presenter (UC-46 / #43, #279). The constructor
+        // runs an initial load(), so the mock presenter returns a success outcome to exercise the
+        // market-card + KPI-stat build path without a UI context.
+        SystemAnalyticsPresenter presenter = mock(SystemAnalyticsPresenter.class);
+        MarketStateDTO market = new MarketStateDTO(
+            "OPEN", LocalDateTime.now(), LocalDateTime.now(), true, true, true);
+        SystemAnalyticsDTO analytics = new SystemAnalyticsDTO(0L, 0d, 0d, 0d, 0d, 0d, 0L, 0L, 0L, 0L, 0L, 5);
+        when(presenter.load()).thenReturn(
+            new SystemAnalyticsPresenter.Outcome.Success(market, analytics));
+        assertDoesNotThrow(() -> new SystemAnalyticsView(presenter),
+            "SystemAnalyticsView failed to construct");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds the **System Analytics** capability for System Admins (UC-46) and wires the previously-hardcoded admin KPIs to real platform data, closing both **[V2] UC-46: View System Analytics Dashboard #43** and **[V2-WIRE-ADMIN-DASH] Wire AdminDashboardView KPIs to SystemAnalyticsService #279**. Builds on the already-implemented market lifecycle (UC-32 #307 / I.2.1 #59), which had no UI surface until now.

## What's included

### 1. New System Analytics page (`/admin/analytics`)
- Admin-only page reached via a new **"Analytics"** link in the platform-admin top bar (plus a drawer item and the now-wired "Platform analytics" account-menu entry).
- **Market status** badge with **Open Market / Close Market** controls, wired to `SystemAdminService.openMarket/closeMarket/viewMarketState`, including external-service health, default-admin presence, and last-opened time.
- **Live performance metrics**: active visitors, visitor entry/exit rate, new-registration rate, reservation rate, purchase rate, and reservation/purchase throughput.
- **Back** button to the admin workspace, a manual **Refresh**, and **auto-refresh** via a Vaadin poll (`analytics.refresh-interval-ms`) owned by the view (not the scheduler).

### 2. Admin workspace landing KPIs (`/admin`) now live
The four hardcoded stats are replaced with real figures:
- **Active companies** — `IProductionCompanyRepository.findActive()` (excludes closed/suspended)
- **Live events** — events in `ON_SALE`
- **Open complaints** — non-closed `COMPLAINT` conversations
- **Platform revenue · 30d** — non-refunded receipt totals over the trailing 30 days

## Design notes
- **Ports & adapters for metrics**: new outbound `ISystemMetrics` port + in-memory adapter (`InMemorySystemMetrics`); the auth/reservation slices and the session sweeper record events, while purchases are **derived from the immutable `OrderReceipt` history** (no checkout changes). A durable/Micrometer-backed adapter is a drop-in for V3.
- **MVP throughout**: views render by switching on sealed presenter `Outcome`s (`AdminDashboardPresenter`, `SystemAnalyticsPresenter`); no service calls or `try/catch` in views.
- Read aggregations live in `SystemAnalyticsService` (`computeAnalytics()` + `adminOverview()`), mirroring `CompanyAnalyticsService`'s trailing-30-day, refund-excluding window.

## Testing
- New unit tests: `InMemorySystemMetricsTest`, `SystemAnalyticsServiceTest` (rates/throughput + admin overview), `SystemAnalyticsPresenterTest`, `AdminDashboardPresenterTest`; both new views added to `VaadinSmokeTest`; the sweeper test asserts the guest-exit hook.
- `dev` merged into this branch (clean, no conflicts). Full `mvn -B clean verify` on the merged tree: **1090 tests, 0 failures, 0 errors**.

## Notes
- Metric counters are in-memory and reset on restart (purchase figures derive from receipts, so they persist).
- Market open/close requires a real admin JWT (sign in as admin via the login flow).

closes #43 
closes #279 