### PR TITLE
[V3-ORM-08] Map ActiveOrder + CartLineItem to JPA (+ config-driven hold window)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
@@ -11,6 +11,19 @@ import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Domain.events.InventorySelection;
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import jakarta.persistence.Version;
+
 /**
  * ActiveOrder = a cart in progress.
  *
@@ -29,14 +42,33 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
  *
  * <p>Invariant: at least one of userId / sessionId is non-null at all times.
  */
+// V3: mapped to JPA. The stable orderKey (a UUID generated at construction) is the @Id — it already
+// uniquely identifies the order's inventory holds, so it is the natural primary key. userId and
+// sessionId are nullable by-id columns (a cart has at least one of them); status is stored by name;
+// @Version drives optimistic locking. items are owned value rows (@ElementCollection of @Embeddable).
+// itemsLock (a thread guard) is @Transient — re-created by the field initializer on hydrate. A
+// protected no-arg ctor lets Hibernate hydrate; the public ctor still enforces the invariants.
+//
+// Identity collapse (one cart per user / per guest session) is enforced in the repository's save,
+// reproducing the in-memory behaviour even though each cart has a distinct orderKey.
+@Entity
+@Table(name = "active_orders")
 public class ActiveOrder implements InvariantChecked {
 
+    @Column(name = "user_id")
     private Integer userId;
+    @Column(name = "session_id")
     private String sessionId;
     /** Status value: order is being processed by checkout — no new items or concurrent checkouts. */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private ActiveOrderStatus status;
-    private final List<CartLineItem> items;
-    private final LocalDateTime createdAt;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "active_order_items", joinColumns = @JoinColumn(name = "order_key"))
+    private List<CartLineItem> items;
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+    @Transient
     private final Object itemsLock = new Object();
     /**
      * Stable identity assigned at construction. Passed to {@link com.ticketing.system.Core.Domain.events.InventorySelection}
@@ -45,7 +77,17 @@ public class ActiveOrder implements InvariantChecked {
      * order holds each reservation. Enables the 3-phase checkout to verify ownership
      * in checkout's Phase 3 without holding event locks during checkout's Phase 2 (payment/issuance).
      */
