### PR TITLE
[V3-ORM-07] Map Conversation + Message to JPA

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/messaging/Conversation.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/messaging/Conversation.java
@@ -11,6 +11,22 @@ import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionExcepti
 import com.ticketing.system.Core.Domain.exceptions.MessageNotFoundException;
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 // Aggregate root for the centralized messaging subsystem.
 // Replaces the per-User MessageInbox, per-Company Inbox, and the standalone Complaint aggregate.
 //
@@ -18,24 +34,59 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 // (MEMBER/COMPANY/ADMIN) or a broadcast descriptor (ADMIN_GROUP / BROADCAST_MEMBERS / SYSTEM).
 //
 // Cross-aggregate references by ID per course rules — never holds direct refs to User / ProductionCompany / Admin.
+// V3: mapped to JPA. conversationId is an ASSIGNED @Id (a UUID); type/status and the two participant
+// types are stored by name. The polymorphic participants stay as plain (id, type) by-id column pairs
+// — never @ManyToOne. @Version drives optimistic locking. messages are owned children
+// (@OneToMany cascade-all + orphan-removal) kept in send order via @OrderColumn, loaded eagerly so a
+// detached Conversation is fully usable. A protected no-arg ctor lets Hibernate hydrate; the public
+// ctor still enforces the invariants.
+@Entity
+@Table(name = "conversations")
 public class Conversation implements InvariantChecked {
 
-    private final String conversationId;
-    private final ConversationType type;
+    @Id
+    private String conversationId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ConversationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ConversationStatus status;
 
     // Initiator (the party that started the thread).
-    private final int initiatorId;
-    private final ParticipantType initiatorType;
+    @Column(name = "initiator_id", nullable = false)
+    private int initiatorId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "initiator_type", nullable = false)
+    private ParticipantType initiatorType;
 
     // Counterparty (the recipient — may be a specific entity or a group descriptor).
-    private final int counterpartyId;        // 0 / sentinel when counterpartyType is a group
-    private final ParticipantType counterpartyType;
+    @Column(name = "counterparty_id", nullable = false)
+    private int counterpartyId;        // 0 / sentinel when counterpartyType is a group
+    @Enumerated(EnumType.STRING)
+    @Column(name = "counterparty_type", nullable = false)
+    private ParticipantType counterpartyType;
 
-    private final String subject;
-    private final LocalDateTime createdAt;
+    @Column
+    private String subject;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Column(name = "last_message_at", nullable = false)
     private LocalDateTime lastMessageAt;
