### PR TITLE
[V3-ORM-05] Map ProductionCompany to JPA (+ purchase-policy JSON converter)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
@@ -8,28 +8,82 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 import com.ticketing.system.Core.Domain.policies.purchase.AndPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicyJsonConverter;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.persistence.Version;
+
+// V3: mapped to JPA. companyId is an ASSIGNED @Id (minted by nextId(), never @GeneratedValue);
+// founderId is a plain by-id column; status is stored by name; @Version drives optimistic locking.
+// ownerIds and managers map to two @ElementCollection by-id side-tables (the owner/manager
+// mutual-exclusion rule stays enforced in checkInvariants, not at the DB). The recursive
+// purchasePolicy tree is stored as one JSON text column (PurchasePolicyJsonConverter). The
+// discountPolicies are empty company-level stubs carrying no state, so they are @Transient. A
+// protected no-arg ctor lets Hibernate hydrate; the public ctor still enforces the invariants.
+@Entity
+@Table(name = "companies")
 public class ProductionCompany implements InvariantChecked {
-    private final int companyId;
+    @Id
+    private int companyId;
     /**
      * The original creator of the company. Immutable: the founder cannot be
      * removed from {@link #ownerIds} and cannot self-resign. The founder
      * always remains an owner — the two roles are coupled by design.
      */
-    private final int founderId;
+    @Column(name = "founder_id", nullable = false)
+    private int founderId;
     /**
      * All current owners (includes {@link #founderId} at all times). Any owner
      * can add or remove another owner; non-founder owners can also self-resign.
      */
-    private final List<Integer> ownerIds;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "company_owner_ids", joinColumns = @JoinColumn(name = "company_id"))
+    @Column(name = "owner_id")
+    private List<Integer> ownerIds;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private CompanyStatus companyStatus;
+
+    @Column(nullable = false)
     private String name;
+
+    @Column
     private String description;
+
+    @Column
     private Double rating;
-    private List<DiscountPolicy> discountPolicies;
+
+    // Empty company-level policy stubs carry no state — not persisted; kept as an empty list.
+    @Transient
+    private List<DiscountPolicy> discountPolicies = new ArrayList<>();
+
+    @Convert(converter = PurchasePolicyJsonConverter.class)
+    @Column(name = "purchase_policy", columnDefinition = "text", nullable = false)
     private PurchasePolicy purchasePolicy;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "company_managers", joinColumns = @JoinColumn(name = "company_id"))
+    @Column(name = "manager_id")
     private List<Integer> managers;
