### PR TITLE
[V3-ORM-00] JPA bring-up + Admin vertical slice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,11 +122,13 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- H2 for integration tests -->
+		<!-- H2: dev runs the `jpa` profile on in-memory H2, and the @DataJpaTest
+		     repository contract tests use it too. runtime (not test) scope so the
+		     dev app can load org.h2.Driver; the deploy still uses Postgres. -->
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>test</scope>
+			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/ticketing/system/Core/Domain/Admin/Admin.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/Admin/Admin.java
@@ -2,15 +2,43 @@ package com.ticketing.system.Core.Domain.Admin;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 // Aggregate root for the Admin aggregate (System Admin, not company-side roles).
 // UC-1 (I.1.4) requires the system to verify at least one Admin exists at startup,
 // auto-creating a default if none.
+//
+// V3: this is the first domain aggregate mapped to JPA. The id is ASSIGNED, never
+// @GeneratedValue (the constructor rejects id <= 0); @Version drives optimistic
+// locking and lets Spring Data tell a new entity (version == null) from a loaded
+// one. Fields are non-final and a protected no-arg constructor exists purely so
+// Hibernate can hydrate instances — the public constructor still enforces the
+// invariants for application-created admins.
+@Entity
+@Table(name = "admins")
 public class Admin implements InvariantChecked {
 
-    private final int id;
-    private final String username;
-    private final String passwordHash;
-    private final boolean isDefault;
+    @Id
+    private int id;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String passwordHash;
+
+    @Column(name = "is_default", nullable = false)
+    private boolean isDefault;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Admin() { }
 
     public Admin(int id, String username, String passwordHash, boolean isDefault) {
         this.id = id;

--- a/src/main/java/com/ticketing/system/Core/Domain/shared/IRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/shared/IRepository.java
@@ -40,10 +40,13 @@ package com.ticketing.system.Core.Domain.shared;
  *   <li><b>In-memory implementations</b> (current) use a per-id
  *       {@link java.util.concurrent.locks.ReentrantLock} via
  *       {@code RepositoryLocks}. Reentrant: same thread re-locking is safe.</li>
- *   <li><b>JPA-backed implementations</b> (future V2) will translate
- *       {@code lockForUpdate} to {@code SELECT ... FOR UPDATE} within the
- *       surrounding {@code @Transactional}; {@code unlock} becomes a no-op
- *       (the transaction boundary releases the row lock on commit/rollback).</li>
+ *   <li><b>JPA-backed implementations</b> (V3) make {@code lockForUpdate} and
+ *       {@code unlock} <b>no-ops</b>. Concurrency is handled by {@code @Version}
+ *       OPTIMISTIC locking on the aggregate — at the granularity of the real
+ *       contention (e.g. per-{@code Seat} for Event, so independent reservations
+ *       don't conflict) — and the service use-case retries on
+ *       {@code OptimisticLockException} (a fresh transaction re-reads the current
+ *       version). No pessimistic {@code SELECT ... FOR UPDATE} is used.</li>
  * </ul>
  *
  * <p><b>Always pair lockForUpdate with unlock in a try/finally.</b>

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
@@ -12,6 +12,7 @@ import com.ticketing.system.Infrastructure.persistence.MemoryTicketRepository;
 import com.ticketing.system.Infrastructure.persistence.MemoryUserRepository;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -20,8 +21,10 @@ import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 /**
  * Wipes every in-memory repository back to an empty state. Used by
@@ -31,10 +34,16 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>Uses reflection rather than adding {@code clear()} methods to each
  * memory repo because (a) {@code clear()} would have no place on the
  * domain {@code IRepository} interface and (b) the same reflection
- * works the day a new memory repo is added — just add it to the
- * constructor list. Resets non-final instance Maps, Collections, and
- * AtomicInteger / AtomicLong counters; leaves locks and final
- * configuration alone.
+ * works the day a new memory repo is added. Resets non-final instance
+ * Maps, Collections, and AtomicInteger / AtomicLong counters; leaves
+ * locks and final configuration alone.
+ *
+ * <p>Each {@code Memory*Repository} is injected via {@link ObjectProvider}, so it is
+ * OPTIONAL: as an aggregate migrates to JPA (the {@code jpa} profile) its
+ * {@code Memory*Repository} bean is {@code @Profile("!jpa")} and disappears — it then
+ * simply drops out of the wipe (its data lives in the database; clearing that is the
+ * {@code seed.mode} reset-safety work, #366). So this cleaner keeps working through the
+ * whole Memory→JPA migration without edits.
  *
  * <p>{@code @Profile("dev")} only — never instantiated in production.
  */
@@ -46,20 +55,24 @@ public class MemoryRepoCleaner {
     private final List<Object> repositories;
 
     public MemoryRepoCleaner(
-            MemoryUserRepository userRepo,
-            MemorySessionRepository sessionRepo,
-            MemoryActiveOrderRepository activeOrderRepo,
-            MemoryEventRepository eventRepo,
-            MemoryTicketRepository ticketRepo,
-            MemoryOrderReceiptRepository orderReceiptRepo,
-            MemoryNotificationRepository notificationRepo,
-            MemoryConversationRepository conversationRepo,
-            MemoryProductionCompanyRepository companyRepo,
-            MemoryAdminRepository adminRepo) {
-        this.repositories = List.of(
-            userRepo, sessionRepo, activeOrderRepo, eventRepo, ticketRepo,
-            orderReceiptRepo, notificationRepo, conversationRepo, companyRepo, adminRepo
-        );
+            ObjectProvider<MemoryUserRepository> userRepo,
+            ObjectProvider<MemorySessionRepository> sessionRepo,
+            ObjectProvider<MemoryActiveOrderRepository> activeOrderRepo,
+            ObjectProvider<MemoryEventRepository> eventRepo,
+            ObjectProvider<MemoryTicketRepository> ticketRepo,
+            ObjectProvider<MemoryOrderReceiptRepository> orderReceiptRepo,
+            ObjectProvider<MemoryNotificationRepository> notificationRepo,
+            ObjectProvider<MemoryConversationRepository> conversationRepo,
+            ObjectProvider<MemoryProductionCompanyRepository> companyRepo,
+            ObjectProvider<MemoryAdminRepository> adminRepo) {
+        // getIfAvailable() is null for any aggregate already migrated to JPA
+        // (its Memory* bean is @Profile("!jpa"), absent in the jpa profile) — it's skipped.
+        this.repositories = Stream.of(
+                userRepo, sessionRepo, activeOrderRepo, eventRepo, ticketRepo,
+                orderReceiptRepo, notificationRepo, conversationRepo, companyRepo, adminRepo)
+            .<Object>map(ObjectProvider::getIfAvailable)
+            .filter(Objects::nonNull)
+            .toList();
     }
 
     public void clearAll() {

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaAdminRepository.java
@@ -1,0 +1,64 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import com.ticketing.system.Core.Domain.Admin.Admin;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+
+/**
+ * JPA-backed {@link IAdminRepository} — active only in the {@code jpa} run/dev
+ * profile. Adapts the domain port onto Spring Data ({@link SpringDataAdminRepository});
+ * the application layer depends only on {@code IAdminRepository}, never on Spring Data.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops: concurrent writes are guarded by
+ * {@code Admin}'s {@code @Version} optimistic lock within the surrounding transaction
+ * (per the {@code IRepository} contract — JPA replaces the in-memory write-lock with
+ * version checks). Admin is written once at platform init, so contention is nil.
+ */
+@Repository
+@Profile("jpa")
+public class JpaAdminRepository implements IAdminRepository {
+
+    private final SpringDataAdminRepository data;
+
+    public JpaAdminRepository(SpringDataAdminRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(Integer id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(Integer id) { /* no-op */ }
+
+    @Override
+    public void save(Admin admin) {
+        data.save(admin);
+    }
+
+    @Override
+    public Admin findById(int adminId) {
+        return data.findById(adminId).orElse(null);
+    }
+
+    @Override
+    public Admin findByUsername(String username) {
+        if (username == null) {
+            return null;
+        }
+        return data.findByUsername(username).orElse(null);
+    }
+
+    @Override
+    public boolean existsAny() {
+        return data.count() > 0;
+    }
+
+    @Override
+    public List<Admin> findAll() {
+        return data.findAll();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryAdminRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.Admin.Admin;
@@ -17,6 +18,7 @@ import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
  * replaces this class without touching the application layer.
  */
 @Repository
+@Profile("!jpa")
 public class MemoryAdminRepository implements IAdminRepository {
 
     private final Map<Integer, Admin> adminsById = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataAdminRepository.java
@@ -1,0 +1,19 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ticketing.system.Core.Domain.Admin.Admin;
+
+/**
+ * Spring Data JPA repository for the {@link Admin} aggregate. Auto-implemented by
+ * Spring Data and used only by {@link JpaAdminRepository} (the adapter that
+ * fulfils the domain {@code IAdminRepository} port). Only scanned when JPA is
+ * active (an EntityManagerFactory exists), i.e. the {@code jpa} run profile and
+ * the JPA contract test; never in the dev profile (JPA autoconfig excluded).
+ */
+public interface SpringDataAdminRepository extends JpaRepository<Admin, Integer> {
+
+    Optional<Admin> findByUsername(String username);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,21 +1,24 @@
-# V2 dev profile (V2-F-01).
+# V3 dev profile.
 #
-# The codebase uses Memory*Repository classes for persistence — no real DB is
-# needed at runtime. But the default `application.yml` is V3-prep wired for
-# Postgres + JPA, which makes Spring Boot fail on startup if there's no DB.
+# dev now runs on the real JPA persistence path against in-memory H2 (no Postgres
+# or Docker needed locally). The `jpa` profile is auto-activated for dev via
+# spring.profiles.group in application.yml, so the Jpa* repositories are wired:
+# mapped aggregates (Admin, …) persist to H2, while aggregates not yet migrated
+# stay on their in-memory Memory* repos until their own Lane-B slice.
 #
-# This profile EXCLUDES DataSource + JPA auto-config so the app boots cleanly
-# with Vaadin + Memory* repos and no Postgres / Docker. Activate it with:
+# Deploy/run uses the SAME `jpa` profile against Postgres (Supabase) by setting the
+# DB_* env vars — a config-only switch, no code change.
 #
 #   ./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
-#
-# V3 will delete this profile and bring back the JPA stack via the ORM lane.
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
+  datasource:
+    url: jdbc:h2:mem:devdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
 
 # Scenario init (ScenarioRunner) — boots the system from an editable command file.
 #   scenario:  the file to run (classpath:scenarios/*.scenario, or file:/abs/path/to/your.scenario)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,15 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: false
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect
+    # No explicit dialect: Hibernate auto-detects it per connection (PostgreSQL on the
+    # deploy/run target, H2 in dev and the @DataJpaTest contract tests), so one config
+    # serves every backend — a config-only switch to the cloud DB.
+
+  # Activating the `dev` profile also activates `jpa`, so dev develops on the real
+  # persistence path (JPA + H2 — see application-dev.yml). Deploy/run = `jpa` + Postgres.
+  profiles:
+    group:
+      dev: jpa
 
 # JWT signing secret (consumed by Infrastructure/security/JwtSessionManager — UC-12).
 # In production the secret MUST be supplied via environment variable, never committed.

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/IAdminRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/IAdminRepositoryContractTest.java
@@ -1,0 +1,86 @@
+package com.ticketing.system.unit.infrastructure.persistence.AdminPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.Admin.Admin;
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+
+/**
+ * Behavioural contract every {@link IAdminRepository} implementation must satisfy.
+ * The Memory and JPA adapters each subclass this with their own {@code newRepository()}
+ * factory, so the identical tests run against both — the V3 "validate the swap behind
+ * the unchanged port" safety net.
+ */
+abstract class IAdminRepositoryContractTest {
+
+    protected abstract IAdminRepository newRepository();
+
+    private IAdminRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    @Test
+    void save_thenFindById_returnsTheSavedAdmin() {
+        repo.save(new Admin(1, "admin", "HASH", true));
+
+        Admin found = repo.findById(1);
+        assertEquals("admin", found.getUsername());
+        assertTrue(found.isDefault());
+    }
+
+    @Test
+    void save_thenFindByUsername_returnsTheSavedAdmin() {
+        repo.save(new Admin(7, "root", "HASH", false));
+
+        Admin found = repo.findByUsername("root");
+        assertEquals(7, found.getId());
+    }
+
+    @Test
+    void findById_returnsNullWhenMissing() {
+        assertNull(repo.findById(9999));
+    }
+
+    @Test
+    void findByUsername_returnsNullWhenMissing() {
+        assertNull(repo.findByUsername("ghost"));
+    }
+
+    @Test
+    void findByUsername_nullArgument_returnsNull() {
+        assertNull(repo.findByUsername(null));
+    }
+
+    @Test
+    void existsAny_falseWhenEmpty_trueAfterSave() {
+        assertFalse(repo.existsAny());
+        repo.save(new Admin(1, "admin", "HASH", true));
+        assertTrue(repo.existsAny());
+    }
+
+    @Test
+    void findAll_returnsEverySavedAdmin() {
+        assertTrue(repo.findAll().isEmpty());
+        repo.save(new Admin(1, "admin", "HASH", true));
+        repo.save(new Admin(2, "second", "HASH2", false));
+        assertEquals(2, repo.findAll().size());
+    }
+
+    @Test
+    void lockForUpdateThenUnlock_isCallableWithoutThrowing() {
+        // Admin is never contended (created once at synchronized platform init); the lock
+        // primitives must simply be callable. The JPA adapter makes them no-ops (optimistic
+        // @Version handles any future contention).
+        repo.lockForUpdate(1);
+        repo.unlock(1);
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/JpaAdminRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/JpaAdminRepositoryTest.java
@@ -1,0 +1,42 @@
+package com.ticketing.system.unit.infrastructure.persistence.AdminPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.JpaAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.SpringDataAdminRepository;
+
+/**
+ * Runs the {@link IAdminRepositoryContractTest} suite against the JPA adapter on an
+ * embedded H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaAdminRepository};
+ * {@code @DataJpaTest} provides H2 + a real {@code admins} table.
+ *
+ * <p>Each contract test starts from an empty table ({@link #cleanTable()}) so the suite is
+ * order-independent — the Memory subclass gets a fresh repo per test, and this gives the
+ * JPA adapter the same clean slate. CI never touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaAdminRepository.class)
+class JpaAdminRepositoryTest extends IAdminRepositoryContractTest {
+
+    @Autowired
+    private JpaAdminRepository repository;
+
+    @Autowired
+    private SpringDataAdminRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IAdminRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/MemoryAdminRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/MemoryAdminRepositoryTest.java
@@ -1,0 +1,13 @@
+package com.ticketing.system.unit.infrastructure.persistence.AdminPersistence;
+
+import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.MemoryAdminRepository;
+
+/** Runs the {@link IAdminRepositoryContractTest} suite against the in-memory adapter. */
+class MemoryAdminRepositoryTest extends IAdminRepositoryContractTest {
+
+    @Override
+    protected IAdminRepository newRepository() {
+        return new MemoryAdminRepository();
+    }
+}


### PR DESCRIPTION
JPA bring-up + the first aggregate (`Admin`) mapped end-to-end — establishes the pattern every Lane-B aggregate (B1–B9) copies. Part of the V3 epic #347.

## What
- **`Admin` → `@Entity`** — assigned `@Id` (no `@GeneratedValue`; the ctor rejects `id<=0`), `@Version Long` (optimistic locking + new-vs-loaded detection), protected no-arg ctor, de-`final`ed fields, validating public ctor kept.
- **Spring Data adapter** — `SpringDataAdminRepository extends JpaRepository` + `JpaAdminRepository implements IAdminRepository` (`@Profile("jpa")`); `MemoryAdminRepository` gated `@Profile("!jpa")`. The application layer depends only on the domain port.
- **Contract test** — `IAdminRepositoryContractTest` (abstract) runs against **both** the Memory adapter and the JPA adapter on H2 (`@DataJpaTest`) — green on both. The reusable swap-validation net.
- **`jpa` profile** — `run` + `dev` on JPA: dev auto-activates `jpa` via `spring.profiles.group` on in-memory H2 (no Postgres/Docker), and deploy uses the same profile against Postgres via `DB_*` env (config-only switch). H2 → `runtime` scope; Hibernate dialect auto-detected per connection.
- **Forward-compat** — `MemoryRepoCleaner` injects each Memory repo via `ObjectProvider`, so it tolerates aggregates already migrated to JPA — keeps dev booting through all of Lane B without edits.

## Decisions (made with the team)
- **Optimistic locking everywhere** — no pessimistic `@Lock` (even Event, via fine-grained `@Version` on Seat/StandingZone); `lockForUpdate/unlock` are no-ops; service-level `@Retryable(OptimisticLockException)` lands at C1. `IRepository` doc updated to match.
- **int ids stay** (no UUID — User/Admin overlap is safe, disjoint pools by JWT ROLE claim); **Admin keeps its fixed id** (id=1, never mints — no `nextId()`).
- **Tests stay Memory-fast**; the JPA path is proven by the `@DataJpaTest` contract test.

## Verification
- `./mvnw -Pno-vaadin test` → **1114 passing, 0 failures, 0 errors**. Both contract subclasses (Memory + JPA-on-H2) green.
- **Dev boot (= `jpa` + H2):** creates a live `admins` table, persists the default admin through `JpaAdminRepository` (`insert into admins`), app starts in ~6s, scenario engine runs (other nine aggregates still on Memory).

Closes #349.
