### PR TITLE
[V3-ORM-01] Map Session to JPA

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/users/Session.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/Session.java
@@ -4,6 +4,12 @@ import java.time.Instant;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 /**
  * Session aggregate — the unified identity record for both Member and Guest
  * sessions. Part of the auth rework (see docs/auth-rework-plan.md).
@@ -20,14 +26,40 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
  * <p>A Guest session can be promoted to a Member session in-place via
  * {@link #promoteTo(int, Instant)} — the sessionId is preserved, so any cart
  * or other state already attached to it survives the transition.
+ *
+ * <p>V3: mapped to JPA. The {@code sessionId} {@code @Id} is ASSIGNED by the
+ * application (the JWT {@code sid} for members, a generated id for guests), never
+ * {@code @GeneratedValue}. {@code userId} is a plain by-id column — never a
+ * {@code @ManyToOne} to User (the cross-aggregate reference rule). {@code @Version}
+ * drives optimistic locking and lets Spring Data tell a new entity (version == null)
+ * from a loaded one. Fields are non-final and a protected no-arg constructor exists
+ * purely so Hibernate can hydrate instances — the public constructor still enforces
+ * the invariants for application-created sessions.
  */
+@Entity
+@Table(name = "sessions")
 public class Session implements InvariantChecked {
 
-    private final String sessionId;
+    @Id
+    private String sessionId;
+
+    @Column(name = "user_id")
     private Integer userId;
-    private final Instant createdAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_seen_at", nullable = false)
     private Instant lastSeenAt;
+
+    @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Session() { }
 
     public Session(String sessionId, Integer userId, Instant createdAt, Instant expiresAt) {
         this.sessionId = sessionId;
@@ -57,6 +89,15 @@ public class Session implements InvariantChecked {
 
     public Instant getExpiresAt() {
         return expiresAt;
+    }
+
+    /**
+     * The JPA optimistic-lock version: {@code null} for a freshly constructed session
+     * (never persisted), non-null once loaded from the database. Lets the persistence
+     * adapter tell a new instance from a loaded one.
+     */
+    public Long getVersion() {
+        return version;
     }
 
     public boolean isMember() {
@@ -108,6 +149,23 @@ public class Session implements InvariantChecked {
             throw new IllegalArgumentException("newExpiresAt must not be null");
         }
         this.expiresAt = newExpiresAt;
+        checkInvariants();
+    }
+
+    /**
+     * Persistence support: copies the updatable state ({@code userId},
+     * {@code lastSeenAt}, {@code expiresAt}) from {@code source} onto this session,
+     * preserving identity ({@code sessionId}, {@code createdAt}) and the JPA
+     * {@code @Version}. Used by the JPA adapter to reproduce the in-memory
+     * repository's overwrite-on-save semantics when a brand-new instance reuses an
+     * already-persisted id — a case the normal merge/persist path can't express for
+     * an assigned id. Not part of the normal domain mutation flow (use
+     * {@link #promoteTo}, {@link #touch}, {@link #extendExpiry}).
+     */
+    public void overwriteFrom(Session source) {
+        this.userId = source.userId;
+        this.lastSeenAt = source.lastSeenAt;
+        this.expiresAt = source.expiresAt;
         checkInvariants();
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaSessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaSessionRepository.java
@@ -1,0 +1,110 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.users.ISessionRepository;
+import com.ticketing.system.Core.Domain.users.Session;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+/**
+ * JPA-backed {@link ISessionRepository} — active only in the {@code jpa} run/dev profile.
+ * Adapts the domain port onto Spring Data ({@link SpringDataSessionRepository}); the
+ * application layer depends only on {@code ISessionRepository}, never on Spring Data.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops: concurrent writes are guarded by
+ * {@code Session}'s {@code @Version} optimistic lock within the surrounding transaction
+ * (per the {@code IRepository} contract — JPA replaces the in-memory write-lock with
+ * version checks).
+ *
+ * <p>{@link #save} is an upsert that preserves optimistic locking on the real flows:
+ * {@code data.save} inserts a fresh session (new {@code sid}, version {@code null}) and
+ * updates a loaded-then-mutated one under its {@code @Version} check (login / start-guest
+ * insert; promote / extend / touch update). The only case {@code data.save} can't express
+ * is a brand-new instance reusing an already-persisted id — with an assigned id + version
+ * {@code null}, merge/persist treats it as transient and tries to INSERT (duplicate key).
+ * That never happens in the application (sids are unique), only in the in-memory
+ * overwrite contract; it's handled by copying the state onto the managed row via
+ * {@link Session#overwriteFrom}. Each write carries its own {@code @Transactional} so the
+ * adapter is self-sufficient before the service layer gains transactions (#359); the read
+ * delegations inherit Spring Data's read-only tx.
+ *
+ * <p>{@code existsByUserId}'s "now" comes from the injected {@link Clock} (parity with
+ * {@code MemorySessionRepository}), and the non-expired filter runs in SQL.
+ */
+@Repository
+@Profile("jpa")
+public class JpaSessionRepository implements ISessionRepository {
+
+    private final SpringDataSessionRepository data;
+    private final Clock clock;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public JpaSessionRepository(SpringDataSessionRepository data, Clock clock) {
+        this.data = data;
+        this.clock = clock;
+    }
+
+    @Override
+    public void lockForUpdate(String id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(String id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public void save(Session session) {
+        if (session.getVersion() == null && data.existsById(session.getSessionId())) {
+            // Brand-new instance reusing an already-persisted id (the in-memory
+            // overwrite contract — never the running app). persist/merge would try to
+            // INSERT for a null version, so copy the state onto the managed row instead.
+            Session managed = entityManager.find(Session.class, session.getSessionId());
+            managed.overwriteFrom(session);
+        } else {
+            // Insert (version null, id absent) or update a loaded session under its
+            // @Version optimistic check (version set).
+            data.save(session);
+        }
+    }
+
+    @Override
+    public Optional<Session> findById(String sessionId) {
+        if (sessionId == null) {
+            return Optional.empty();
+        }
+        return data.findById(sessionId);
+    }
+
+    @Override
+    public boolean existsByUserId(int userId) {
+        return data.existsByUserIdAndExpiresAtAfter(userId, clock.instant());
+    }
+
+    @Override
+    @Transactional
+    public void delete(String sessionId) {
+        if (sessionId == null) {
+            return;
+        }
+        // Idempotent: deleteById would throw EmptyResultDataAccessException for an
+        // unknown id, but the contract requires a silent no-op (delete_unknownIsIdempotent).
+        if (data.existsById(sessionId)) {
+            data.deleteById(sessionId);
+        }
+    }
+
+    @Override
+    public List<Session> findExpiredBefore(Instant cutoff) {
+        return data.findByExpiresAtLessThanEqual(cutoff);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemorySessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemorySessionRepository.java
@@ -8,22 +8,24 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
 import com.ticketing.system.Core.Domain.users.Session;
 
 /**
- * In-memory {@link ISessionRepository} for V1.
+ * In-memory {@link ISessionRepository}.
  *
  * <p>Storage is a thread-safe {@code ConcurrentHashMap} keyed by sessionId.
- * Mirrors {@code MemoryUserRepository}'s shape. A future JPA-backed adapter
- * will replace this class without touching the application layer.
+ * Mirrors {@code MemoryUserRepository}'s shape. {@code @Profile("!jpa")}: the
+ * {@code jpa} run/dev profile swaps in {@link JpaSessionRepository} instead.
  *
  * <p>{@link Clock} is injected so tests can supply a fixed clock for
  * deterministic expiry behavior.
  */
 @Repository
+@Profile("!jpa")
 public class MemorySessionRepository implements ISessionRepository {
 
     private final Map<String, Session> sessionsById = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataSessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataSessionRepository.java
@@ -1,0 +1,30 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ticketing.system.Core.Domain.users.Session;
+
+/**
+ * Spring Data JPA repository for {@link Session} — the auto-implemented SQL backing
+ * {@link JpaSessionRepository}. The application layer never sees this type; it depends
+ * only on the {@code ISessionRepository} domain port.
+ *
+ * <p>Two derived queries push the Session-specific predicates into SQL:
+ * <ul>
+ *   <li>{@code existsByUserIdAndExpiresAtAfter} — at least one non-expired member
+ *       session for a user ({@code expiresAt > now}, mirroring the exclusive
+ *       {@code !Session.isExpiredAt(now)} boundary). Guest rows ({@code userId == null})
+ *       never match a non-null user id, so they are excluded as required.</li>
+ *   <li>{@code findByExpiresAtLessThanEqual} — the UC-2 sweep ({@code expiresAt <= cutoff},
+ *       mirroring the inclusive {@code Session.isExpiredAt} boundary).</li>
+ * </ul>
+ */
+public interface SpringDataSessionRepository extends JpaRepository<Session, String> {
+
+    boolean existsByUserIdAndExpiresAtAfter(Integer userId, Instant now);
+
+    List<Session> findByExpiresAtLessThanEqual(Instant cutoff);
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/JpaSessionRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/JpaSessionRepositoryContractTest.java
@@ -1,0 +1,56 @@
+package com.ticketing.system.unit.infrastructure.persistence.SessionPersistence;
+
+import java.time.Clock;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.users.ISessionRepository;
+import com.ticketing.system.Infrastructure.persistence.JpaSessionRepository;
+import com.ticketing.system.Infrastructure.persistence.SpringDataSessionRepository;
+
+/**
+ * Runs the {@link ISessionRepositoryContractTest} suite against the JPA adapter on an
+ * embedded H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaSessionRepository};
+ * {@code @DataJpaTest} provides H2 + a real {@code sessions} table.
+ *
+ * <p>The repository is Spring-built (via {@code @Import}) so its {@code @PersistenceContext}
+ * EntityManager — needed by {@code save}'s {@code merge} — is injected; the {@code @DataJpaTest}
+ * slice doesn't load {@code SecurityConfig}, so {@link TestClockConfig} supplies the {@code Clock}
+ * (system-UTC, matching the Memory contract test). Each test starts from an empty table
+ * ({@link #cleanTable()}) so the suite is order-independent. CI never touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import({JpaSessionRepository.class, JpaSessionRepositoryContractTest.TestClockConfig.class})
+class JpaSessionRepositoryContractTest extends ISessionRepositoryContractTest {
+
+    @Autowired
+    private JpaSessionRepository repository;
+
+    @Autowired
+    private SpringDataSessionRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected ISessionRepository newRepository() {
+        return repository;
+    }
+
+    @TestConfiguration
+    static class TestClockConfig {
+        @Bean
+        Clock clock() {
+            return Clock.systemUTC();
+        }
+    }
+}


### PR DESCRIPTION
Maps the **Session** aggregate to JPA behind the `ISessionRepository` port — the second Lane-B vertical slice (copies the Admin recipe from #349). Part of the V3 epic #347, depends on #349 (merged).

## What
- **`Session` → `@Entity`** (`@Table("sessions")`): assigned `String @Id` (the JWT `sid` for members, a generated id for guests — never `@GeneratedValue`); `userId` as a **plain nullable `Integer` column, never `@ManyToOne`** (cross-aggregate rule); three `Instant` columns; `@Version Long` for optimistic locking. Fields de-`final`ed + protected no-arg ctor for Hibernate; the public ctor still enforces the invariants.
- **`SpringDataSessionRepository`** — derived `findByExpiresAtLessThanEqual` (the UC-2 sweep, `expiresAt <= cutoff`, exact match to the inclusive `isExpiredAt` boundary) and `existsByUserIdAndExpiresAtAfter` (non-expired member presence, runs the filter in SQL).
- **`JpaSessionRepository`** (`@Profile("jpa")`) adapts the port; `MemorySessionRepository` gated `@Profile("!jpa")`. `lockForUpdate`/`unlock` are no-ops (optimistic `@Version` replaces the in-memory write-lock).

## Two design points worth noting
- **`save` is a version-preserving upsert.** `data.save` inserts a fresh session and updates a loaded one **under its `@Version` optimistic check** — the two real flows (login / start-guest insert; promote / extend / touch update). The one case `merge`/`persist` can't express — a brand-new instance reusing an already-persisted id (assigned id + null version ⇒ it tries to INSERT) — never happens in the app (sids are unique); it's handled by copying state onto the managed row via `Session.overwriteFrom`, satisfying the in-memory overwrite contract without weakening optimistic locking.
- **`existsByUserId`'s "now"** comes from the injected `Clock` (parity with the Memory impl); no port change.

## Verification
- `./mvnw -Pno-vaadin test` → **1128 passing, 0 failures** (+14 new JPA Session contract tests). The existing `ISessionRepositoryContractTest` runs green against **both** Memory and JPA-on-H2.
- **Dev boot (= `dev` + `jpa`):** `JpaSessionRepository` is the live bean, the seed scenario passes **40/40**, and live guest/member session creation persists through JPA (Session is on JPA; the other eight aggregates still on Memory).

Closes #350.
