### PR TITLE
[V3-ORM-03] Map Notification to JPA + JSON data converter

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/notifications/Notification.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/notifications/Notification.java
@@ -8,29 +8,68 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 // Aggregate root for the Notification aggregate (UC-35 / UC-36 / UC-37 design walkthrough).
 // Promoted from a sub-entity of User to its own aggregate so high-volume PENDING storage
 // and login-time delivery don't drag the User aggregate.
 //
 // Cross-aggregate references by ID per course rules:
 //   recipientUserId — User aggregate
+// V3: mapped to JPA. The String @Id is ASSIGNED by the application (a UUID), never
+// @GeneratedValue; recipientUserId is a plain by-id column (never @ManyToOne); the two
+// enums are stored by name (@Enumerated STRING); @Version drives optimistic locking. The
+// data payload is stored as one JSON text column via NotificationDataJsonConverter rather
+// than an @ElementCollection side table. Fields are non-final with a protected no-arg ctor
+// so Hibernate can hydrate; the public ctors still enforce the invariants.
+@Entity
+@Table(name = "notifications")
 public class Notification implements InvariantChecked {
 
-    private final String id;
-    private final int recipientUserId;
-    private final NotificationType type;
+    @Id
+    private String id;
+
+    @Column(name = "recipient_user_id", nullable = false)
+    private int recipientUserId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private NotificationStatus status;
-    private final String message;
-    private final LocalDateTime createdAt;
+
+    @Column
+    private String message;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
     /**
      * Structured payload — type-specific key/value data the recipient (or UI) can
      * render. E.g. PURCHASE_CONFIRMED carries {@code orderId}, {@code total},
      * {@code eventName}; EVENT_CANCELLED carries {@code eventId}, {@code reason}.
      * The {@link #message} stays the human-readable summary; {@code data} is the
      * machine-readable companion. Never null — empty map for notifications with
-     * no extra context.
+     * no extra context. Persisted as one JSON text column (see
+     * {@link NotificationDataJsonConverter}).
      */
-    private final Map<String, Object> data;
+    @Convert(converter = NotificationDataJsonConverter.class)
+    @Column(name = "data", columnDefinition = "text", nullable = false)
+    private Map<String, Object> data;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Notification() { }
 
     /**
      * Backward-compatible 6-arg constructor — leaves {@link #data} as an empty map.

--- a/src/main/java/com/ticketing/system/Core/Domain/notifications/NotificationDataJsonConverter.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/notifications/NotificationDataJsonConverter.java
@@ -1,0 +1,53 @@
+package com.ticketing.system.Core.Domain.notifications;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Stores a {@link Notification}'s {@code Map<String,Object> data} payload as a single
+ * JSON text column instead of an {@code @ElementCollection} side table. Jackson turns
+ * the map into JSON text on the way to the database and parses it back on the way out.
+ *
+ * <p>Round-trip fidelity: String, boolean, whole numbers, decimals, lists and nested maps
+ * come back equal. JSON carries no Java type tags, so an exotic {@code Long} comes back as
+ * {@code Integer} and a {@code BigDecimal} as {@code Double} (same value, different flavor)
+ * — acceptable for this render-only payload, and not a type our notifications use.
+ *
+ * <p>Lives next to {@link Notification} (referenced by its {@code @Convert}) rather than in
+ * the infrastructure layer, so a core class never imports downward. JPA instantiates the
+ * converter itself (it is not a Spring bean), so it holds its own {@link ObjectMapper}.
+ */
+@Converter
+public class NotificationDataJsonConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() { };
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> data) {
+        try {
+            return MAPPER.writeValueAsString(data == null ? new HashMap<>() : data);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to serialize notification data to JSON", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) {
+            return new HashMap<>();
+        }
+        try {
+            return MAPPER.readValue(json, MAP_TYPE);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to parse notification data JSON", e);
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/JpaNotificationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/JpaNotificationRepository.java
@@ -1,0 +1,73 @@
+package com.ticketing.system.Infrastructure.persistence.NotificationPersistence;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
+import com.ticketing.system.Core.Domain.notifications.Notification;
+import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
+
+/**
+ * JPA-backed {@link INotificationRepository} — active only in the {@code jpa} run/dev
+ * profile. Adapts the domain port onto Spring Data ({@link SpringDataNotificationRepository});
+ * the application layer depends only on {@code INotificationRepository}, never on Spring Data.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops: concurrent writes are guarded by
+ * {@code Notification}'s {@code @Version} optimistic lock within the surrounding transaction.
+ * {@link #save} delegates to {@code data.save}: a fresh notification (version {@code null}) is
+ * inserted, a loaded-then-mutated one (markDelivered / markPending) is updated under its
+ * {@code @Version} check. The write is {@code @Transactional} so the adapter is self-sufficient
+ * before the service layer gains transactions (#359); reads inherit Spring Data's read-only tx.
+ */
+@Repository
+@Profile("jpa")
+public class JpaNotificationRepository implements INotificationRepository {
+
+    private final SpringDataNotificationRepository data;
+    private final AtomicInteger idSequence = new AtomicInteger(1);
+
+    public JpaNotificationRepository(SpringDataNotificationRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(String id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(String id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public void save(Notification notification) {
+        data.save(notification);
+    }
+
+    @Override
+    public Notification findById(String notificationId) {
+        if (notificationId == null) {
+            return null;
+        }
+        return data.findById(notificationId).orElse(null);
+    }
+
+    @Override
+    public List<Notification> findByRecipientAndStatus(int recipientUserId, NotificationStatus status) {
+        return data.findByRecipientUserIdAndStatus(recipientUserId, status);
+    }
+
+    @Override
+    public List<Notification> findByRecipient(int recipientUserId) {
+        return data.findByRecipientUserId(recipientUserId);
+    }
+
+    @Override
+    public int nextId() {
+        // Vestigial: no caller uses notification nextId() (ids are UUIDs). Kept only to
+        // satisfy the port; an in-memory counter is enough since the value is never persisted.
+        return idSequence.getAndIncrement();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/MemoryNotificationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/MemoryNotificationRepository.java
@@ -5,18 +5,22 @@ import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
 import com.ticketing.system.Core.Domain.notifications.Notification;
 import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 
 @Repository
+@Profile("!jpa")
 public class MemoryNotificationRepository implements INotificationRepository {
-    private final Map<String, Notification> storage = new HashMap<>();
+    // ConcurrentHashMap (not HashMap) for thread-safe concurrent access, matching the
+    // other Memory repositories — notifications are written and read from many threads.
+    private final Map<String, Notification> storage = new ConcurrentHashMap<>();
     private final AtomicInteger idSequence = new AtomicInteger(1);
     private final RepositoryLocks<String> locks = new RepositoryLocks<>();
 
@@ -38,6 +42,9 @@ public class MemoryNotificationRepository implements INotificationRepository {
 
     @Override
     public Notification findById(String id) {
+        if (id == null) {
+            return null;
+        }
         return storage.get(id);
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/SpringDataNotificationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/NotificationPersistence/SpringDataNotificationRepository.java
@@ -1,0 +1,21 @@
+package com.ticketing.system.Infrastructure.persistence.NotificationPersistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ticketing.system.Core.Domain.notifications.Notification;
+import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
+
+/**
+ * Spring Data JPA repository for {@link Notification} — the auto-implemented SQL backing
+ * {@link JpaNotificationRepository}. The application layer never sees this type; it depends
+ * only on the {@code INotificationRepository} domain port. The {@code data} payload is mapped
+ * by {@code NotificationDataJsonConverter}, so it round-trips as a JSON text column.
+ */
+public interface SpringDataNotificationRepository extends JpaRepository<Notification, String> {
+
+    List<Notification> findByRecipientUserIdAndStatus(int recipientUserId, NotificationStatus status);
+
+    List<Notification> findByRecipientUserId(int recipientUserId);
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/INotificationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/INotificationRepositoryContractTest.java
@@ -1,0 +1,129 @@
+package com.ticketing.system.unit.infrastructure.persistence.NotificationPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
+import com.ticketing.system.Core.Domain.notifications.Notification;
+import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
+import com.ticketing.system.Core.Domain.notifications.NotificationType;
+
+/**
+ * Contract every {@link INotificationRepository} implementation must satisfy. The Memory and
+ * JPA adapters each subclass this with their own {@link #newRepository()} factory; the tests
+ * are reused. The {@code data} round-trip test pins the acceptance: a heterogeneous payload
+ * survives serialization to the JSON column and back.
+ */
+abstract class INotificationRepositoryContractTest {
+
+    protected abstract INotificationRepository newRepository();
+
+    private INotificationRepository repo;
+
+    private static final LocalDateTime T = LocalDateTime.of(2026, 1, 1, 12, 0, 0);
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    private Notification note(String id, int recipient, NotificationStatus status) {
+        return new Notification(id, recipient, NotificationType.PURCHASE_CONFIRMED, status, "hello", T);
+    }
+
+    private Set<String> ids(List<Notification> ns) {
+        return ns.stream().map(Notification::getId).collect(Collectors.toSet());
+    }
+
+    @Test
+    void save_thenFindById_returnsTheSavedNotification() {
+        repo.save(note("n1", 5, NotificationStatus.PENDING));
+
+        Notification found = repo.findById("n1");
+        assertNotNull(found);
+        assertEquals(5, found.getRecipientUserId());
+        assertEquals(NotificationType.PURCHASE_CONFIRMED, found.getType());
+        assertEquals(NotificationStatus.PENDING, found.getStatus());
+    }
+
+    @Test
+    void findById_returnsNullWhenMissing() {
+        assertNull(repo.findById("ghost"));
+    }
+
+    @Test
+    void findById_returnsNullForNullId() {
+        assertNull(repo.findById(null));
+    }
+
+    @Test
+    void save_updatesALoadedNotificationInPlace() {
+        repo.save(note("n1", 5, NotificationStatus.PENDING));
+        Notification loaded = repo.findById("n1");
+        loaded.markDelivered();
+        repo.save(loaded);
+
+        assertEquals(NotificationStatus.DELIVERED, repo.findById("n1").getStatus());
+    }
+
+    @Test
+    void findByRecipientAndStatus_filtersByRecipientAndStatus() {
+        repo.save(note("n1", 5, NotificationStatus.PENDING));
+        repo.save(note("n2", 5, NotificationStatus.DELIVERED));
+        repo.save(note("n3", 7, NotificationStatus.PENDING));
+
+        assertEquals(Set.of("n1"), ids(repo.findByRecipientAndStatus(5, NotificationStatus.PENDING)));
+        assertEquals(Set.of("n2"), ids(repo.findByRecipientAndStatus(5, NotificationStatus.DELIVERED)));
+        assertTrue(repo.findByRecipientAndStatus(99, NotificationStatus.PENDING).isEmpty());
+    }
+
+    @Test
+    void findByRecipient_returnsAllForThatRecipient() {
+        repo.save(note("n1", 5, NotificationStatus.PENDING));
+        repo.save(note("n2", 5, NotificationStatus.DELIVERED));
+        repo.save(note("n3", 7, NotificationStatus.PENDING));
+
+        assertEquals(Set.of("n1", "n2"), ids(repo.findByRecipient(5)));
+        assertTrue(repo.findByRecipient(99).isEmpty());
+    }
+
+    @Test
+    void heterogeneousData_roundTrips() {
+        Map<String, Object> data = new HashMap<>();
+        data.put("orderId", "ord-123");          // String
+        data.put("total", 100);                  // Integer
+        data.put("price", 12.5);                 // Double
+        data.put("vip", true);                   // Boolean
+        data.put("items", List.of("A", "B"));    // List
+        data.put("meta", Map.of("seat", "12A")); // nested Map
+
+        repo.save(new Notification("n1", 5, NotificationType.PURCHASE_CONFIRMED,
+                NotificationStatus.PENDING, "hello", T, data));
+
+        assertEquals(data, repo.findById("n1").getData());
+    }
+
+    @Test
+    void emptyData_roundTripsAsEmptyMap() {
+        repo.save(note("n1", 5, NotificationStatus.PENDING)); // 6-arg ctor → empty data
+        assertTrue(repo.findById("n1").getData().isEmpty());
+    }
+
+    @Test
+    void nextId_returnsDistinctValues() {
+        assertNotEquals(repo.nextId(), repo.nextId());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/JpaNotificationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/JpaNotificationRepositoryContractTest.java
@@ -1,0 +1,41 @@
+package com.ticketing.system.unit.infrastructure.persistence.NotificationPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
+import com.ticketing.system.Infrastructure.persistence.NotificationPersistence.JpaNotificationRepository;
+import com.ticketing.system.Infrastructure.persistence.NotificationPersistence.SpringDataNotificationRepository;
+
+/**
+ * Runs the {@link INotificationRepositoryContractTest} suite against the JPA adapter on an
+ * embedded H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaNotificationRepository};
+ * {@code @DataJpaTest} provides H2 + a real {@code notifications} table (with the {@code data}
+ * JSON column wired through {@code NotificationDataJsonConverter}). Each test starts from an
+ * empty table ({@link #cleanTable()}) so the suite is order-independent. CI never touches a
+ * real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaNotificationRepository.class)
+class JpaNotificationRepositoryContractTest extends INotificationRepositoryContractTest {
+
+    @Autowired
+    private JpaNotificationRepository repository;
+
+    @Autowired
+    private SpringDataNotificationRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected INotificationRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/MemoryNotificationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/NotificationPersistence/MemoryNotificationRepositoryContractTest.java
@@ -1,0 +1,12 @@
+package com.ticketing.system.unit.infrastructure.persistence.NotificationPersistence;
+
+import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
+import com.ticketing.system.Infrastructure.persistence.NotificationPersistence.MemoryNotificationRepository;
+
+class MemoryNotificationRepositoryContractTest extends INotificationRepositoryContractTest {
+
+    @Override
+    protected INotificationRepository newRepository() {
+        return new MemoryNotificationRepository();
+    }
+}


### PR DESCRIPTION
Maps the **Notification** aggregate to JPA, storing its `Map<String,Object> data` payload as a single **JSON text column**. Fourth Lane-B slice; part of the V3 epic #347, depends on #349 (merged).

## What
- **`@Entity` (`notifications`)**: assigned `String @Id` (a UUID, never `@GeneratedValue`); `recipientUserId` plain by-id column (never `@ManyToOne`); `NotificationType`/`NotificationStatus` `@Enumerated(STRING)`; `@Version`. Fields de-`final`ed + protected ctor; public ctors still enforce invariants.
- **`data` → JSON column** via `NotificationDataJsonConverter` (an `AttributeConverter<Map,String>` using Jackson) — **not** an `@ElementCollection` side table. The converter lives next to `Notification` (referenced by its `@Convert`) so a core class never imports the infrastructure layer. Stored as a portable `text` column (works on H2 dev + Postgres deploy).
- **`SpringDataNotificationRepository`** (derived `findByRecipientUserId` / `findByRecipientUserIdAndStatus`) + **`JpaNotificationRepository`** (`@Profile("jpa")`): `save` → `data.save` (insert fresh / update loaded under `@Version`); `lockForUpdate`/`unlock` no-ops; `nextId()` is a vestigial in-memory counter (no caller uses it — ids are UUIDs).
- **`MemoryNotificationRepository`** gated `@Profile("!jpa")`, and its **storage `HashMap` → `ConcurrentHashMap`** (it was the only Memory repo not thread-safe). That surfaced a latent issue — `ConcurrentHashMap` rejects null keys — so `findById` is now null-guarded (matching the JPA adapter and `MemorySessionRepository`).

## Contract test, written first (`test`)
`INotificationRepository` had none. New `INotificationRepositoryContractTest` covers save/findById (incl. null id), in-place update of a loaded notification, `findByRecipientAndStatus`, `findByRecipient`, `nextId` distinctness, and the acceptance — a **heterogeneous `data` payload (String/Integer/Double/Boolean/List/nested Map) round-trips through the JSON column** — run on **both** Memory and JPA-on-H2 (`@DataJpaTest`).

## Verification
- `./mvnw -Pno-vaadin test` → **1170 passing, 0 failures** (+18 Notification contract).
- **Dev boot (`dev`+`jpa`):** clean start ~6.1s, scenario **40/40**, notifications created/delivered through the JSON column during the run, 0 errors.

Closes #352.