-    private final String orderKey = UUID.randomUUID().toString();
+    @Id
+    @Column(name = "order_key")
+    private String orderKey = UUID.randomUUID().toString();
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected ActiveOrder() {
+        this.items = new ArrayList<>();
+    }
 
     public ActiveOrder(Integer userId, String sessionId) {
         this.userId = userId;

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/CartLineItem.java
@@ -6,14 +6,55 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 import java.time.LocalDateTime;
 import java.time.Duration;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+/**
+ * V3: an {@code @Embeddable} value object — one row in the owning ActiveOrder's
+ * {@code active_order_items} element collection (no identity of its own). event/zone are by-id
+ * values. Fields are non-final with a protected no-arg ctor so Hibernate can hydrate; the public
+ * ctor still enforces the invariants.
+ *
+ * <p>The reservation hold window is a system-wide configurable constant
+ * ({@code constants.ticket-reservation-duration}), applied once at startup by
+ * {@code ReservationHoldConfig}. It is {@code static} (not per-item state, so never persisted) and
+ * shared by every line item; it defaults to 10 minutes until the config is applied (e.g. in plain
+ * unit tests that don't boot Spring).
+ */
+@Embeddable
 public class CartLineItem implements InvariantChecked {
 
+    @Column(name = "event_id", nullable = false)
     private int eventId;
+
+    @Column(name = "zone_id", nullable = false)
     private int zoneId;
+
+    @Column(name = "price", nullable = false)
     private double priceAtoneticketReservation;
+
+    @Column(name = "added_at", nullable = false)
     private LocalDateTime addedAt;
+
+    @Column(name = "seat_number")
     private String seatNumber;  // null for standing zones
-    private final Duration EXPIRATION_LIMIT = Duration.ofMinutes(10);
+
+    private static volatile Duration expirationLimit = Duration.ofMinutes(10);
+
+    /** Applied once at startup from {@code constants.ticket-reservation-duration} (see ReservationHoldConfig). */
+    public static void setExpirationLimit(Duration limit) {
+        if (limit != null && !limit.isZero() && !limit.isNegative()) {
+            expirationLimit = limit;
+        }
+    }
+
+    /** The configured reservation hold window (the same value the expiry sweep uses). */
+    public static Duration getExpirationLimit() {
+        return expirationLimit;
+    }
+
+    /** For JPA only — do not call from application code. */
+    protected CartLineItem() { }
 
     public CartLineItem(int eventId, int zoneId, String seatNumber, double priceAtReservation, LocalDateTime addedAt) {
         this.eventId = eventId;
@@ -86,7 +127,7 @@ public class CartLineItem implements InvariantChecked {
 
         Duration elapsedTime = Duration.between(addedAt, LocalDateTime.now());
 
-        Duration remaining = EXPIRATION_LIMIT.minus(elapsedTime);
+        Duration remaining = expirationLimit.minus(elapsedTime);
 
         if (remaining.isNegative() || remaining.isZero()) {
 

--- a/src/main/java/com/ticketing/system/Infrastructure/config/ReservationHoldConfig.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/config/ReservationHoldConfig.java
@@ -1,0 +1,31 @@
+package com.ticketing.system.Infrastructure.config;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
+
+import jakarta.annotation.PostConstruct;
+
+/**
+ * Applies the configurable cart-reservation hold window
+ * ({@code constants.ticket-reservation-duration}, in minutes) to the domain once at startup, so
+ * {@link CartLineItem}'s expiry check uses the configured value instead of a hardcoded constant.
+ *
+ * <p>The window is a system-wide constant held statically on {@code CartLineItem} (it is not
+ * per-item state, so it is never persisted), so it is set here rather than injected into every
+ * value object. This keeps the domain free of Spring config while still being configuration-driven.
+ */
+@Configuration
+public class ReservationHoldConfig {
+
+    @Value("${constants.ticket-reservation-duration}")
+    private int reservationTimeoutMinutes;
+
+    @PostConstruct
+    void applyHoldWindow() {
+        CartLineItem.setExpirationLimit(Duration.ofMinutes(reservationTimeoutMinutes));
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepository.java
@@ -1,0 +1,91 @@
+package com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
+
+/**
+ * JPA-backed {@link IActiveOrderRepository} — active only in the {@code jpa} run/dev profile. Adapts
+ * the domain port onto Spring Data ({@link SpringDataActiveOrderRepository}); the application layer
+ * depends only on {@code IActiveOrderRepository}, never on Spring Data. Owned cart items
+ * ({@code @ElementCollection}) persist by cascade with the order.
+ *
+ * <p>{@code lockForUpdate}/{@code unlock} are no-ops: concurrency is guarded by {@code ActiveOrder}'s
+ * {@code @Version}. The guest→member cart-merge that previously relied on the double-lock in
+ * {@code AuthenticationService.handleCartOnPromotion} therefore runs optimistically — the merge is
+ * re-runnable (re-read the cart, re-attach, save), so it survives as a {@code @Version} retry once the
+ * service-level {@code @Retryable} lands (C1, #359).
+ *
+ * <p>{@link #save} reproduces the in-memory identity collapse: a member cart is unique per userId and
+ * a guest cart per sessionId, even though each {@link ActiveOrder} carries a distinct orderKey. So a
+ * save first entity-deletes any <em>other</em> cart sharing this cart's identity (the entity delete
+ * cascades the item collection), then persists this one. Writes are {@code @Transactional} so the
+ * adapter is self-sufficient before the service layer gains transactions (#359).
+ */
+@Repository
+@Profile("jpa")
+public class JpaActiveOrderRepository implements IActiveOrderRepository {
+
+    private final SpringDataActiveOrderRepository data;
+
+    public JpaActiveOrderRepository(SpringDataActiveOrderRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(String id) { /* no-op — @Version optimistic locking */ }
+
+    @Override
+    public void unlock(String id) { /* no-op */ }
+
+    @Override
+    @Transactional
+    public void save(ActiveOrder activeOrder) {
+        List<ActiveOrder> sameIdentity = activeOrder.isMember()
+                ? data.findByUserId(activeOrder.getUserId())
+                : data.findBySessionIdAndUserIdIsNull(activeOrder.getSessionId());
+        for (ActiveOrder existing : sameIdentity) {
+            if (!existing.getOrderKey().equals(activeOrder.getOrderKey())) {
+                data.delete(existing); // entity delete cascades the @ElementCollection items
+            }
+        }
+        data.save(activeOrder);
+    }
+
+    @Override
+    public ActiveOrder getByUserId(int userId) {
+        return data.findByUserId(userId).stream().findFirst().orElse(null);
+    }
+
+    @Override
+    public Optional<ActiveOrder> getBySessionId(String sessionId) {
+        if (sessionId == null || sessionId.isBlank()) {
+            return Optional.empty();
+        }
+        return data.findFirstBySessionId(sessionId);
+    }
+
+    @Override
+    @Transactional
+    public void delete(ActiveOrder activeOrder) {
+        if (activeOrder == null) {
+            return;
+        }
+        // Idempotent + cascades the item collection; deleting an unknown cart is a no-op.
+        data.findById(activeOrder.getOrderKey()).ifPresent(data::delete);
+    }
+
+    @Override
+    public List<ActiveOrder> findExpired() {
+        LocalDateTime cutoff = LocalDateTime.now().minus(CartLineItem.getExpirationLimit());
+        return data.findWithItemAddedBefore(cutoff);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
@@ -6,13 +6,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
 import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 
 /**
- * In-memory {@link IActiveOrderRepository} for V1.
+ * In-memory {@link IActiveOrderRepository}. {@code @Profile("!jpa")}: the {@code jpa} run/dev
+ * profile swaps in {@link JpaActiveOrderRepository} instead.
  *
  * <p>
  * Storage is a single {@link CopyOnWriteArrayList} of carts; lookups scan.
@@ -22,6 +24,7 @@ import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
  * Guest-turned-Member cart over a prior orphaned Member cart).
  */
 @Repository
+@Profile("!jpa")
 public class MemoryActiveOrderRepository implements IActiveOrderRepository {
 
     private final List<ActiveOrder> carts = new CopyOnWriteArrayList<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/SpringDataActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/SpringDataActiveOrderRepository.java
@@ -1,0 +1,33 @@
+package com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+
+/**
+ * Spring Data JPA repository for {@link ActiveOrder} — the auto-implemented SQL backing
+ * {@link JpaActiveOrderRepository}. The application layer never sees this type; it depends only on
+ * the {@code IActiveOrderRepository} domain port. Owned cart items persist as an
+ * {@code @ElementCollection} by cascade with the order.
+ */
+public interface SpringDataActiveOrderRepository extends JpaRepository<ActiveOrder, String> {
+
+    /** Member carts for a user (after the save-time identity collapse there is at most one). */
+    List<ActiveOrder> findByUserId(int userId);
+
+    /** Guest carts (no userId) bound to a session — used by the guest-identity collapse. */
+    List<ActiveOrder> findBySessionIdAndUserIdIsNull(String sessionId);
+
+    /** Any cart (guest or active-session member) attached to the session. */
+    Optional<ActiveOrder> findFirstBySessionId(String sessionId);
+
+    /** Sweep query: carts holding any item whose hold window has elapsed ({@code addedAt <= cutoff}). */
+    @Query("select distinct o from ActiveOrder o join o.items i where i.addedAt <= :cutoff")
+    List<ActiveOrder> findWithItemAddedBefore(@Param("cutoff") LocalDateTime cutoff);
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/IActiveOrderRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/IActiveOrderRepositoryContractTest.java
@@ -140,4 +140,19 @@ abstract class IActiveOrderRepositoryContractTest {
         repo.save(cart);
         assertTrue(repo.findExpired().isEmpty());
     }
+
+    @Test
+    void save_persistsCartItems() {
+        // A member cart with items survives save/reload (the "cart survives a restart" acceptance).
+        ActiveOrder cart = ActiveOrder.forMember(5, "sid-A");
+        cart.addStandingReservation(1, 10, 2, 50.0, java.time.LocalDateTime.now());          // 2 standing
+        cart.addSeatedReservation(1, 11, java.util.List.of("A1"), 75.0, java.time.LocalDateTime.now()); // 1 seated
+        repo.save(cart);
+
+        ActiveOrder found = repo.getByUserId(5);
+        assertNotNull(found);
+        assertEquals(3, found.getItems().size());
+        assertTrue(found.getItems().stream()
+                .anyMatch(i -> i.geteventId() == 1 && i.getzoneId() == 11 && "A1".equals(i.getSeatNumber())));
+    }
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepositoryContractTest.java
@@ -1,0 +1,40 @@
+package com.ticketing.system.unit.infrastructure.persistence.ActiveOrderPersistence;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.JpaActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.SpringDataActiveOrderRepository;
+
+/**
+ * Runs the {@link IActiveOrderRepositoryContractTest} suite against the JPA adapter on an embedded H2
+ * schema. {@code @ActiveProfiles("jpa")} activates {@link JpaActiveOrderRepository};
+ * {@code @DataJpaTest} provides H2 + real {@code active_orders} and {@code active_order_items} tables.
+ * Each test starts from an empty schema ({@link #cleanTable()}) so the suite is order-independent;
+ * deleting an order cascades to its item collection. CI never touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaActiveOrderRepository.class)
+class JpaActiveOrderRepositoryContractTest extends IActiveOrderRepositoryContractTest {
+
+    @Autowired
+    private JpaActiveOrderRepository repository;
+
+    @Autowired
+    private SpringDataActiveOrderRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IActiveOrderRepository newRepository() {
+        return repository;
+    }
+}


### PR DESCRIPTION
Maps the **ActiveOrder** cart aggregate (+ owned **CartLineItem**) to JPA, unblocking Lane F (persistent cart). Ninth Lane-B slice; part of the V3 epic #347, depends on #349 (merged).

## What
- **`ActiveOrder` → `@Entity` (`active_orders`)**: the stable **`orderKey` UUID is the `@Id`** (it already uniquely tags the order's inventory holds). `userId`/`sessionId` are **nullable by-id columns** (a cart always has at least one); status by name; `@Version`.
- **`items` → `@ElementCollection` of `@Embeddable CartLineItem`** (event/zone by-id values), EAGER. **`itemsLock` and the expiry window → `@Transient`/static** (not persisted).
- **Identity collapse on save**: a member cart is unique per `userId`, a guest cart per `sessionId`, even though each order has its own `orderKey` — so `JpaActiveOrderRepository.save` first entity-deletes any *other* cart sharing this cart's identity (cascading its items), then persists this one (reproducing the in-memory behavior; the existing contract's collapse + distinctness tests pass on JPA).
- **`findExpired`** is a time query (`addedAt <= now − holdWindow`).
- **Double-lock verify**: `lockForUpdate`/`unlock` are no-ops; the guest→member cart-merge in `AuthenticationService.handleCartOnPromotion` runs optimistically and is re-runnable, so it survives as a `@Version` retry once C1 (#359) adds the service `@Retryable`. No code change there.

## Config-driven reservation hold window (your request)
The 10-minute cart-hold window was hardcoded in `CartLineItem`. It's now **driven by `constants.ticket-reservation-duration`** (the property `ReservationService` already reads), applied once at startup by a small `ReservationHoldConfig` to a static on `CartLineItem` — config-driven, correct for reloaded carts, with no Spring config leaking into the domain value object.

## Contract test (`test`)
Reused the existing `IActiveOrderRepositoryContractTest` via a new `JpaActiveOrderRepositoryContractTest` (`@DataJpaTest` on H2), and added `save_persistsCartItems` (a member cart with standing + seated items round-trips) — the **"a member cart survives a restart"** acceptance.

## Verification
- `./mvnw -Pno-vaadin test` → **1247 passing, 0 failures** (+14; contract now runs 13 cases on both impls).
- **Dev boot (`dev`+`jpa`):** clean ~7.1s, scenario **40/40**, carts/reservations/checkouts + guest→member merges persisted through JPA, 0 errors.

Closes #357.