-    private final List<Message> messages;
+
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "conversation_id")
+    @OrderColumn(name = "message_order")
+    @Fetch(FetchMode.SUBSELECT)
+    private List<Message> messages;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Conversation() { }
 
     public Conversation(String conversationId, ConversationType type,
                         int initiatorId, ParticipantType initiatorType,

--- a/src/main/java/com/ticketing/system/Core/Domain/messaging/Message.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/messaging/Message.java
@@ -4,17 +4,46 @@ import java.time.LocalDateTime;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
 // Sub-entity of the Conversation aggregate.
 // Identity is local to the conversation. Cross-aggregate refs by ID:
 //   senderId — User / ProductionCompany / Admin (resolved by senderType)
+//
+// V3: an owned child @Entity of the Conversation aggregate (mapped via Conversation's @OneToMany,
+// never its own repository). messageId is an ASSIGNED @Id (a UUID); senderType is stored by name.
+// The mutable read flag maps to is_read (READ is a SQL reserved word). Fields are non-final with a
+// protected no-arg ctor so Hibernate can hydrate; the public ctor still enforces the invariants.
+@Entity
+@Table(name = "messages")
 public class Message implements InvariantChecked {
 
-    private final String messageId;
-    private final int senderId;
-    private final ParticipantType senderType;
-    private final String body;
-    private final LocalDateTime sentAt;
+    @Id
+    private String messageId;
+
+    @Column(name = "sender_id", nullable = false)
+    private int senderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_type", nullable = false)
+    private ParticipantType senderType;
+
+    @Column(nullable = false)
+    private String body;
+
+    @Column(name = "sent_at", nullable = false)
+    private LocalDateTime sentAt;
+
+    @Column(name = "is_read", nullable = false)
     private boolean read;
+
+    /** For JPA only — do not call from application code. */
+    protected Message() { }
 
     public Message(String messageId, int senderId, ParticipantType senderType,
                    String body, LocalDateTime sentAt) {

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/JpaConversationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/JpaConversationRepository.java
@@ -1,0 +1,82 @@
+package com.ticketing.system.Infrastructure.persistence.ConversationPersistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.messaging.Conversation;
+import com.ticketing.system.Core.Domain.messaging.ConversationStatus;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
+import com.ticketing.system.Core.Domain.messaging.ParticipantType;
+
+/**
+ * JPA-backed {@link IConversationRepository} — active only in the {@code jpa} run/dev profile. Adapts
+ * the domain port onto Spring Data ({@link SpringDataConversationRepository}); the application layer
+ * depends only on {@code IConversationRepository}, never on Spring Data. Owned, send-ordered messages
+ * ({@code @OneToMany} + {@code @OrderColumn}) persist by cascade with the conversation.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops (concurrency via {@code @Version}). {@code save}
+ * delegates to {@code data.save} under {@code @Version} (a fresh conversation inserts with its first
+ * message; a loaded one updates, cascading new messages and read-flag changes) and is
+ * {@code @Transactional}. {@code countUnreadForMember} is computed by the database from message
+ * read-state.
+ */
+@Repository
+@Profile("jpa")
+public class JpaConversationRepository implements IConversationRepository {
+
+    private final SpringDataConversationRepository data;
+
+    public JpaConversationRepository(SpringDataConversationRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(String id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(String id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public void save(Conversation conversation) {
+        data.save(conversation);
+    }
+
+    @Override
+    public Optional<Conversation> findById(String conversationId) {
+        if (conversationId == null) {
+            return Optional.empty();
+        }
+        return data.findById(conversationId);
+    }
+
+    @Override
+    public List<Conversation> findByParticipant(int participantId, ParticipantType participantType) {
+        return data.findByParticipant(participantId, participantType);
+    }
+
+    @Override
+    public List<Conversation> findByType(ConversationType type) {
+        return data.findByType(type);
+    }
+
+    @Override
+    public List<Conversation> findByCompanyAsCounterparty(int companyId) {
+        return data.findByCounterpartyTypeAndCounterpartyId(ParticipantType.COMPANY, companyId);
+    }
+
+    @Override
+    public int countUnreadForMember(int memberId) {
+        return (int) data.countUnreadForMember(memberId);
+    }
+
+    @Override
+    public List<Conversation> findByTypeAndStatus(ConversationType type, ConversationStatus status) {
+        return data.findByTypeAndStatus(type, status);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/MemoryConversationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/MemoryConversationRepository.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.messaging.Conversation;
@@ -16,14 +17,16 @@ import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
 import com.ticketing.system.Core.Domain.messaging.ParticipantType;
 
 /**
- * In-memory {@link IConversationRepository} for V1. Lets Spring wire
- * MessagingService.
+ * In-memory {@link IConversationRepository}. Lets Spring wire MessagingService.
+ * {@code @Profile("!jpa")}: the {@code jpa} run/dev profile swaps in
+ * {@link JpaConversationRepository} instead.
  *
  * <p>Read-tracking ({@code countUnreadForMember}) is computed by summing
  * {@link Conversation#unreadCountFor(int)} over the conversations where the
  * member is a participant.
  */
 @Repository
+@Profile("!jpa")
 public class MemoryConversationRepository implements IConversationRepository {
 
     private final Map<String, Conversation> conversationsById = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/SpringDataConversationRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ConversationPersistence/SpringDataConversationRepository.java
@@ -1,0 +1,44 @@
+package com.ticketing.system.Infrastructure.persistence.ConversationPersistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ticketing.system.Core.Domain.messaging.Conversation;
+import com.ticketing.system.Core.Domain.messaging.ConversationStatus;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.ParticipantType;
+
+/**
+ * Spring Data JPA repository for {@link Conversation} — the auto-implemented SQL backing
+ * {@link JpaConversationRepository}. The application layer never sees this type; it depends only on
+ * the {@code IConversationRepository} domain port. Owned messages persist as an ordered
+ * {@code @OneToMany} by cascade with the conversation.
+ */
+public interface SpringDataConversationRepository extends JpaRepository<Conversation, String> {
+
+    List<Conversation> findByType(ConversationType type);
+
+    List<Conversation> findByTypeAndStatus(ConversationType type, ConversationStatus status);
+
+    List<Conversation> findByCounterpartyTypeAndCounterpartyId(ParticipantType counterpartyType, int counterpartyId);
+
+    /** Conversations where the participant is the initiator or the counterparty. */
+    @Query("select c from Conversation c where "
+            + "(c.initiatorId = :pid and c.initiatorType = :ptype) or "
+            + "(c.counterpartyId = :pid and c.counterpartyType = :ptype)")
+    List<Conversation> findByParticipant(@Param("pid") int participantId,
+                                         @Param("ptype") ParticipantType participantType);
+
+    /**
+     * Unread badge: messages addressed to the member (not sent by them, not yet read) across the
+     * conversations where the member is a participant — derived directly from message read-state.
+     */
+    @Query("select count(m) from Conversation c join c.messages m where "
+            + "((c.initiatorType = com.ticketing.system.Core.Domain.messaging.ParticipantType.MEMBER and c.initiatorId = :memberId) or "
+            + " (c.counterpartyType = com.ticketing.system.Core.Domain.messaging.ParticipantType.MEMBER and c.counterpartyId = :memberId)) "
+            + "and m.senderId <> :memberId and m.read = false")
+    long countUnreadForMember(@Param("memberId") int memberId);
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/IConversationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/IConversationRepositoryContractTest.java
@@ -1,0 +1,125 @@
+package com.ticketing.system.unit.infrastructure.persistence.ConversationPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.messaging.Conversation;
+import com.ticketing.system.Core.Domain.messaging.ConversationStatus;
+import com.ticketing.system.Core.Domain.messaging.ConversationType;
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
+import com.ticketing.system.Core.Domain.messaging.Message;
+import com.ticketing.system.Core.Domain.messaging.ParticipantType;
+
+/**
+ * Contract every {@link IConversationRepository} implementation must satisfy. The Memory and JPA
+ * adapters each subclass this with their own {@link #newRepository()} factory; the tests are reused.
+ * The messages/read-state/unread-count tests pin the acceptance: the ordered message thread, the
+ * per-message read flag, and the derived unread count survive save/reload on both adapters.
+ */
+abstract class IConversationRepositoryContractTest {
+
+    protected abstract IConversationRepository newRepository();
+
+    private IConversationRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = newRepository();
+    }
+
+    /** INQUIRY: member (initiator) -> company (counterparty), first message from the member. */
+    private Conversation inquiry(int memberId, int companyId, String subject, String firstBody) {
+        return Conversation.start(ConversationType.INQUIRY, memberId, ParticipantType.MEMBER,
+                companyId, ParticipantType.COMPANY, subject, firstBody);
+    }
+
+    private Set<String> ids(List<Conversation> cs) {
+        return cs.stream().map(Conversation::getConversationId).collect(Collectors.toSet());
+    }
+
+    @Test
+    void save_thenFindById_returnsTheConversation() {
+        Conversation c = inquiry(5, 10, "Help", "hello");
+        repo.save(c);
+
+        Conversation found = repo.findById(c.getConversationId()).orElseThrow();
+        assertEquals(ConversationType.INQUIRY, found.getType());
+        assertEquals(5, found.getInitiatorId());
+        assertEquals(10, found.getCounterpartyId());
+        assertEquals(ParticipantType.COMPANY, found.getCounterpartyType());
+    }
+
+    @Test
+    void findById_emptyWhenMissingOrNull() {
+        assertFalse(repo.findById("ghost").isPresent());
+        assertFalse(repo.findById(null).isPresent());
+    }
+
+    @Test
+    void findByParticipant_findsAsInitiatorAndAsCounterparty() {
+        Conversation c = inquiry(5, 10, "Help", "hello");
+        repo.save(c);
+
+        assertEquals(Set.of(c.getConversationId()), ids(repo.findByParticipant(5, ParticipantType.MEMBER)));
+        assertEquals(Set.of(c.getConversationId()), ids(repo.findByParticipant(10, ParticipantType.COMPANY)));
+        assertTrue(repo.findByParticipant(99, ParticipantType.MEMBER).isEmpty());
+    }
+
+    @Test
+    void findByType_andFindByCompanyAsCounterparty_andFindByTypeAndStatus() {
+        Conversation c = inquiry(5, 10, "Help", "hello");
+        repo.save(c);
+
+        assertEquals(Set.of(c.getConversationId()), ids(repo.findByType(ConversationType.INQUIRY)));
+        assertTrue(repo.findByType(ConversationType.COMPLAINT).isEmpty());
+
+        assertEquals(Set.of(c.getConversationId()), ids(repo.findByCompanyAsCounterparty(10)));
+        assertTrue(repo.findByCompanyAsCounterparty(999).isEmpty());
+
+        assertEquals(Set.of(c.getConversationId()),
+                ids(repo.findByTypeAndStatus(ConversationType.INQUIRY, ConversationStatus.OPEN)));
+        assertTrue(repo.findByTypeAndStatus(ConversationType.INQUIRY, ConversationStatus.CLOSED).isEmpty());
+    }
+
+    @Test
+    void save_persistsMessagesInOrderWithReadState() {
+        Conversation c = inquiry(5, 10, "Help", "first");
+        c.addMessage(10, ParticipantType.COMPANY, "reply");
+        repo.save(c);
+
+        Conversation found = repo.findById(c.getConversationId()).orElseThrow();
+        List<Message> messages = found.getMessages();
+        assertEquals(2, messages.size());
+        assertEquals("first", messages.get(0).getBody());   // @OrderColumn preserves send order
+        assertEquals("reply", messages.get(1).getBody());
+        assertFalse(messages.get(1).isRead());
+
+        // member 5 reads the company's reply, then we persist and reload
+        found.markMessageRead(messages.get(1).getMessageId(), 5);
+        repo.save(found);
+        assertTrue(repo.findById(c.getConversationId()).orElseThrow().getMessages().get(1).isRead());
+    }
+
+    @Test
+    void countUnreadForMember_derivesFromMessageReadState() {
+        Conversation c = inquiry(5, 10, "Help", "from member");
+        c.addMessage(10, ParticipantType.COMPANY, "reply"); // company -> member: unread for member 5
+        repo.save(c);
+
+        assertEquals(1, repo.countUnreadForMember(5)); // the company reply
+        assertEquals(0, repo.countUnreadForMember(10)); // 10 is the company, not a MEMBER participant
+
+        String replyId = c.getMessages().get(1).getMessageId();
+        c.markMessageRead(replyId, 5);
+        repo.save(c);
+        assertEquals(0, repo.countUnreadForMember(5));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/JpaConversationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/JpaConversationRepositoryContractTest.java
@@ -1,0 +1,41 @@
+package com.ticketing.system.unit.infrastructure.persistence.ConversationPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.JpaConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.SpringDataConversationRepository;
+
+/**
+ * Runs the {@link IConversationRepositoryContractTest} suite against the JPA adapter on an embedded H2
+ * schema. {@code @ActiveProfiles("jpa")} activates {@link JpaConversationRepository};
+ * {@code @DataJpaTest} provides H2 + real {@code conversations} and {@code messages} tables (with the
+ * {@code message_order} order column). Each test starts from an empty schema ({@link #cleanTable()})
+ * so the suite is order-independent; deleting a conversation cascades to its messages. CI never
+ * touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaConversationRepository.class)
+class JpaConversationRepositoryContractTest extends IConversationRepositoryContractTest {
+
+    @Autowired
+    private JpaConversationRepository repository;
+
+    @Autowired
+    private SpringDataConversationRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IConversationRepository newRepository() {
+        return repository;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/MemoryConversationRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ConversationPersistence/MemoryConversationRepositoryContractTest.java
@@ -1,0 +1,12 @@
+package com.ticketing.system.unit.infrastructure.persistence.ConversationPersistence;
+
+import com.ticketing.system.Core.Domain.messaging.IConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.MemoryConversationRepository;
+
+class MemoryConversationRepositoryContractTest extends IConversationRepositoryContractTest {
+
+    @Override
+    protected IConversationRepository newRepository() {
+        return new MemoryConversationRepository();
+    }
+}


### PR DESCRIPTION
Maps the **Conversation** aggregate (+ owned, ordered **Message** children) to JPA. Eighth Lane-B slice; part of the V3 epic #347, depends on #349 (merged). First slice using `@OrderColumn`.

## What
- **`Conversation` → `@Entity` (`conversations`)**: assigned `String @Id` (UUID); `type`/`status` and the two participant types stored by name; `@Version`. The polymorphic participants stay as plain `(initiatorId, initiatorType)` / `(counterpartyId, counterpartyType)` **by-id column pairs, never `@ManyToOne`**.
- **`messages` → owned `@OneToMany(cascade=ALL, orphanRemoval=true)`**, kept in **send order via `@OrderColumn`**, EAGER (subselect) so a detached conversation is fully usable. **`Message` → child `@Entity` (`messages`)**: assigned `String @Id` (UUID), `senderId` by-id, `senderType` by name, and the **per-message mutable read flag** (mapped to `is_read` — `READ` is a SQL reserved word).
- **`countUnreadForMember` is a DB-side JPQL count** that derives the unread badge directly from message read-state (messages addressed to the member, not sent by them, `!read`, across their conversations).
- **`JpaConversationRepository`** (`@Profile("jpa")`): derived `findByType`/`findByTypeAndStatus`/counterparty lookup + a JPQL participant query; `save` cascades new messages and read-flag changes under `@Version`. `MemoryConversationRepository` gated `@Profile("!jpa")`.

## Contract test (`test`)
`IConversationRepository` had none. New `IConversationRepositoryContractTest` covers the lookups (participant as initiator **and** counterparty, type, company-counterparty, type+status) plus the acceptance: **messages persist in send order with their read flag**, and **`countUnreadForMember` derives from read-state** (and drops to zero once read). Run on **both** Memory and JPA-on-H2 (`@DataJpaTest`).

## Verification
- `./mvnw -Pno-vaadin test` → **1233 passing, 0 failures** (+12 Conversation contract).
- **Dev boot (`dev`+`jpa`):** clean ~6.8s, scenario **40/40**, messaging (conversations + ordered messages) persisted through JPA, 0 errors.

Closes #356.
