### PR TITLE
[V3-PREP] Pre-flight cleanups: dedup @EnableScheduling, isolate acceptance DB

### DIFF
--- a/src/main/java/com/ticketing/system/EventTicketSystemApplication.java
+++ b/src/main/java/com/ticketing/system/EventTicketSystemApplication.java
@@ -2,10 +2,8 @@ package com.ticketing.system;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling 
 public class EventTicketSystemApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/SeedReport.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/SeedReport.java
@@ -49,6 +49,7 @@ public final class SeedReport {
 
         StringBuilder sb = new StringBuilder();
         sb.append("\n========== SEED SMOKE REPORT ==========\n");
+        sb.append(String.format("%-15s %5s %5s %5s %8s%n", "stage", "PASS", "SKIP", "FAIL", "BLOCKED"));
         for (var en : byStage.entrySet()) {
             int[] t = en.getValue();
             sb.append(String.format("%-15s %5d %5d %5d %8d%n", en.getKey(), t[0], t[1], t[2], t[3]));

--- a/src/test/resources/application-acceptance.yml
+++ b/src/test/resources/application-acceptance.yml
@@ -1,13 +1,18 @@
+# Acceptance-test profile — isolated in-memory H2 so the suite never touches a
+# shared or real database (lecture 4.c: tests must not pollute the DB the system
+# uses). A fresh schema is created and dropped per run, so nothing persists.
+# Switch to a throwaway/ephemeral instance (e.g. Testcontainers) if a real
+# Postgres dialect is ever needed — never point this at a shared DB.
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ticketing_test}
-    username: ${DB_USER:postgres}
-    password: ${DB_PASSWORD:postgres}
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:acceptancedb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
 
   jpa:
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
Pre-flight cleanups for the V3 migration — part of the V3 epic #347.

## Changes
- **Dedup `@EnableScheduling`** — dropped the unconditional copy from `EventTicketSystemApplication`; `SchedulingConfig` (`@Profile("!test")`) is now the single source, so the sweeper is scheduled in non-test only. Previously the app-class annotation enabled scheduling even under the `test` profile, defeating `SchedulingConfig`'s gate.
- **Isolate the acceptance profile** — `application-acceptance.yml` moved off the shared `ticketing_test` Postgres (which used `ddl-auto: create-drop`) onto in-memory H2, so the suite can never drop or pollute a real database (lecture 4.c). No test currently activates the profile; this removes the foot-gun if one ever does.
- **Restore the SEED SMOKE REPORT headers** — a Copilot auto-fix on the scenario-engine PR (#381) had deleted the `stage / PASS / SKIP / FAIL / BLOCKED` column-header row from `SeedReport.render()`, leaving the dev boot report as bare unlabeled numbers. Restored it.

## Verification
- **Scheduling:** `SchedulingConfig` is the sole `@Profile("!test")` `@EnableScheduling` source; sweeper unaffected in dev/prod, off in tests (as intended).
- **#304** (notification blocking every reservation): verified via an **actual dev boot** — the scenario engine ran **40/40 PASS**, and the failure-notification path (`notifyTicketReservationFailure` → `NotificationDispatchService`) dispatched cleanly with **no `UnsupportedOperationException`**. #304 was already closed (fixed in `096a163`); this confirms it in a running dev instance.
- `./mvnw -Pno-vaadin test` → **1104 passing, 0 failures, 0 errors**.

Closes #348.
