### PR TITLE
[V3-ORM-02] Map Ticket to JPA + fix String/int key mismatch (+ persistence folder reorg)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -42,7 +42,7 @@ import com.ticketing.system.Core.Domain.users.ISessionRepository;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.Session;
 import com.ticketing.system.Core.Domain.users.User;
-import com.ticketing.system.Infrastructure.persistence.MemoryActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.MemoryActiveOrderRepository;
 
 
 /**

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -808,7 +808,7 @@ public class EventManagementService {
             // PAID or ISSUED, it should be marked as REFUNDED; otherwise, it can be marked
             // as VOIDED. In a real system, we might want to handle this more robustly (e.g.
             // consider different ticket statuses, handle partial refunds, etc.).
-            List<Ticket> tickets = ticketRepository.findByEventId(String.valueOf(eventId));
+            List<Ticket> tickets = ticketRepository.findByEventId(eventId);
             // Note: we update ticket statuses after processing refunds to avoid
             // complications where we mark tickets as refunded but then encounter an error
             // during the refund process. By only updating ticket statuses after we've

--- a/src/main/java/com/ticketing/system/Core/Domain/Tickets/ITicketRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/Tickets/ITicketRepository.java
@@ -12,13 +12,14 @@ public interface ITicketRepository extends IRepository<Ticket, Integer> {
     boolean save(Ticket ticket);
 
     // UC-8 / UC-22 — render venue map / list company sales.
-    List<Ticket> findByEventId(String eventId);
+    // Keys are int: Ticket stores eventId/zoneId as int, so the port uses int end-to-end.
+    List<Ticket> findByEventId(int eventId);
 
     // UC-9 (quantity-mode reservation) — atomically pick N AVAILABLE tickets in a zone.
-    List<Ticket> findAvailableInZone(String eventId, String zoneId, int quantity);
+    List<Ticket> findAvailableInZone(int eventId, int zoneId, int quantity);
 
     // UC-8 — count for standing-zone availability display.
-    int countAvailableInZone(String eventId, String zoneId);
+    int countAvailableInZone(int eventId, int zoneId);
 
     // UC-10 / UC-22 / UC-16 — tickets that belong to one OrderReceipt.
     List<Ticket> findByOrderReceiptId(int orderReceiptId);

--- a/src/main/java/com/ticketing/system/Core/Domain/Tickets/Ticket.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/Tickets/Ticket.java
@@ -4,20 +4,66 @@ package com.ticketing.system.Core.Domain.Tickets;
 import com.ticketing.system.Core.Domain.exceptions.TicketNotAvailableException;
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+/**
+ * Unified Ticket aggregate root (inventory + post-purchase record).
+ *
+ * <p>V3: mapped to JPA as a flat row — the four references ({@code eventId},
+ * {@code zoneid}, {@code orderReceiptId}, {@code holderUserId}) are plain by-id
+ * columns, never {@code @ManyToOne} (the cross-aggregate reference rule). The
+ * {@code ticketId} {@code @Id} is ASSIGNED by the issuer (the barcode/ticketId the
+ * ticket issuer returns), never {@code @GeneratedValue}. {@code status} is stored by
+ * name ({@code @Enumerated(STRING)}) so the column is stable against enum reordering,
+ * and {@code @Version} drives optimistic locking. A protected no-arg constructor lets
+ * Hibernate hydrate instances; the public constructor still enforces the invariants.
+ */
+@Entity
+@Table(name = "tickets")
 public class Ticket implements InvariantChecked {
 
+    @Column(name = "zone_id", nullable = false)
     private int zoneid;
+
+    @Column(name = "event_id", nullable = false)
     private int eventId;
+
+    @Column(name = "seat_number")
     private String seatNumber;   // nullable for standing zones, non-null for seated zones. Represents the seat label this ticket refers to inside its zone.
+
+    @Column(nullable = false)
     private double price;
+
+    @Id
     private int ticketId;
+
+    @Column(name = "order_receipt_id", nullable = false)
     private int orderReceiptId;
+
+    @Column(name = "barcode_value")
     private String barcodeValue;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private TicketStatus status;
+
     // D7 (auth rework #181): nullable. Set on the Member path of CheckoutService;
     // stays null for Guest purchases. Lets UC-16 view-my-history go through
     // ITicketRepository.findByHolderUserId(int) in a single hop.
+    @Column(name = "holder_user_id")
     private Integer holderUserId;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Ticket() { }
 
 
     /**

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
@@ -1,15 +1,15 @@
 package com.ticketing.system.Infrastructure.dev.seed;
 
-import com.ticketing.system.Infrastructure.persistence.MemoryActiveOrderRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryAdminRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryConversationRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryEventRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryNotificationRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryOrderReceiptRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryProductionCompanyRepository;
-import com.ticketing.system.Infrastructure.persistence.MemorySessionRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryTicketRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryUserRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.MemoryActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.AdminPersistence.MemoryAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.MemoryConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.EventPersistence.MemoryEventRepository;
+import com.ticketing.system.Infrastructure.persistence.NotificationPersistence.MemoryNotificationRepository;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.MemoryOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence.MemoryProductionCompanyRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.MemorySessionRepository;
+import com.ticketing.system.Infrastructure.persistence.TicketPersistence.MemoryTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.UserPersistence.MemoryUserRepository;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/JpaAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/JpaAdminRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.AdminPersistence;
 import java.util.List;
 
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/MemoryAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/MemoryAdminRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.AdminPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/SpringDataAdminRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/AdminPersistence/SpringDataAdminRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.AdminPersistence;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/MemoryConversationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/MemoryConversationRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.ConversationPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.EventPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryReadWriteLocks;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/JpaTicketRepository.java
@@ -1,0 +1,95 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Limit;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+
+/**
+ * JPA-backed {@link ITicketRepository} — active only in the {@code jpa} run/dev profile.
+ * Adapts the domain port onto Spring Data ({@link SpringDataTicketRepository}); the
+ * application layer depends only on {@code ITicketRepository}, never on Spring Data.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops: concurrent writes are guarded by
+ * {@code Ticket}'s {@code @Version} optimistic lock within the surrounding transaction
+ * (per the {@code IRepository} contract — JPA replaces the in-memory write-lock with
+ * version checks).
+ *
+ * <p>{@link #save} delegates to {@code data.save}: a fresh ticket (issuer-assigned id,
+ * version {@code null}) is inserted, a loaded-then-mutated ticket (reserve / markPaid /
+ * markIssued / ...) is updated under its {@code @Version} check — the only two flows
+ * tickets ever see (unique issuer ids mean a fresh instance never reuses a live id).
+ * {@link #saveAll} delegates to {@code data.saveAll} for UC-20 bulk pre-generation. The
+ * writes are {@code @Transactional} so the adapter is self-sufficient before the service
+ * layer gains transactions (#359); reads inherit Spring Data's read-only tx.
+ */
+@Repository
+@Profile("jpa")
+public class JpaTicketRepository implements ITicketRepository {
+
+    private final SpringDataTicketRepository data;
+
+    public JpaTicketRepository(SpringDataTicketRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(Integer id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(Integer id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public boolean save(Ticket ticket) {
+        data.save(ticket);
+        return true;
+    }
+
+    @Override
+    public Ticket findById(int ticketId) {
+        return data.findById(ticketId).orElse(null);
+    }
+
+    @Override
+    public List<Ticket> findByEventId(int eventId) {
+        return data.findByEventId(eventId);
+    }
+
+    @Override
+    public List<Ticket> findAvailableInZone(int eventId, int zoneId, int quantity) {
+        if (quantity <= 0) {
+            return List.of();
+        }
+        return data.findAvailableInZone(eventId, zoneId, Limit.of(quantity));
+    }
+
+    @Override
+    public int countAvailableInZone(int eventId, int zoneId) {
+        return (int) data.countAvailableInZone(eventId, zoneId);
+    }
+
+    @Override
+    public List<Ticket> findByOrderReceiptId(int orderReceiptId) {
+        return data.findByOrderReceiptId(orderReceiptId);
+    }
+
+    @Override
+    public List<Ticket> findByHolderUserId(int holderUserId) {
+        return data.findByHolderUserId(holderUserId);
+    }
+
+    @Override
+    @Transactional
+    public void saveAll(List<Ticket> tickets) {
+        if (tickets == null) {
+            return;
+        }
+        data.saveAll(tickets);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/MemoryTicketRepository.java
@@ -5,22 +5,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.Tickets.Ticket;
 
 /**
- * In-memory {@link ITicketRepository} for V1. Lets Spring wire
+ * In-memory {@link ITicketRepository}. Lets Spring wire
  * CatalogService / CheckoutService / EventManagementService /
- * MemberAccountService.
+ * MemberAccountService. {@code @Profile("!jpa")}: the {@code jpa} run/dev profile
+ * swaps in {@link JpaTicketRepository} instead.
  *
- * <p>Note: the interface mixes {@code int} (findById, holderUserId) and
- * {@code String} (findByEventId, findByOrderReceiptId) keys — for the
- * String-keyed methods we parse to int where possible and throw on the
- * orderReceiptId join (Ticket has no orderReceiptId field yet — UC-22 work).
+ * <p>All keys are {@code int}, matching the {@code Ticket} fields end-to-end (the
+ * former {@code String} eventId/zoneId on the port have been corrected to {@code int}).
  */
 @Repository
+@Profile("!jpa")
 public class MemoryTicketRepository implements ITicketRepository {
 
     private final Map<Integer, Ticket> ticketsById = new ConcurrentHashMap<>();
@@ -44,39 +45,22 @@ public class MemoryTicketRepository implements ITicketRepository {
     }
 
     @Override
-    public List<Ticket> findByEventId(String eventId) {
-        int target;
-        try {
-            target = Integer.parseInt(eventId);
-        } catch (NumberFormatException e) {
-            return List.of();
-        }
+    public List<Ticket> findByEventId(int eventId) {
         List<Ticket> result = new ArrayList<>();
         for (Ticket t : ticketsById.values()) {
-            if (t.getEventId() == target)
+            if (t.getEventId() == eventId)
                 result.add(t);
         }
         return result;
     }
 
-    
-
-
 
     @Override
-    public List<Ticket> findAvailableInZone(String eventId, String zoneId, int quantity) {
-        int eventTarget;
-        int zoneTarget;
-        try {
-            eventTarget = Integer.parseInt(eventId);
-            zoneTarget = Integer.parseInt(zoneId);
-        } catch (NumberFormatException e) {
-            return List.of();
-        }
+    public List<Ticket> findAvailableInZone(int eventId, int zoneId, int quantity) {
         List<Ticket> result = new ArrayList<>();
         for (Ticket t : ticketsById.values()) {
-            if (t.getEventId() == eventTarget
-                    && t.getZoneId() == zoneTarget
+            if (t.getEventId() == eventId
+                    && t.getZoneId() == zoneId
                     && t.isAvailable()
                     && quantity > result.size()) {
                 result.add(t);
@@ -86,18 +70,10 @@ public class MemoryTicketRepository implements ITicketRepository {
     }
 
     @Override
-    public int countAvailableInZone(String eventId, String zoneId) {
-        int eventTarget;
-        int zoneTarget;
-        try {
-            eventTarget = Integer.parseInt(eventId);
-            zoneTarget = Integer.parseInt(zoneId);
-        } catch (NumberFormatException e) {
-            return 0;
-        }
+    public int countAvailableInZone(int eventId, int zoneId) {
         int count = 0;
         for (Ticket t : ticketsById.values()) {
-            if (t.getEventId() == eventTarget && t.getZoneId() == zoneTarget && t.isAvailable())
+            if (t.getEventId() == eventId && t.getZoneId() == zoneId && t.isAvailable())
                 count++;
         }
         return count;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/MemoryNotificationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/MemoryNotificationRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.NotificationPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
 import com.ticketing.system.Core.Domain.notifications.Notification;
 import com.ticketing.system.Core.Domain.notifications.NotificationStatus;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/JpaSessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/JpaSessionRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.SessionPersistence;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.List;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/MemorySessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/MemorySessionRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.SessionPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/SpringDataSessionRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SessionPersistence/SpringDataSessionRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.SessionPersistence;
 import java.time.Instant;
 import java.util.List;
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/SpringDataTicketRepository.java
@@ -1,0 +1,39 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import java.util.List;
+
+import org.springframework.data.domain.Limit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+
+/**
+ * Spring Data JPA repository for {@link Ticket} — the auto-implemented SQL backing
+ * {@link JpaTicketRepository}. The application layer never sees this type; it depends
+ * only on the {@code ITicketRepository} domain port.
+ *
+ * <p>The three single-key lookups are derived queries. The two zone lookups use an
+ * explicit JPQL {@code @Query}: the field is named {@code zoneid} while its getter is
+ * {@code getZoneId()}, so a derived {@code ...Zoneid...} name would be ambiguous —
+ * JPQL referencing {@code t.zoneid} is unambiguous. {@code findAvailableInZone} caps the
+ * result with a {@link Limit} (the requested quantity); both filter to
+ * {@code status = AVAILABLE}.
+ */
+public interface SpringDataTicketRepository extends JpaRepository<Ticket, Integer> {
+
+    List<Ticket> findByEventId(int eventId);
+
+    List<Ticket> findByOrderReceiptId(int orderReceiptId);
+
+    List<Ticket> findByHolderUserId(int holderUserId);
+
+    @Query("select t from Ticket t where t.eventId = :eventId and t.zoneid = :zoneId "
+            + "and t.status = com.ticketing.system.Core.Domain.Tickets.TicketStatus.AVAILABLE")
+    List<Ticket> findAvailableInZone(@Param("eventId") int eventId, @Param("zoneId") int zoneId, Limit limit);
+
+    @Query("select count(t) from Ticket t where t.eventId = :eventId and t.zoneid = :zoneId "
+            + "and t.status = com.ticketing.system.Core.Domain.Tickets.TicketStatus.AVAILABLE")
+    long countAvailableInZone(@Param("eventId") int eventId, @Param("zoneId") int zoneId);
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/JpaTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/JpaTicketRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.TicketPersistence;
 import java.util.List;
 
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/MemoryTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/MemoryTicketRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.TicketPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/SpringDataTicketRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/TicketPersistence/SpringDataTicketRepository.java
@@ -1,5 +1,4 @@
-package com.ticketing.system.Infrastructure.persistence;
-
+package com.ticketing.system.Infrastructure.persistence.TicketPersistence;
 import java.util.List;
 
 import org.springframework.data.domain.Limit;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/UserPersistence/MemoryUserRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/UserPersistence/MemoryUserRepository.java
@@ -1,5 +1,6 @@
-package com.ticketing.system.Infrastructure.persistence;
+package com.ticketing.system.Infrastructure.persistence.UserPersistence;
 
+import com.ticketing.system.Infrastructure.persistence.RepositoryLocks;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CheckoutServiceAcceptanceTest.java
@@ -14,7 +14,7 @@ import com.ticketing.system.Core.Domain.events.*;
 import com.ticketing.system.Core.Domain.orders.*;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
-import com.ticketing.system.Infrastructure.persistence.MemoryActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.MemoryActiveOrderRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -155,7 +155,7 @@ class EventManagementServiceTest {
                 when(paymentGateway.refund(anyInt(), anyDouble())).thenReturn(
                                 new RefundResultDTO("refund-tx-1", "99", 100.0, java.time.LocalDateTime.now(),
                                                 List.of(), List.of()));
-                when(mockTicketRepo.findByEventId(String.valueOf(EVENT_ID))).thenReturn(List.of());
+                when(mockTicketRepo.findByEventId(EVENT_ID)).thenReturn(List.of());
 
                 when(orderReceiptRepository.findByEventId(EVENT_ID))
                                 .thenReturn(List.of(realReceipt));
@@ -239,7 +239,7 @@ class EventManagementServiceTest {
 
                 Ticket paidTicket = new Ticket(EVENT_ID, ZONE_ID, ORDER_RECEIPT_ID, null, 100.0, 1, "BARCODE123");
                 // paidTicket.markPaid();
-                when(mockTicketRepo.findByEventId(String.valueOf(EVENT_ID))).thenReturn(List.of(paidTicket));
+                when(mockTicketRepo.findByEventId(EVENT_ID)).thenReturn(List.of(paidTicket));
 
                 eventService.cancelEventAndRefund(OWNER_TOKEN, EVENT_ID);
 
@@ -260,7 +260,7 @@ class EventManagementServiceTest {
 
                 issuedTicket.markIssued("BARCODE123");
 
-                when(mockTicketRepo.findByEventId(String.valueOf(EVENT_ID))).thenReturn(List.of(issuedTicket));
+                when(mockTicketRepo.findByEventId(EVENT_ID)).thenReturn(List.of(issuedTicket));
 
                 eventService.cancelEventAndRefund(OWNER_TOKEN, EVENT_ID);
 
@@ -281,7 +281,7 @@ class EventManagementServiceTest {
 
                 availableTicket.release();
 
-                when(mockTicketRepo.findByEventId(String.valueOf(EVENT_ID))).thenReturn(List.of(availableTicket));
+                when(mockTicketRepo.findByEventId(EVENT_ID)).thenReturn(List.of(availableTicket));
 
                 eventService.cancelEventAndRefund(OWNER_TOKEN, EVENT_ID);
 

--- a/src/test/java/com/ticketing/system/unit/application/MessagingServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/MessagingServiceTest.java
@@ -39,7 +39,7 @@ import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
 import com.ticketing.system.Core.Domain.messaging.ParticipantType;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
-import com.ticketing.system.Infrastructure.persistence.MemoryConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.MemoryConversationRepository;
 
 class MessagingServiceTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepositoryContractTest.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.unit.infrastructure.persistence.ActiveOrderPersistence;
 
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.MemoryActiveOrderRepository;
 
 class MemoryActiveOrderRepositoryContractTest extends IActiveOrderRepositoryContractTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/JpaAdminRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/JpaAdminRepositoryTest.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
-import com.ticketing.system.Infrastructure.persistence.JpaAdminRepository;
-import com.ticketing.system.Infrastructure.persistence.SpringDataAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.AdminPersistence.JpaAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.AdminPersistence.SpringDataAdminRepository;
 
 /**
  * Runs the {@link IAdminRepositoryContractTest} suite against the JPA adapter on an

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/MemoryAdminRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/AdminPersistence/MemoryAdminRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.unit.infrastructure.persistence.AdminPersistence;
 
 import com.ticketing.system.Core.Domain.Admin.IAdminRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryAdminRepository;
+import com.ticketing.system.Infrastructure.persistence.AdminPersistence.MemoryAdminRepository;
 
 /** Runs the {@link IAdminRepositoryContractTest} suite against the in-memory adapter. */
 class MemoryAdminRepositoryTest extends IAdminRepositoryContractTest {

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/MemoryEventRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/MemoryEventRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.unit.infrastructure.persistence.EventPersistence;
 
 import com.ticketing.system.Core.Domain.events.IEventRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryEventRepository;
+import com.ticketing.system.Infrastructure.persistence.EventPersistence.MemoryEventRepository;
 
 public class MemoryEventRepositoryTest extends IEventRepositoryContractTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/JpaSessionRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/JpaSessionRepositoryContractTest.java
@@ -11,8 +11,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
-import com.ticketing.system.Infrastructure.persistence.JpaSessionRepository;
-import com.ticketing.system.Infrastructure.persistence.SpringDataSessionRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.JpaSessionRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.SpringDataSessionRepository;
 
 /**
  * Runs the {@link ISessionRepositoryContractTest} suite against the JPA adapter on an

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/MemorySessionRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/SessionPersistence/MemorySessionRepositoryContractTest.java
@@ -3,7 +3,7 @@ package com.ticketing.system.unit.infrastructure.persistence.SessionPersistence;
 import java.time.Clock;
 
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
-import com.ticketing.system.Infrastructure.persistence.MemorySessionRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.MemorySessionRepository;
 
 class MemorySessionRepositoryContractTest extends ISessionRepositoryContractTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/ITicketRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/ITicketRepositoryContractTest.java
@@ -1,0 +1,181 @@
+package com.ticketing.system.unit.infrastructure.persistence.TicketPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Core.Domain.Tickets.Ticket;
+import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
+
+/**
+ * Contract every {@link ITicketRepository} implementation must satisfy. The Memory and
+ * JPA adapters each subclass this with their own {@link #newRepository()} factory; the
+ * tests are reused. Keys are {@code int} end-to-end (the former String/int mismatch on
+ * the port is fixed).
+ *
+ * <p>A freshly constructed {@link Ticket} is {@code PAID} (tickets are created at payment
+ * time); {@link #available} flips one to {@code AVAILABLE} via {@code release()} so the
+ * zone-availability queries have something to find.
+ */
+abstract class ITicketRepositoryContractTest {
+
+    protected abstract ITicketRepository newRepository();
+
+    private ITicketRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    // --- helpers ---------------------------------------------------------------
+
+    /** PAID ticket (the constructor default), no holder. */
+    private Ticket ticket(int id, int eventId, int zoneId, int orderReceiptId) {
+        return new Ticket(eventId, zoneId, orderReceiptId, null, 10.0, id, "BC-" + id);
+    }
+
+    /** AVAILABLE ticket in the given event/zone. */
+    private Ticket available(int id, int eventId, int zoneId) {
+        Ticket t = ticket(id, eventId, zoneId, 1);
+        t.release();
+        return t;
+    }
+
+    private Set<Integer> ids(List<Ticket> tickets) {
+        return tickets.stream().map(Ticket::getId).collect(Collectors.toSet());
+    }
+
+    // --- save / findById -------------------------------------------------------
+
+    @Test
+    void save_thenFindById_returnsTheSavedTicket() {
+        assertTrue(repo.save(ticket(1, 10, 2, 1)));
+
+        Ticket found = repo.findById(1);
+        assertNotNull(found);
+        assertEquals(10, found.getEventId());
+        assertEquals(2, found.getZoneId());
+    }
+
+    @Test
+    void findById_returnsNullWhenMissing() {
+        assertNull(repo.findById(999));
+    }
+
+    @Test
+    void save_updatesALoadedTicketInPlace() {
+        repo.save(ticket(1, 10, 2, 1)); // PAID
+        Ticket loaded = repo.findById(1);
+        loaded.markRefunded();
+        repo.save(loaded);
+
+        assertEquals(TicketStatus.REFUNDED, repo.findById(1).getStatus());
+    }
+
+    // --- findByEventId ---------------------------------------------------------
+
+    @Test
+    void findByEventId_returnsOnlyThatEvent() {
+        repo.save(ticket(1, 10, 2, 1));
+        repo.save(ticket(2, 10, 3, 1));
+        repo.save(ticket(3, 20, 2, 1));
+
+        assertEquals(Set.of(1, 2), ids(repo.findByEventId(10)));
+        assertEquals(Set.of(3), ids(repo.findByEventId(20)));
+    }
+
+    @Test
+    void findByEventId_emptyWhenNoMatch() {
+        repo.save(ticket(1, 10, 2, 1));
+        assertTrue(repo.findByEventId(999).isEmpty());
+    }
+
+    // --- findAvailableInZone / countAvailableInZone ----------------------------
+
+    @Test
+    void findAvailableInZone_returnsOnlyAvailableInThatEventAndZone() {
+        repo.save(available(1, 10, 2));
+        repo.save(available(2, 10, 2));
+        repo.save(ticket(3, 10, 2, 1));   // PAID — not available
+        repo.save(available(4, 10, 3));   // wrong zone
+        repo.save(available(5, 20, 2));   // wrong event
+
+        assertEquals(Set.of(1, 2), ids(repo.findAvailableInZone(10, 2, 10)));
+    }
+
+    @Test
+    void findAvailableInZone_respectsQuantityLimit() {
+        repo.save(available(1, 10, 2));
+        repo.save(available(2, 10, 2));
+        repo.save(available(3, 10, 2));
+
+        List<Ticket> picked = repo.findAvailableInZone(10, 2, 2);
+        assertEquals(2, picked.size());
+        assertTrue(picked.stream().allMatch(t -> t.isAvailable() && t.getEventId() == 10 && t.getZoneId() == 2));
+    }
+
+    @Test
+    void findAvailableInZone_emptyWhenQuantityZero() {
+        repo.save(available(1, 10, 2));
+        assertTrue(repo.findAvailableInZone(10, 2, 0).isEmpty());
+    }
+
+    @Test
+    void countAvailableInZone_countsOnlyAvailableInThatEventAndZone() {
+        repo.save(available(1, 10, 2));
+        repo.save(available(2, 10, 2));
+        repo.save(ticket(3, 10, 2, 1));   // PAID
+        repo.save(available(4, 10, 3));   // wrong zone
+        repo.save(available(5, 20, 2));   // wrong event
+
+        assertEquals(2, repo.countAvailableInZone(10, 2));
+        assertEquals(0, repo.countAvailableInZone(99, 99));
+    }
+
+    // --- findByOrderReceiptId / findByHolderUserId -----------------------------
+
+    @Test
+    void findByOrderReceiptId_returnsOnlyThatReceipt() {
+        repo.save(ticket(1, 10, 2, 100));
+        repo.save(ticket(2, 10, 2, 100));
+        repo.save(ticket(3, 10, 2, 200));
+
+        assertEquals(Set.of(1, 2), ids(repo.findByOrderReceiptId(100)));
+    }
+
+    @Test
+    void findByHolderUserId_returnsMatchingAndExcludesNullHolder() {
+        Ticket held1 = ticket(1, 10, 2, 1);
+        held1.setHolderUserId(5);
+        Ticket held2 = ticket(2, 10, 2, 1);
+        held2.setHolderUserId(5);
+        repo.save(held1);
+        repo.save(held2);
+        repo.save(ticket(3, 10, 2, 1)); // holder null
+
+        assertEquals(Set.of(1, 2), ids(repo.findByHolderUserId(5)));
+        assertTrue(repo.findByHolderUserId(7).isEmpty());
+    }
+
+    // --- saveAll ---------------------------------------------------------------
+
+    @Test
+    void saveAll_persistsEveryTicket() {
+        repo.saveAll(List.of(ticket(1, 10, 2, 1), ticket(2, 10, 2, 1), ticket(3, 20, 2, 1)));
+
+        assertNotNull(repo.findById(1));
+        assertNotNull(repo.findById(2));
+        assertNotNull(repo.findById(3));
+        assertEquals(Set.of(1, 2), ids(repo.findByEventId(10)));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/JpaTicketRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/JpaTicketRepositoryContractTest.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
-import com.ticketing.system.Infrastructure.persistence.JpaTicketRepository;
-import com.ticketing.system.Infrastructure.persistence.SpringDataTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.TicketPersistence.JpaTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.TicketPersistence.SpringDataTicketRepository;
 
 /**
  * Runs the {@link ITicketRepositoryContractTest} suite against the JPA adapter on an

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/JpaTicketRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/JpaTicketRepositoryContractTest.java
@@ -1,0 +1,40 @@
+package com.ticketing.system.unit.infrastructure.persistence.TicketPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Infrastructure.persistence.JpaTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.SpringDataTicketRepository;
+
+/**
+ * Runs the {@link ITicketRepositoryContractTest} suite against the JPA adapter on an
+ * embedded H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaTicketRepository};
+ * {@code @DataJpaTest} provides H2 + a real {@code tickets} table. Each test starts from an
+ * empty table ({@link #cleanTable()}) so the suite is order-independent. CI never touches a
+ * real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaTicketRepository.class)
+class JpaTicketRepositoryContractTest extends ITicketRepositoryContractTest {
+
+    @Autowired
+    private JpaTicketRepository repository;
+
+    @Autowired
+    private SpringDataTicketRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected ITicketRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/MemoryTicketRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/MemoryTicketRepositoryContractTest.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.unit.infrastructure.persistence.TicketPersistence;
 
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.TicketPersistence.MemoryTicketRepository;
 
 class MemoryTicketRepositoryContractTest extends ITicketRepositoryContractTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/MemoryTicketRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/TicketPersistence/MemoryTicketRepositoryContractTest.java
@@ -1,0 +1,12 @@
+package com.ticketing.system.unit.infrastructure.persistence.TicketPersistence;
+
+import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
+import com.ticketing.system.Infrastructure.persistence.MemoryTicketRepository;
+
+class MemoryTicketRepositoryContractTest extends ITicketRepositoryContractTest {
+
+    @Override
+    protected ITicketRepository newRepository() {
+        return new MemoryTicketRepository();
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/UserPersistence/MemoryUserRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/UserPersistence/MemoryUserRepositoryContractTest.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.unit.infrastructure.persistence.UserPersistence;
 
 import com.ticketing.system.Core.Domain.users.IUserRepository;
-import com.ticketing.system.Infrastructure.persistence.MemoryUserRepository;
+import com.ticketing.system.Infrastructure.persistence.UserPersistence.MemoryUserRepository;
 
 class MemoryUserRepositoryContractTest extends IUserRepositoryContractTest {
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/security/JwtSessionManagerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/security/JwtSessionManagerTest.java
@@ -17,7 +17,7 @@ import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Core.Domain.exceptions.SessionExpiredException;
 import com.ticketing.system.Core.Domain.users.ISessionRepository;
 import com.ticketing.system.Core.Domain.users.Session;
-import com.ticketing.system.Infrastructure.persistence.MemorySessionRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.MemorySessionRepository;
 import com.ticketing.system.Infrastructure.security.JwtSessionManager;
 
 class JwtSessionManagerTest {


### PR DESCRIPTION
Maps the **Ticket** aggregate to JPA, **fixes the String/int key mismatch** on the port, and (folded in at the team's request) **reorganizes the system-side persistence folder into per-aggregate packages**. Third Lane-B slice; part of the V3 epic #347, depends on #349 (merged).

## Ticket → JPA (`feat`)
- **`@Entity` (`tickets`)**: assigned `int @Id` (the issuer-assigned `ticketId`, never `@GeneratedValue`); four plain by-id columns `eventId`/`zoneid`/`orderReceiptId`/`holderUserId` — **never `@ManyToOne`**; `TicketStatus` `@Enumerated(STRING)`; `@Version`. Protected no-arg ctor for Hibernate; the public ctor still enforces invariants.
- **`SpringDataTicketRepository`**: derived `findByEventId` / `findByOrderReceiptId` / `findByHolderUserId`; explicit `@Query` for the two zone lookups (the field is `zoneid` but the getter is `getZoneId()`, so a derived name would be ambiguous), capped by `Limit`.
- **`JpaTicketRepository`** (`@Profile("jpa")`): `save` → `data.save` (insert fresh / update loaded under `@Version`), bulk `saveAll` for UC-20 pre-generation; `lockForUpdate`/`unlock` no-ops. `MemoryTicketRepository` gated `@Profile("!jpa")`.

## Fix the String/int key mismatch (`feat`)
`findByEventId` / `findAvailableInZone` / `countAvailableInZone` took `String` while `Ticket` stores `int`. Changed them to `int` end-to-end; dropped the `parseInt` try/catch in Memory; simplified the one prod caller (`EventManagementService` — it already held an `int`) and its 4 test stubs. The two zone methods had no callers.

## Contract test, written first (`test`)
`ITicketRepository` had none. New `ITicketRepositoryContractTest` covers save/findById, an in-place update of a loaded ticket, `findByEventId`, `findAvailableInZone` (status+zone filter, quantity limit, empty on 0), `countAvailableInZone`, `findByOrderReceiptId`, `findByHolderUserId` (excludes null holders), and bulk `saveAll` — run on **both** Memory and JPA-on-H2 (`@DataJpaTest`).

## Persistence folder reorg (`chore`)
Mirror the test side: each `Memory`/`Jpa`/`SpringData` repo moved into a `<Aggregate>Persistence` subpackage (all 10 aggregates); the two shared lock helpers stay at the `persistence/` root. Pure move tracked as renames — package decls + all importers updated; Spring still component-scans subpackages so wiring/`@Profile` is unchanged.

## Verification
- `./mvnw -Pno-vaadin test` → **1152 passing, 0 failures** (+24 Ticket contract), unchanged across the reorg.
- **Dev boot (`dev`+`jpa`):** clean start in ~5.8s, scenario **40/40**, 0 errors, all repos in their new subpackages.

Closes #351.
