### PR TITLE
[V3-ORM-06] Map OrderReceipt to JPA (+ remove getReceiptsById leak)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/orders/IOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/orders/IOrderReceiptRepository.java
@@ -1,7 +1,6 @@
 package com.ticketing.system.Core.Domain.orders;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
@@ -30,6 +29,4 @@ public interface IOrderReceiptRepository extends IRepository<OrderReceipt, Integ
     List<OrderReceipt> findGlobal(GlobalHistoryFiltersDTO filters);
 
     List<OrderReceipt> findByEventId(int eventId);
-    
-    Map<Integer, OrderReceipt> getReceiptsById();
 }

--- a/src/main/java/com/ticketing/system/Core/Domain/orders/OrderReceipt.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/orders/OrderReceipt.java
@@ -8,23 +8,62 @@ import java.util.Optional;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+// V3: mapped to JPA. receiptId is an ASSIGNED @Id (minted by nextId(), never @GeneratedValue);
+// userid is a nullable by-id column (member receipts) and guestEmail/guestSessionId identify guest
+// receipts — the member/guest XOR stays enforced in checkInvariants, not at the DB. @Version drives
+// optimistic locking. receiptLines and transactionRecords are owned value lists, each an
+// @ElementCollection of @Embeddable in its own side-table, loaded eagerly so a detached receipt is
+// fully usable. A protected no-arg ctor lets Hibernate hydrate; the factories still enforce the
+// invariants.
+@Entity
+@Table(name = "receipts")
 public class OrderReceipt implements InvariantChecked {
 
-    private final int receiptId;
+    @Id
+    private int receiptId;
 
     // Member receipt identity
-    private final Integer userid;          // nullable for guest receipts, positive integer for member receipts
+    @Column(name = "user_id")
+    private Integer userid;                // nullable for guest receipts, positive integer for member receipts
 
     // Guest receipt identity
-    private final String guestEmail;       // nullable for member receipts, non-null/non-blank for guest receipts
-    private final String guestSessionId;   // nullable for member receipts, non-null/non-blank for guest receipts
+    @Column(name = "guest_email")
+    private String guestEmail;             // nullable for member receipts, non-null/non-blank for guest receipts
+    @Column(name = "guest_session_id")
+    private String guestSessionId;         // nullable for member receipts, non-null/non-blank for guest receipts
 
-    private final List<ReceiptLine> receiptLines;
-    private final List<TransactionRecord> transactionRecords;
-    private final double totalPrice;
-    private final LocalDateTime purchaseTime;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "receipt_lines", joinColumns = @JoinColumn(name = "receipt_id"))
+    private List<ReceiptLine> receiptLines;
 
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "receipt_transactions", joinColumns = @JoinColumn(name = "receipt_id"))
+    private List<TransactionRecord> transactionRecords;
+
+    @Column(name = "total_price", nullable = false)
+    private double totalPrice;
+
+    @Column(name = "purchase_time", nullable = false)
+    private LocalDateTime purchaseTime;
+
+    @Column(name = "is_refunded", nullable = false)
     private boolean isRefunded = false;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected OrderReceipt() { }
 
     private OrderReceipt(int receiptId, Integer userid, String guestEmail, String guestSessionId, double totalPrice,
             List<ReceiptLine> receiptLines, List<TransactionRecord> transactionRecords) {
@@ -61,7 +100,9 @@ public class OrderReceipt implements InvariantChecked {
         this.guestEmail = guestEmail;
         this.guestSessionId = guestSessionId;
         this.totalPrice = totalPrice;
-        this.receiptLines = List.copyOf(receiptLines);
+        // Mutable defensive copy — Hibernate manages the @ElementCollection; the getter still
+        // returns an immutable view, so callers cannot mutate the internal list.
+        this.receiptLines = new ArrayList<>(receiptLines);
         this.transactionRecords = new ArrayList<>();
         this.purchaseTime = LocalDateTime.now();
 

--- a/src/main/java/com/ticketing/system/Core/Domain/orders/ReceiptLine.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/orders/ReceiptLine.java
@@ -4,14 +4,38 @@ import java.time.LocalDateTime;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+/**
+ * V3: an {@code @Embeddable} value object — one row in the owning OrderReceipt's
+ * {@code receipt_lines} element collection (no identity of its own). Fields are non-final
+ * with a protected no-arg ctor so Hibernate can hydrate; the public ctor still enforces
+ * the invariants.
+ */
+@Embeddable
 public class ReceiptLine implements InvariantChecked {
 
-    private final int ticketId;
-    private final double price;
-    private final int eventid;
-    private final LocalDateTime addedAt;
-    private final int zoneId;
-    private final String seatNumber;
+    @Column(name = "ticket_id", nullable = false)
+    private int ticketId;
+
+    @Column(nullable = false)
+    private double price;
+
+    @Column(name = "event_id", nullable = false)
+    private int eventid;
+
+    @Column(name = "added_at", nullable = false)
+    private LocalDateTime addedAt;
+
+    @Column(name = "zone_id", nullable = false)
+    private int zoneId;
+
+    @Column(name = "seat_number")
+    private String seatNumber;
+
+    /** For JPA only — do not call from application code. */
+    protected ReceiptLine() { }
 
     public ReceiptLine(int ticketId, double price, int eventid, int zoneId, String seatNumber, LocalDateTime addedAt) {
         this.ticketId = ticketId;

--- a/src/main/java/com/ticketing/system/Core/Domain/orders/TransactionRecord.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/orders/TransactionRecord.java
@@ -4,6 +4,11 @@ import java.time.LocalDateTime;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+
 /**
  * Immutable audit record for an external transaction related to an OrderReceipt.
  *
@@ -11,7 +16,12 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
  * application/external-port DTOs. This value object stores only the stable domain
  * facts needed for purchase history, refunds, and audit.
  */
-public final class TransactionRecord implements InvariantChecked {
+// V3: an @Embeddable value object — one row in the owning OrderReceipt's receipt_transactions
+// element collection (no identity of its own). The class and its fields are non-final with a
+// protected no-arg ctor so Hibernate can hydrate; the private ctor + factories still enforce the
+// invariants for application-created records.
+@Embeddable
+public class TransactionRecord implements InvariantChecked {
 
     public enum TransactionType {
         PAYMENT_CHARGE,    // corresponds to a successful charge via IPaymentGateway. Amount should be positive.
@@ -19,12 +29,27 @@ public final class TransactionRecord implements InvariantChecked {
         REFUND             // corresponds to a successful refund via IPaymentGateway. Amount should be positive, representing the refunded amount.
     }
 
-    private final TransactionType type;
-    private final String providerName;
-    private final String externalTransactionId;
-    private final double amount;
-    private final String currency;
-    private final LocalDateTime timestamp;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transaction_type", nullable = false)
+    private TransactionType type;
+
+    @Column(name = "provider_name", nullable = false)
+    private String providerName;
+
+    @Column(name = "external_transaction_id", nullable = false)
+    private String externalTransactionId;
+
+    @Column(nullable = false)
+    private double amount;
+
+    @Column
+    private String currency;
+
+    @Column(name = "transaction_timestamp", nullable = false)
+    private LocalDateTime timestamp;
+
+    /** For JPA only — do not call from application code. */
+    protected TransactionRecord() { }
 
     private TransactionRecord(TransactionType type, String providerName, String externalTransactionId, double amount, String currency, LocalDateTime timestamp) {
         this.type = type;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepository.java
@@ -1,0 +1,120 @@
+package com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+import jakarta.persistence.criteria.Predicate;
+
+/**
+ * JPA-backed {@link IOrderReceiptRepository} — active only in the {@code jpa} run/dev profile.
+ * Adapts the domain port onto Spring Data ({@link SpringDataOrderReceiptRepository}); the application
+ * layer depends only on {@code IOrderReceiptRepository}, never on Spring Data. Owned receipt-line and
+ * transaction value lists ({@code @ElementCollection}) persist by cascade with the receipt.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops (concurrency via {@code @Version}). {@code save}
+ * delegates to {@code data.save} under {@code @Version} and is {@code @Transactional}. {@link #nextId()}
+ * keeps the assigned-id design but seeds an in-memory counter from {@code max(receiptId)} on first use
+ * so ids survive a restart. {@link #findGlobal} assembles the optional admin filters into a dynamic
+ * {@link Specification} (it ignores {@code companyId}, matching the in-memory impl — a receipt does not
+ * know company ownership directly).
+ */
+@Repository
+@Profile("jpa")
+public class JpaOrderReceiptRepository implements IOrderReceiptRepository {
+
+    private final SpringDataOrderReceiptRepository data;
+    private final AtomicInteger idSequence = new AtomicInteger(0);
+    private volatile boolean seeded = false;
+
+    public JpaOrderReceiptRepository(SpringDataOrderReceiptRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(Integer id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(Integer id) { /* no-op */ }
+
+    @Override
+    public int nextId() {
+        ensureSeeded();
+        return idSequence.incrementAndGet();
+    }
+
+    private void ensureSeeded() {
+        if (!seeded) {
+            synchronized (this) {
+                if (!seeded) {
+                    idSequence.set(data.findMaxReceiptId());
+                    seeded = true;
+                }
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public void save(OrderReceipt orderReceipt) {
+        data.save(orderReceipt);
+    }
+
+    @Override
+    public Optional<OrderReceipt> findByOrderReceiptId(int orderReceiptId) {
+        return data.findById(orderReceiptId);
+    }
+
+    @Override
+    public List<OrderReceipt> findByHolderUserId(int holderUserId) {
+        return data.findByUserid(holderUserId);
+    }
+
+    @Override
+    public List<OrderReceipt> findByEventIds(List<Integer> eventIds) {
+        if (eventIds == null || eventIds.isEmpty()) {
+            return List.of();
+        }
+        return data.findByEventIds(eventIds);
+    }
+
+    @Override
+    public List<OrderReceipt> findByEventId(int eventId) {
+        return data.findByEventId(eventId);
+    }
+
+    @Override
+    public List<OrderReceipt> findGlobal(GlobalHistoryFiltersDTO filters) {
+        if (filters == null) {
+            return data.findAll();
+        }
+        Specification<OrderReceipt> spec = (root, query, cb) -> {
+            query.distinct(true);
+            List<Predicate> predicates = new ArrayList<>();
+            if (filters.buyerUserId() != null) {
+                predicates.add(cb.equal(root.get("userid"), filters.buyerUserId()));
+            }
+            if (filters.eventIds() != null && !filters.eventIds().isEmpty()) {
+                predicates.add(root.join("receiptLines").get("eventid").in(filters.eventIds()));
+            }
+            if (filters.fromDate() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("purchaseTime"), filters.fromDate().atStartOfDay()));
+            }
+            if (filters.toDate() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("purchaseTime"), filters.toDate().atTime(23, 59, 59)));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+        return data.findAll(spec);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepository.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
@@ -15,14 +16,13 @@ import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 
 /**
- * In-memory {@link IOrderReceiptRepository} for V1. Lets Spring wire
+ * In-memory {@link IOrderReceiptRepository}. Lets Spring wire
  * CheckoutService / MemberAccountService / SystemAdminService.
- *
- * <p>Receipts are keyed by their {@code receiptId} converted to String —
- * the interface signatures use String keys throughout. UC-31's
- * filter/page/size global query throws until real admin reporting is built.
+ * {@code @Profile("!jpa")}: the {@code jpa} run/dev profile swaps in
+ * {@link JpaOrderReceiptRepository} instead.
  */
 @Repository
+@Profile("!jpa")
 public class MemoryOrderReceiptRepository implements IOrderReceiptRepository {
 
     private final Map<Integer, OrderReceipt> receiptsById = new ConcurrentHashMap<>();
@@ -101,13 +101,6 @@ public class MemoryOrderReceiptRepository implements IOrderReceiptRepository {
     }
 
     
-
-    public Map<Integer, OrderReceipt> getReceiptsById() {
-        return receiptsById;
-    }
-
-
-
 
 
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/SpringDataOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/SpringDataOrderReceiptRepository.java
@@ -1,0 +1,36 @@
+package com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+/**
+ * Spring Data JPA repository for {@link OrderReceipt} — the auto-implemented SQL backing
+ * {@link JpaOrderReceiptRepository}. The application layer never sees this type; it depends only on
+ * the {@code IOrderReceiptRepository} domain port. Owned receipt-line and transaction value lists
+ * persist as {@code @ElementCollection} side-tables by cascade with the receipt.
+ *
+ * <p>{@link JpaSpecificationExecutor} backs the admin global-history query, whose optional filters
+ * are assembled dynamically. The event-id lookups join into the receipt-line rows.
+ */
+public interface SpringDataOrderReceiptRepository
+        extends JpaRepository<OrderReceipt, Integer>, JpaSpecificationExecutor<OrderReceipt> {
+
+    /** Member receipts for a buyer (guest receipts have a null userid, so they are excluded). */
+    List<OrderReceipt> findByUserid(int userid);
+
+    @Query("select distinct r from OrderReceipt r join r.receiptLines l where l.eventid = :eventId")
+    List<OrderReceipt> findByEventId(@Param("eventId") int eventId);
+
+    @Query("select distinct r from OrderReceipt r join r.receiptLines l where l.eventid in :eventIds")
+    List<OrderReceipt> findByEventIds(@Param("eventIds") List<Integer> eventIds);
+
+    /** Highest existing receiptId (0 when empty) — seeds the assigned-id sequence across restarts. */
+    @Query("select coalesce(max(r.receiptId), 0) from OrderReceipt r")
+    int findMaxReceiptId();
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/IOrderReceiptRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/IOrderReceiptRepositoryContractTest.java
@@ -1,0 +1,141 @@
+package com.ticketing.system.unit.infrastructure.persistence.OrderReceiptPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+import com.ticketing.system.Core.Domain.orders.ReceiptLine;
+import com.ticketing.system.Core.Domain.orders.TransactionRecord;
+import com.ticketing.system.Core.Domain.orders.TransactionRecord.TransactionType;
+
+/**
+ * Contract every {@link IOrderReceiptRepository} implementation must satisfy. The Memory and JPA
+ * adapters each subclass this with their own {@link #newRepository()} factory; the tests are reused.
+ * The lines/transactions test pins the acceptance: the owned value lists survive save/reload on both
+ * adapters.
+ */
+abstract class IOrderReceiptRepositoryContractTest {
+
+    protected abstract IOrderReceiptRepository newRepository();
+
+    private IOrderReceiptRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    private ReceiptLine line(int ticketId, int eventId) {
+        return new ReceiptLine(ticketId, 50.0, eventId, 1, "A1", LocalDateTime.now());
+    }
+
+    private OrderReceipt member(int receiptId, int userId, int eventId) {
+        return OrderReceipt.forMember(receiptId, userId, 50.0, List.of(line(receiptId * 10, eventId)));
+    }
+
+    private Set<Integer> ids(List<OrderReceipt> rs) {
+        return rs.stream().map(OrderReceipt::getId).collect(Collectors.toSet());
+    }
+
+    @Test
+    void nextId_producesDistinctIncreasingValues() {
+        int a = repo.nextId();
+        int b = repo.nextId();
+        assertNotEquals(a, b);
+        assertTrue(b > a);
+    }
+
+    @Test
+    void save_thenFindById_returnsTheMemberReceipt() {
+        repo.save(member(1, 7, 5));
+
+        OrderReceipt found = repo.findByOrderReceiptId(1).orElseThrow();
+        assertEquals(7, found.getUserid());
+        assertTrue(found.isMemberReceipt());
+    }
+
+    @Test
+    void save_thenFindById_returnsTheGuestReceipt() {
+        repo.save(OrderReceipt.forGuest("g@example.com", "sess-1", 2, 50.0, List.of(line(20, 5))));
+
+        OrderReceipt found = repo.findByOrderReceiptId(2).orElseThrow();
+        assertTrue(found.isGuestReceipt());
+        assertEquals("g@example.com", found.getGuestEmail());
+    }
+
+    @Test
+    void findById_emptyWhenMissing() {
+        assertFalse(repo.findByOrderReceiptId(9999).isPresent());
+    }
+
+    @Test
+    void save_persistsReceiptLinesAndTransactions() {
+        OrderReceipt r = OrderReceipt.forMember(1, 7, 100.0, List.of(line(10, 5), line(11, 5)));
+        r.addTransaction(TransactionRecord.paymentCharge(999, "WSEP", 100.0, "ILS", LocalDateTime.now()));
+        repo.save(r);
+
+        OrderReceipt found = repo.findByOrderReceiptId(1).orElseThrow();
+        assertEquals(2, found.getReceiptLines().size());
+        assertTrue(found.getReceiptLines().stream()
+                .anyMatch(l -> l.getTicketId() == 10 && l.getEventId() == 5 && "A1".equals(l.getSeatNumber())));
+        assertEquals(1, found.getTransactionRecords().size());
+        TransactionRecord tx = found.getTransactionRecords().get(0);
+        assertEquals(TransactionType.PAYMENT_CHARGE, tx.getType());
+        assertEquals("999", tx.getExternalTransactionId());
+        assertEquals("ILS", tx.getCurrency());
+    }
+
+    @Test
+    void findByHolderUserId_returnsMemberReceiptsForThatBuyer() {
+        repo.save(member(1, 7, 5));
+        repo.save(member(2, 7, 6));
+        repo.save(member(3, 9, 5));
+        repo.save(OrderReceipt.forGuest("g@example.com", "sess-1", 4, 50.0, List.of(line(40, 5))));
+
+        assertEquals(Set.of(1, 2), ids(repo.findByHolderUserId(7)));
+        assertTrue(repo.findByHolderUserId(123).isEmpty());
+    }
+
+    @Test
+    void findByEventId_returnsReceiptsContainingThatEvent() {
+        repo.save(member(1, 7, 5));
+        repo.save(member(2, 7, 6));
+
+        assertEquals(Set.of(1), ids(repo.findByEventId(5)));
+        assertTrue(repo.findByEventId(999).isEmpty());
+    }
+
+    @Test
+    void findByEventIds_returnsReceiptsContainingAnyOfThoseEvents() {
+        repo.save(member(1, 7, 5));
+        repo.save(member(2, 7, 6));
+        repo.save(member(3, 7, 8));
+
+        assertEquals(Set.of(1, 2), ids(repo.findByEventIds(List.of(5, 6))));
+        assertTrue(repo.findByEventIds(List.of()).isEmpty());
+    }
+
+    @Test
+    void findGlobal_noFiltersReturnsAll_filterByBuyerNarrows() {
+        repo.save(member(1, 7, 5));
+        repo.save(member(2, 9, 6));
+
+        assertEquals(Set.of(1, 2), ids(repo.findGlobal(null)));
+        assertEquals(Set.of(1),
+                ids(repo.findGlobal(new GlobalHistoryFiltersDTO(7, null, null, null, null))));
+        assertEquals(Set.of(2),
+                ids(repo.findGlobal(new GlobalHistoryFiltersDTO(null, null, List.of(6), null, null))));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepositoryContractTest.java
@@ -1,0 +1,40 @@
+package com.ticketing.system.unit.infrastructure.persistence.OrderReceiptPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.JpaOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.SpringDataOrderReceiptRepository;
+
+/**
+ * Runs the {@link IOrderReceiptRepositoryContractTest} suite against the JPA adapter on an embedded
+ * H2 schema. {@code @ActiveProfiles("jpa")} activates {@link JpaOrderReceiptRepository};
+ * {@code @DataJpaTest} provides H2 + real {@code receipts}, {@code receipt_lines} and
+ * {@code receipt_transactions} tables. Each test starts from an empty schema ({@link #cleanTable()})
+ * so the suite is order-independent. CI never touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaOrderReceiptRepository.class)
+class JpaOrderReceiptRepositoryContractTest extends IOrderReceiptRepositoryContractTest {
+
+    @Autowired
+    private JpaOrderReceiptRepository repository;
+
+    @Autowired
+    private SpringDataOrderReceiptRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IOrderReceiptRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/OrderReceiptPersistence/MemoryOrderReceiptRepositoryContractTest.java
@@ -1,0 +1,12 @@
+package com.ticketing.system.unit.infrastructure.persistence.OrderReceiptPersistence;
+
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.MemoryOrderReceiptRepository;
+
+class MemoryOrderReceiptRepositoryContractTest extends IOrderReceiptRepositoryContractTest {
+
+    @Override
+    protected IOrderReceiptRepository newRepository() {
+        return new MemoryOrderReceiptRepository();
+    }
+}


### PR DESCRIPTION
Maps the **OrderReceipt** aggregate (+ owned `ReceiptLine` / `TransactionRecord`) to JPA, and **removes the `getReceiptsById` live-map leak** first. Seventh Lane-B slice; part of the V3 epic #347, depends on #349 (merged). First slice using `@Embeddable` value lists.

## What
- **Prerequisite — leak removed**: deleted `IOrderReceiptRepository.getReceiptsById()` (it returned the live in-memory `Map`, which a JPA impl can't honor). It had **no callers**, so no refactor was needed.
- **`OrderReceipt` → `@Entity` (`receipts`)**: assigned `int @Id` (minted by `nextId()`), nullable `userid` by-id column (members) + `guestEmail`/`guestSessionId` (guests) — the **member/guest XOR stays app-enforced** in `checkInvariants`. `@Version`.
- **`ReceiptLine` + `TransactionRecord` → `@Embeddable` value objects**, each an `@ElementCollection` in its own side-table (`receipt_lines` / `receipt_transactions`), EAGER. `TransactionType` stored by name. Protected ctors + non-final fields for Hibernate; the factories still enforce invariants. No `MultipleBagFetchException`.
- **`JpaOrderReceiptRepository`** (`@Profile("jpa")`): `findByUserid`, event-id `@Query` joins into the line rows, and `findGlobal` built as a dynamic `Specification` over the optional admin filters (ignoring `companyId`, as the in-memory impl does). `nextId()` seeds from `max(receiptId)` so ids survive a restart. `MemoryOrderReceiptRepository` gated `@Profile("!jpa")`.

## id-ownership decision
Kept **`nextId()` + caller-assigned** (consistent with User #353 and Company #354) per your call.

## Contract test (`test`)
`IOrderReceiptRepository` had none. New `IOrderReceiptRepositoryContractTest` covers `nextId`, save/find for member **and** guest receipts, `findByHolderUserId`, the event-id queries, `findGlobal` (no-filter + buyer/event filters), and the acceptance — **lines + transaction records persist and round-trip** (incl. the nested `TransactionType`). Run on **both** Memory and JPA-on-H2 (`@DataJpaTest`).

## Verification
- `./mvnw -Pno-vaadin test` → **1221 passing, 0 failures** (+18 OrderReceipt contract).
- **Dev boot (`dev`+`jpa`):** clean ~6.5s, scenario **40/40**, purchases persisted as receipts with lines + transactions, 0 errors.

Closes #355.