-    
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected ProductionCompany() { }
+
     public ProductionCompany(int companyId, int founderId, String name, CompanyStatus companyStatus, String description, Double rating) {
         this.companyId = companyId;
         this.founderId = founderId;

--- a/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/PurchasePolicyJsonConverter.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/policies/purchase/PurchasePolicyJsonConverter.java
@@ -1,0 +1,90 @@
+package com.ticketing.system.Core.Domain.policies.purchase;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Serializes a {@link PurchasePolicy} tree to a single JSON text column and rebuilds it on load.
+ *
+ * <p>Purchase policies are a recursive Composite (And/Or over Age/Max/Min/None leaves) that are
+ * <em>evaluated</em>, never queried by sub-policy — so the whole tree is stored as JSON rather than
+ * spread across tables (V3 plan §6). Serialization walks the tree explicitly via the policies'
+ * existing getters and dispatches on a small {@code "type"} tag, so there is no reflection or
+ * polymorphic-deserialization magic; reconstruction calls the same public constructors recursively.
+ *
+ * <p>Shared by both policy owners — {@link com.ticketing.system.Core.Domain.company.ProductionCompany}
+ * (B5) and Event (B9). JPA instantiates the converter itself (it is not a Spring bean), so it holds
+ * its own {@link ObjectMapper}. Lives next to the policies it serializes — a domain-to-domain
+ * reference, not a downward one.
+ */
+@Converter
+public class PurchasePolicyJsonConverter implements AttributeConverter<PurchasePolicy, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(PurchasePolicy policy) {
+        try {
+            return MAPPER.writeValueAsString(toNode(policy == null ? new NoPurchasePolicy() : policy));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to serialize purchase policy to JSON", e);
+        }
+    }
+
+    @Override
+    public PurchasePolicy convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) {
+            return new NoPurchasePolicy();
+        }
+        try {
+            return fromNode(MAPPER.readTree(json));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to parse purchase policy JSON", e);
+        }
+    }
+
+    private JsonNode toNode(PurchasePolicy policy) {
+        ObjectNode node = MAPPER.createObjectNode();
+        if (policy instanceof NoPurchasePolicy) {
+            node.put("type", "none");
+        } else if (policy instanceof AgePurchasePolicy age) {
+            node.put("type", "age");
+            node.put("minimumAge", age.getMinimumAge());
+        } else if (policy instanceof MaxTicketsPurchasePolicy max) {
+            node.put("type", "maxTickets");
+            node.put("maximumTickets", max.getMaximumTickets());
+        } else if (policy instanceof MinTicketsPurchasePolicy min) {
+            node.put("type", "minTickets");
+            node.put("minimumTickets", min.getMinimumTickets());
+        } else if (policy instanceof AndPurchasePolicy and) {
+            node.put("type", "and");
+            node.set("left", toNode(and.getLeftPolicy()));
+            node.set("right", toNode(and.getRightPolicy()));
+        } else if (policy instanceof OrPurchasePolicy or) {
+            node.put("type", "or");
+            node.set("left", toNode(or.getLeftPolicy()));
+            node.set("right", toNode(or.getRightPolicy()));
+        } else {
+            throw new IllegalArgumentException("Unknown purchase policy type: " + policy.getClass().getName());
+        }
+        return node;
+    }
+
+    private PurchasePolicy fromNode(JsonNode node) {
+        String type = node.get("type").asText();
+        return switch (type) {
+            case "none" -> new NoPurchasePolicy();
+            case "age" -> new AgePurchasePolicy(node.get("minimumAge").asInt());
+            case "maxTickets" -> new MaxTicketsPurchasePolicy(node.get("maximumTickets").asInt());
+            case "minTickets" -> new MinTicketsPurchasePolicy(node.get("minimumTickets").asInt());
+            case "and" -> new AndPurchasePolicy(fromNode(node.get("left")), fromNode(node.get("right")));
+            case "or" -> new OrPurchasePolicy(fromNode(node.get("left")), fromNode(node.get("right")));
+            default -> throw new IllegalArgumentException("Unknown purchase policy type: " + type);
+        };
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepository.java
@@ -1,0 +1,103 @@
+package com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.company.CompanyStatus;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.exceptions.CompanyNotFoundException;
+
+/**
+ * JPA-backed {@link IProductionCompanyRepository} — active only in the {@code jpa} run/dev profile.
+ * Adapts the domain port onto Spring Data ({@link SpringDataProductionCompanyRepository}); the
+ * application layer depends only on {@code IProductionCompanyRepository}, never on Spring Data.
+ * Owner/manager id lists ({@code @ElementCollection}) and the purchase policy (JSON column) persist
+ * by cascade with the company.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops (concurrency via {@code @Version}).
+ * {@code save}/{@code updateCompany} delegate to {@code data.save} under {@code @Version} and are
+ * {@code @Transactional} so the adapter is self-sufficient before the service layer gains
+ * transactions (#359). {@link #nextId()} keeps the assigned-id design but seeds an in-memory counter
+ * from {@code max(companyId)} on first use, so ids survive a restart on a persistent database.
+ */
+@Repository
+@Profile("jpa")
+public class JpaProductionCompanyRepository implements IProductionCompanyRepository {
+
+    private final SpringDataProductionCompanyRepository data;
+    private final AtomicInteger idSequence = new AtomicInteger(0);
+    private volatile boolean seeded = false;
+
+    public JpaProductionCompanyRepository(SpringDataProductionCompanyRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(Integer id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(Integer id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public void save(ProductionCompany company) {
+        data.save(company);
+    }
+
+    @Override
+    @Transactional
+    public void updateCompany(ProductionCompany company) {
+        data.save(company);
+    }
+
+    @Override
+    public ProductionCompany getCompanyById(int companyId) {
+        return data.findById(companyId).orElseThrow(() -> new CompanyNotFoundException(companyId));
+    }
+
+    @Override
+    public Optional<ProductionCompany> findByName(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        return data.findByName(name);
+    }
+
+    @Override
+    public boolean existsByName(String name) {
+        return name != null && data.existsByName(name);
+    }
+
+    @Override
+    public List<ProductionCompany> findActive() {
+        return data.findByCompanyStatus(CompanyStatus.ACTIVE);
+    }
+
+    @Override
+    public List<ProductionCompany> findByFounder(int founderUserId) {
+        return data.findByFounderId(founderUserId);
+    }
+
+    @Override
+    public int nextId() {
+        ensureSeeded();
+        return idSequence.incrementAndGet();
+    }
+
+    private void ensureSeeded() {
+        if (!seeded) {
+            synchronized (this) {
+                if (!seeded) {
+                    idSequence.set(data.findMaxCompanyId());
+                    seeded = true;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.company.CompanyStatus;
@@ -15,10 +16,13 @@ import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
 
 /**
- * In-memory {@link IProductionCompanyRepository} for V1. Lets Spring wire
+ * In-memory {@link IProductionCompanyRepository}. Lets Spring wire
  * CatalogService / CompanyManagementService / EventManagementService.
+ * {@code @Profile("!jpa")}: the {@code jpa} run/dev profile swaps in
+ * {@link JpaProductionCompanyRepository} instead.
  */
 @Repository
+@Profile("!jpa")
 public class MemoryProductionCompanyRepository implements IProductionCompanyRepository {
 
     private final Map<Integer, ProductionCompany> companiesById = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/SpringDataProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/SpringDataProductionCompanyRepository.java
@@ -1,0 +1,32 @@
+package com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.ticketing.system.Core.Domain.company.CompanyStatus;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+
+/**
+ * Spring Data JPA repository for {@link ProductionCompany} — the auto-implemented SQL backing
+ * {@link JpaProductionCompanyRepository}. The application layer never sees this type; it depends
+ * only on the {@code IProductionCompanyRepository} domain port. Owner/manager id lists persist as
+ * {@code @ElementCollection} side-tables and the purchase policy as a JSON column, all by cascade
+ * with the company.
+ */
+public interface SpringDataProductionCompanyRepository extends JpaRepository<ProductionCompany, Integer> {
+
+    Optional<ProductionCompany> findByName(String name);
+
+    boolean existsByName(String name);
+
+    List<ProductionCompany> findByCompanyStatus(CompanyStatus status);
+
+    List<ProductionCompany> findByFounderId(int founderId);
+
+    /** Highest existing companyId (0 when empty) — seeds the assigned-id sequence across restarts. */
+    @Query("select coalesce(max(c.companyId), 0) from ProductionCompany c")
+    int findMaxCompanyId();
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/IProductionCompanyRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/IProductionCompanyRepositoryContractTest.java
@@ -1,0 +1,134 @@
+package com.ticketing.system.unit.infrastructure.persistence.ProductionCompanyPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.company.CompanyStatus;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.policies.purchase.AgePurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.AndPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.MaxTicketsPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicyJsonConverter;
+
+/**
+ * Contract every {@link IProductionCompanyRepository} implementation must satisfy. The Memory and
+ * JPA adapters each subclass this with their own {@link #newRepository()} factory; the tests are
+ * reused. The owner/manager and policy round-trip tests pin the acceptance: the two id lists and the
+ * purchase-policy tree survive save/reload on both adapters.
+ */
+abstract class IProductionCompanyRepositoryContractTest {
+
+    protected abstract IProductionCompanyRepository newRepository();
+
+    private IProductionCompanyRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    private ProductionCompany company(int id, int founderId, String name, CompanyStatus status) {
+        return new ProductionCompany(id, founderId, name, status, "a description", 4.5);
+    }
+
+    @Test
+    void save_thenGetCompanyById_returnsTheSavedCompany() {
+        repo.save(company(1, 7, "Acme", CompanyStatus.ACTIVE));
+
+        ProductionCompany found = repo.getCompanyById(1);
+        assertEquals("Acme", found.getName());
+        assertEquals(7, found.getFounderId());
+        assertEquals(CompanyStatus.ACTIVE, found.getStatus());
+    }
+
+    @Test
+    void getCompanyById_throwsWhenMissing() {
+        assertThrows(RuntimeException.class, () -> repo.getCompanyById(9999));
+    }
+
+    @Test
+    void findByName_returnsSavedAndEmptyOtherwise() {
+        repo.save(company(1, 7, "Acme", CompanyStatus.ACTIVE));
+
+        assertTrue(repo.findByName("Acme").isPresent());
+        assertFalse(repo.findByName("Ghost").isPresent());
+        assertFalse(repo.findByName(null).isPresent());
+    }
+
+    @Test
+    void existsByName_trueAfterSaveFalseOtherwise() {
+        assertFalse(repo.existsByName("Acme"));
+        repo.save(company(1, 7, "Acme", CompanyStatus.ACTIVE));
+        assertTrue(repo.existsByName("Acme"));
+    }
+
+    @Test
+    void findActive_returnsOnlyActiveCompanies() {
+        repo.save(company(1, 7, "ActiveCo", CompanyStatus.ACTIVE));
+        repo.save(company(2, 7, "InactiveCo", CompanyStatus.INACTIVE));
+
+        assertEquals(Set.of("ActiveCo"),
+                repo.findActive().stream().map(ProductionCompany::getName).collect(java.util.stream.Collectors.toSet()));
+    }
+
+    @Test
+    void findByFounder_returnsCompaniesFoundedByThatUser() {
+        repo.save(company(1, 7, "First", CompanyStatus.ACTIVE));
+        repo.save(company(2, 7, "Second", CompanyStatus.ACTIVE));
+        repo.save(company(3, 9, "Other", CompanyStatus.ACTIVE));
+
+        assertEquals(Set.of("First", "Second"),
+                repo.findByFounder(7).stream().map(ProductionCompany::getName).collect(java.util.stream.Collectors.toSet()));
+        assertTrue(repo.findByFounder(123).isEmpty());
+    }
+
+    @Test
+    void nextId_producesDistinctIncreasingValues() {
+        int a = repo.nextId();
+        int b = repo.nextId();
+        assertNotEquals(a, b);
+        assertTrue(b > a);
+    }
+
+    @Test
+    void save_persistsOwnerAndManagerLists() {
+        ProductionCompany c = company(1, 7, "Acme", CompanyStatus.ACTIVE); // founder 7 is the first owner
+        c.addOwner(7, 8);   // owner 7 adds owner 8
+        c.addManager(9);    // 9 becomes a manager
+        repo.save(c);
+
+        ProductionCompany found = repo.getCompanyById(1);
+        assertEquals(Set.of(7, 8), new HashSet<>(found.getOwnerIds()));
+        assertEquals(Set.of(9), new HashSet<>(found.getManagers()));
+    }
+
+    @Test
+    void save_roundTripsTheDefaultNoPurchasePolicy() {
+        repo.save(company(1, 7, "Acme", CompanyStatus.ACTIVE));
+        assertTrue(repo.getCompanyById(1).getPurchasePolicy() instanceof NoPurchasePolicy);
+    }
+
+    @Test
+    void save_roundTripsAComposedPurchasePolicyTree() {
+        ProductionCompany c = company(1, 7, "Acme", CompanyStatus.ACTIVE);
+        c.setPurchasePolicy(new AndPurchasePolicy(new AgePurchasePolicy(18), new MaxTicketsPurchasePolicy(4)));
+        repo.save(c);
+
+        ProductionCompany found = repo.getCompanyById(1);
+        // Structural equality: the reloaded tree serializes identically to the original.
+        PurchasePolicyJsonConverter converter = new PurchasePolicyJsonConverter();
+        assertEquals(converter.convertToDatabaseColumn(c.getPurchasePolicy()),
+                converter.convertToDatabaseColumn(found.getPurchasePolicy()));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepositoryContractTest.java
@@ -1,0 +1,41 @@
+package com.ticketing.system.unit.infrastructure.persistence.ProductionCompanyPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence.JpaProductionCompanyRepository;
+import com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence.SpringDataProductionCompanyRepository;
+
+/**
+ * Runs the {@link IProductionCompanyRepositoryContractTest} suite against the JPA adapter on an
+ * embedded H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaProductionCompanyRepository};
+ * {@code @DataJpaTest} provides H2 + real {@code companies}, {@code company_owner_ids} and
+ * {@code company_managers} tables (plus the JSON {@code purchase_policy} column). Each test starts
+ * from an empty schema ({@link #cleanTable()}) so the suite is order-independent. CI never touches a
+ * real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaProductionCompanyRepository.class)
+class JpaProductionCompanyRepositoryContractTest extends IProductionCompanyRepositoryContractTest {
+
+    @Autowired
+    private JpaProductionCompanyRepository repository;
+
+    @Autowired
+    private SpringDataProductionCompanyRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IProductionCompanyRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepositoryContractTest.java
@@ -1,0 +1,12 @@
+package com.ticketing.system.unit.infrastructure.persistence.ProductionCompanyPersistence;
+
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence.MemoryProductionCompanyRepository;
+
+class MemoryProductionCompanyRepositoryContractTest extends IProductionCompanyRepositoryContractTest {
+
+    @Override
+    protected IProductionCompanyRepository newRepository() {
+        return new MemoryProductionCompanyRepository();
+    }
+}


### PR DESCRIPTION
Maps the **ProductionCompany** aggregate to JPA, including its two id-list collections and the recursive **purchase-policy tree → JSON column** (the converter B9/Event will reuse). Sixth Lane-B slice; part of the V3 epic #347, depends on #349 (merged).

## What
- **`@Entity` (`companies`)**: assigned `int @Id` (minted by `nextId()`), `founderId` by-id column, `CompanyStatus` stored by name, `@Version`.
- **`ownerIds` / `managers` (`List<Integer>`) → two `@ElementCollection` by-id side-tables** (`company_owner_ids`, `company_managers`), EAGER. The owner/manager mutual-exclusion invariant stays **app-enforced** in `checkInvariants` (not at the DB), per the issue. No `MultipleBagFetchException` — element collections load via separate selects.
- **`discountPolicies`** are the empty `company/` stubs (zero state) → `@Transient`, kept as an empty list ("treat as no-state").
- **`purchasePolicy` → JSON text column** via a new **`PurchasePolicyJsonConverter`**: it walks the recursive Composite (And/Or over Age/Max/Min/None) and serializes it as plain JSON, rebuilding it on load via the policies' existing getters — no reflection or polymorphic-deser magic. Lives next to the policies (domain-to-domain) and is **shared with B9 (Event)**.
- **`JpaProductionCompanyRepository`** (`@Profile("jpa")`): derived `findByName`/`existsByName`/`findByCompanyStatus`/`findByFounderId`; `getCompanyById` throws `CompanyNotFoundException`; `nextId()` seeds from `max(companyId)` so ids survive a restart. `MemoryProductionCompanyRepository` gated `@Profile("!jpa")`.

## Contract test (`test`)
`IProductionCompanyRepository` had none. New `IProductionCompanyRepositoryContractTest` covers the CRUD/query methods plus the acceptance — owner + manager lists persist, and the purchase-policy tree round-trips (default `NoPurchasePolicy` **and** a composed `And(Age(18), MaxTickets(4))` tree) — run on **both** Memory and JPA-on-H2 (`@DataJpaTest`).

## Verification
- `./mvnw -Pno-vaadin test` → **1203 passing, 0 failures** (+20 ProductionCompany contract).
- **Dev boot (`dev`+`jpa`):** clean ~6.3s, scenario **40/40**, companies persisted through the two id-list tables + the JSON policy column, 0 errors.

Closes #354.
