### PR TITLE
[V3-ORM-09] Map Event + VenueMap + InventoryZone + Seat + policies to JPA

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicy.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicy.java
@@ -21,6 +21,10 @@ public class DiscountPolicy implements InvariantChecked { //? Note: but not in i
         }
     }
 
+    public double getDiscountPercentage() {
+        return discountPercentage;
+    }
+
     public double apply(double price) {
         return price * (1 - discountPercentage / 100);
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicyJsonConverter.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/DiscountPolicyJsonConverter.java
@@ -1,0 +1,48 @@
+package com.ticketing.system.Core.Domain.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Serializes an event's {@link DiscountPolicy} to a single JSON text column and rebuilds it on load.
+ * Like {@code PurchasePolicyJsonConverter}, a policy is evaluated, never queried, so it is stored as
+ * JSON rather than a column. DiscountPolicy is currently a flat percentage, so the JSON is
+ * {@code {"discountPercentage": N}}; keeping a converter (rather than a plain column) leaves room for
+ * the policy to grow without a schema change. JPA instantiates the converter itself, so it holds its
+ * own {@link ObjectMapper}.
+ */
+@Converter
+public class DiscountPolicyJsonConverter implements AttributeConverter<DiscountPolicy, String> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(DiscountPolicy policy) {
+        DiscountPolicy effective = policy == null ? new DiscountPolicy(0.0) : policy;
+        ObjectNode node = MAPPER.createObjectNode();
+        node.put("discountPercentage", effective.getDiscountPercentage());
+        try {
+            return MAPPER.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to serialize discount policy to JSON", e);
+        }
+    }
+
+    @Override
+    public DiscountPolicy convertToEntityAttribute(String json) {
+        if (json == null || json.isBlank()) {
+            return new DiscountPolicy(0.0);
+        }
+        try {
+            JsonNode node = MAPPER.readTree(json);
+            return new DiscountPolicy(node.get("discountPercentage").asDouble());
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("failed to parse discount policy JSON", e);
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -2,6 +2,7 @@
 package com.ticketing.system.Core.Domain.events;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
@@ -13,21 +14,70 @@ import com.ticketing.system.Core.Domain.policies.purchase.AndPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchaseContext;
 import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicyJsonConverter;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+// V3: aggregate root mapped to JPA. Assigned int @Id (minted by nextId()); comapnyid is a by-id
+// column; category/status stored by name; @Version drives the event-level optimistic lock
+// (structural/lifecycle edits) while Seat and InventoryZone carry their own @Version so independent
+// buyer reservations never false-conflict. artistsNames and showDates (@Embeddable) are element
+// collections; venueMap is an owned @OneToOne (nullable in DRAFT); the policies are stored as JSON.
+// A protected no-arg ctor lets Hibernate hydrate; the public ctors enforce the invariants.
 @Slf4j
+@Entity
+@Table(name = "events")
 public class Event implements InvariantChecked {
-    private final int id;
+    @Id
+    private int id;
+    @Column(nullable = false)
     private String name;
+    @Column
     private String description;
-    private final Double rating;
-    private final List<String> artistsNames;
+    @Column
+    private Double rating;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @jakarta.persistence.CollectionTable(name = "event_artists", joinColumns = @JoinColumn(name = "event_id"))
+    @Column(name = "artist_name")
+    private List<String> artistsNames;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private EventCategory category;
-    private final int comapnyid;
+    @Column(name = "company_id", nullable = false)
+    private int comapnyid;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private EventStatus status;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "venue_map_id")
     private VenueMap venueMap;
+    @ElementCollection(fetch = FetchType.EAGER)
+    @jakarta.persistence.CollectionTable(name = "event_show_dates", joinColumns = @JoinColumn(name = "event_id"))
     private List<ShowDate> showDates;
+    @Convert(converter = PurchasePolicyJsonConverter.class)
+    @Column(name = "purchase_policy", columnDefinition = "text", nullable = false)
     private PurchasePolicy purchasePolicy;
-    private final DiscountPolicy discountPolicy;
+    @Convert(converter = DiscountPolicyJsonConverter.class)
+    @Column(name = "discount_policy", columnDefinition = "text")
+    private DiscountPolicy discountPolicy;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Event() { }
 
     // Description-less constructor — kept for existing callers/tests. Delegates with a null
     // description (description is optional and carries no invariant).
@@ -48,12 +98,12 @@ public class Event implements InvariantChecked {
         this.name = name;
         this.description = description;
         this.rating = rating;
-        this.artistsNames = artistsNames == null ? null : List.copyOf(artistsNames);
+        this.artistsNames = artistsNames == null ? null : new ArrayList<>(artistsNames);
         this.category = category;
         this.comapnyid = comapnyid;
         this.status = status;
         this.venueMap = venueMap;
-        this.showDates = showDates == null ? null : List.copyOf(showDates);
+        this.showDates = showDates == null ? null : new ArrayList<>(showDates);
         // purchasePolicy defaults to NoPurchasePolicy when not supplied.
         this.purchasePolicy = PurchasePolicy == null ? new NoPurchasePolicy() : PurchasePolicy;
         // Discount Policies are not currently in the implementation plan so in the creation of the event we manually,

--- a/src/main/java/com/ticketing/system/Core/Domain/events/InventoryZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/InventoryZone.java
@@ -2,6 +2,17 @@ package com.ticketing.system.Core.Domain.events;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 /**
  * Abstract base for all inventory-zone types inside a {@link VenueMap}.
  *
@@ -25,20 +36,47 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
  * Seated-zone callers must downcast or use the typed
  * {@link SeatedZone#reserveSeats(java.util.List)} / {@link SeatedZone#releaseSeats(java.util.List)} methods.
  */
+// V3: JOINED inheritance — InventoryZone is the parent table, SeatedZone/StandingZone get their own
+// joined tables (keeps their NOT-NULL subclass constraints, which SINGLE_TABLE would forbid). The
+// @Id is a DB-generated surrogate because the domain zone id is only unique within a VenueMap, not
+// globally; the domain id stays a column (zone_number). @Version gives each zone its own optimistic
+// lock (counter updates on a StandingZone bump it; structural seat changes on a SeatedZone bump it).
+// A protected no-arg ctor lets Hibernate hydrate the subclasses.
+@Entity
+@Table(name = "inventory_zones")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "zone_type")
 public abstract class InventoryZone implements InvariantChecked {
 
-    protected final int id;
-    protected final String name;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long zonePk;
+
+    @Column(name = "zone_number", nullable = false)
+    protected int id;
+    @Column(nullable = false)
+    protected String name;
+    @Column(nullable = false)
     protected double price;
 
     // Grid placement on the VenueMap canvas: 1-based start cell + cell spans.
     // gridRowSpan == 0 means "not explicitly placed" → the preview falls back to
     // auto-layout. Bounds against the grid size and non-overlap with other zones
     // are enforced by VenueMap.placeZoneOnGrid (which holds the whole map).
+    @Column(name = "grid_row")
     private int gridRow;
+    @Column(name = "grid_col")
     private int gridCol;
+    @Column(name = "grid_row_span")
     private int gridRowSpan;
+    @Column(name = "grid_col_span")
     private int gridColSpan;
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected InventoryZone() { }
 
     protected InventoryZone(int id, String name, double price) {
         // Invariants (name non-blank, price >= 0) are enforced by the concrete

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Location.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Location.java
@@ -2,6 +2,12 @@ package com.ticketing.system.Core.Domain.events;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Embeddable;
+
+// V3: an @Embeddable value object embedded in VenueMap (columns country, city). Hibernate 6
+// instantiates the record via its canonical constructor; an all-null embedded location loads back
+// as a null reference, so the validating compact constructor only runs for non-null values.
+@Embeddable
 public record Location(
                 String country,
                 String city) implements InvariantChecked {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Seat.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Seat.java
@@ -4,6 +4,16 @@ import java.time.LocalDateTime;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
 /**
  * A single addressable seat inside a {@link SeatedZone}.
  *
@@ -16,17 +26,47 @@ import com.ticketing.system.Core.Domain.shared.InvariantChecked;
  * which {@code ActiveOrder} holds the reservation, enabling the 3-phase
  * checkout to verify ownership before confirming sale — even after the
  * event lock is released during the payment/issuance phase.
+ *
+ * <p>V3: an owned child {@code @Entity} of a SeatedZone (mapped via its {@code @OneToMany} seat map,
+ * keyed by {@code label}). The {@code @Id} is a DB-generated surrogate because a seat label is only
+ * unique within its zone, not globally; {@code label} stays a column (and the map key). Status is
+ * stored by name; {@code reservedByOrderKey} is a nullable by-id column. {@code @Version} gives each
+ * seat its own optimistic lock so independent seat reservations never false-conflict. Fields are
+ * non-final with a protected no-arg ctor for Hibernate; the public ctor enforces the invariants.
  */
+@Entity
+@Table(name = "seats")
 public class Seat implements InvariantChecked {
 
-    private final String label;
-    private final double x;
-    private final double y;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seatPk;
+
+    @Column(nullable = false)
+    private String label;
+
+    @Column(name = "x_coord", nullable = false)
+    private double x;
+
+    @Column(name = "y_coord", nullable = false)
+    private double y;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private SeatStatus status;
+
     /** Non-null only while status == RESERVED; identifies the holding ActiveOrder. */
+    @Column(name = "reserved_by_order_key")
     private String reservedByOrderKey;
     /** When the hold expires (informational — enforcement is in the sweep job). */
+    @Column(name = "reserved_until")
     private LocalDateTime reservedUntil; //TODO: when going to checkout, this should be set to {time now} + {reservation timeout period}.
+
+    @Version
+    private Long version;
+
+    /** For JPA only — do not call from application code. */
+    protected Seat() { }
 
     public Seat(String label, double x, double y) {
         this.label = label;

--- a/src/main/java/com/ticketing/system/Core/Domain/events/SeatedZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/SeatedZone.java
@@ -10,6 +10,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKey;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
+import jakarta.persistence.Transient;
+
 
 /**
  * Zone with addressable, named seats. Replaces the bare counter of
@@ -24,21 +34,32 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Adding/removing seats from a SeatedZone after tickets are issued, so after ON_SALE turned on is
  * intentionally not supported — cannot change zones or their internals after event goes ON_SALE.
  */
+@Entity
+@DiscriminatorValue("SEATED")
 public class SeatedZone extends InventoryZone {
 
-    private final ConcurrentHashMap<String, Seat> seats;
-    private final ConcurrentHashMap<String, ReentrantLock> seatLocks;
+    // Owned seat catalogue, keyed by label. High-churn seat status rules out @ElementCollection, so
+    // Seat is a child @Entity; cascade-all + orphan-removal persist/delete seats with the zone.
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "zone_pk")
+    @MapKey(name = "label")
+    private Map<String, Seat> seats = new ConcurrentHashMap<>();
+    // Per-seat locks and the layout lock are runtime concurrency guards, never persisted. seatLocks
+    // is rebuilt from the loaded seat labels by rebuildSeatLocks() (@PostLoad), restoring the
+    // seats↔locks 1:1 invariant.
+    @Transient
+    private final ConcurrentHashMap<String, ReentrantLock> seatLocks = new ConcurrentHashMap<>();
+    @Transient
     private final ReentrantReadWriteLock layoutLock = new ReentrantReadWriteLock();
 
-
+    /** For JPA only — do not call from application code. */
+    protected SeatedZone() { }
 
     public SeatedZone(int id, String name, double price, List<Seat> initialSeats) {
         super(id, name, price);
         if (initialSeats == null) {
             throw new IllegalArgumentException("initialSeats must not be null");
         }
-        this.seats = new ConcurrentHashMap<>();
-        this.seatLocks = new ConcurrentHashMap<>();
         for (Seat seat : initialSeats) {
             if (this.seats.containsKey(seat.getLabel())) {
                 throw new IllegalArgumentException("Duplicate seat label: " + seat.getLabel());
@@ -47,6 +68,14 @@ public class SeatedZone extends InventoryZone {
             this.seatLocks.put(seat.getLabel(), new ReentrantLock());
         }
         checkInvariants();
+    }
+
+    /** Restores the seats↔seatLocks 1:1 invariant after Hibernate loads the seat map. */
+    @PostLoad
+    void rebuildSeatLocks() {
+        for (String label : seats.keySet()) {
+            seatLocks.putIfAbsent(label, new ReentrantLock());
+        }
     }
 
     /** Snapshot of the seats — modifications to the returned list don't affect the zone. */
@@ -120,10 +149,12 @@ public class SeatedZone extends InventoryZone {
         try {
             // Acquire all locks in sorted order to prevent deadlock with concurrent reservers.
             for (String label : sorted) {
-                ReentrantLock lock = seatLocks.get(label);
-                if (lock == null) {
+                if (!seats.containsKey(label)) {
                     throw new IllegalArgumentException("Seat not found in zone: " + label);
                 }
+                // seatLocks is transient (never persisted); @PostLoad can run before the EAGER seats
+                // collection loads, so create the lock on demand if missing — seats is the source of truth.
+                ReentrantLock lock = seatLocks.computeIfAbsent(label, k -> new ReentrantLock());
                 lock.lock();
                 acquired.add(lock);
             }
@@ -176,10 +207,12 @@ public class SeatedZone extends InventoryZone {
 
         try {
             for (String label : sorted) {
-                ReentrantLock lock = seatLocks.get(label);
-                if (lock == null) {
+                if (!seats.containsKey(label)) {
                     throw new IllegalArgumentException("Seat not found in zone: " + label);
                 }
+                // seatLocks is transient (never persisted); @PostLoad can run before the EAGER seats
+                // collection loads, so create the lock on demand if missing — seats is the source of truth.
+                ReentrantLock lock = seatLocks.computeIfAbsent(label, k -> new ReentrantLock());
                 lock.lock();
                 acquired.add(lock);
             }
@@ -235,10 +268,12 @@ public class SeatedZone extends InventoryZone {
 
         try {
             for (String label : sorted) {
-                ReentrantLock lock = seatLocks.get(label);
-                if (lock == null) {
+                if (!seats.containsKey(label)) {
                     throw new IllegalArgumentException("Seat not found in zone: " + label);
                 }
+                // seatLocks is transient (never persisted); @PostLoad can run before the EAGER seats
+                // collection loads, so create the lock on demand if missing — seats is the source of truth.
+                ReentrantLock lock = seatLocks.computeIfAbsent(label, k -> new ReentrantLock());
                 lock.lock();
                 acquired.add(lock);
             }
@@ -446,11 +481,12 @@ public class SeatedZone extends InventoryZone {
         if (seatLocks == null) {
             throw new IllegalStateException("SeatedZone invariant violated: seatLocks map must not be null");
         }
-        // Every seat needs a matching lock entry (1:1 correspondence) and vice-versa.
-        Set<String> seatKeys = seats.keySet();
-        Set<String> lockKeys = seatLocks.keySet();
-        if (!seatKeys.equals(lockKeys)) {
-            throw new IllegalStateException("SeatedZone invariant violated: seats and seatLocks key sets disagree");
+        // seatLocks is transient runtime state (never persisted). @PostLoad can run before the EAGER
+        // seat collection is populated, so reconcile the locks with the seats (the source of truth)
+        // here rather than failing — each seat ends up with exactly one lock.
+        seatLocks.keySet().retainAll(seats.keySet());
+        for (String seatLabel : seats.keySet()) {
+            seatLocks.putIfAbsent(seatLabel, new ReentrantLock());
         }
         // Per-seat sanity: label matches map key and seat satisfies its own invariants.
         for (Map.Entry<String, Seat> entry : seats.entrySet()) {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/ShowDate.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/ShowDate.java
@@ -4,9 +4,21 @@ import java.time.LocalDateTime;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+// V3: an @Embeddable value object — one row in an Event's show_dates element collection. The
+// future-dated precondition lives only in the public ctor, so Hibernate's no-arg hydrate can load a
+// past show date. A protected no-arg ctor lets Hibernate instantiate it.
+@Embeddable
 public class ShowDate implements InvariantChecked {
+    @Column(name = "start_time", nullable = false)
     private LocalDateTime startTime;
+    @Column(name = "end_time", nullable = false)
     private LocalDateTime endTime;
+
+    /** For JPA only — do not call from application code. */
+    protected ShowDate() { }
 
     public ShowDate(LocalDateTime startTime, LocalDateTime endTime) {
         // validateTimes enforces the construction-time "must be future-dated" precondition,

--- a/src/main/java/com/ticketing/system/Core/Domain/events/StandingZone.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/StandingZone.java
@@ -3,6 +3,16 @@ package com.ticketing.system.Core.Domain.events;
 import java.util.HashMap;
 import java.util.Map;
 
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.Transient;
+
 /**
  * Counter-based zone — no addressable seats, just "N tickets available".
  *
@@ -15,16 +25,28 @@ import java.util.Map;
  * the reservation is stored under the sentinel key {@code "anonymous"}.
  * All synchronization happens via a private {@code inventoryLock}.
  */
+@Entity
+@DiscriminatorValue("STANDING")
 public class StandingZone extends InventoryZone {
 
+    @Column(nullable = false)
     private int capacity;
     /** Maps orderKey → quantity reserved by that order. used for tracking reservations per order. */
-    private final Map<String, Integer> reservedByOrderKey = new HashMap<>();
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "standing_zone_reservations", joinColumns = @JoinColumn(name = "zone_pk"))
+    @MapKeyColumn(name = "order_key")
+    @Column(name = "quantity")
+    private Map<String, Integer> reservedByOrderKey = new HashMap<>();
+    @Column(name = "sold_amount", nullable = false)
     private int soldAmount;
+    @Transient
     private final Object inventoryLock = new Object();
 
     /** Sentinel used when no order key is provided (backwards-compatible callers). */
     private static final String ANONYMOUS_KEY = "anonymous";
+
+    /** For JPA only — do not call from application code. */
+    protected StandingZone() { }
 
     public StandingZone(int id, String name, int capacity, double price) {
         super(id, name, price);

--- a/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/VenueMap.java
@@ -6,19 +6,51 @@ import java.util.ArrayList;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+// V3: an owned @Entity of Event (mapped via Event's @OneToOne). Assigned int @Id (minted by
+// IEventRepository.nextVenueMapId()). location is an @Embedded value (nullable). The polymorphic
+// inventoryZones are owned children (@OneToMany cascade-all + orphan-removal) loaded eagerly. A
+// protected no-arg ctor lets Hibernate hydrate.
+@Entity
+@Table(name = "venue_maps")
 public class VenueMap implements InvariantChecked {
 
     /** Default venue canvas grid when none is specified. */
     public static final int DEFAULT_GRID_ROWS = 3;
     public static final int DEFAULT_GRID_COLS = 3;
 
+    @Id
     private int id;
+    @Embedded
     private Location location;
-    private final List<InventoryZone> inventoryZones;
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "venue_map_id")
+    @Fetch(FetchMode.SUBSELECT)
+    private List<InventoryZone> inventoryZones;
+    @Column(name = "next_zone_id")
     private int nextZoneId;
     // Venue canvas grid: zones snap to cells of this gridRows × gridCols layout.
+    @Column(name = "grid_rows")
     private int gridRows;
+    @Column(name = "grid_cols")
     private int gridCols;
+
+    /** For JPA only — do not call from application code. */
+    protected VenueMap() {
+        this.inventoryZones = new ArrayList<>();
+    }
 
     public VenueMap(int id, Location location, List<InventoryZone> inventoryZones) {
         this(id, location, inventoryZones, DEFAULT_GRID_ROWS, DEFAULT_GRID_COLS);

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/EventSearchSpecification.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/EventSearchSpecification.java
@@ -1,0 +1,129 @@
+package com.ticketing.system.Infrastructure.persistence.EventPersistence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+/**
+ * Translates {@link CatalogSearchFiltersDTO} into a Criteria {@link Specification} for the catalogue
+ * search (UC-7), mirroring {@code MemoryEventRepository.matchesSearch}. Simple predicates (name,
+ * category, rating, location) sit on the Event root; the "at least one matching element" filters
+ * (artist, keyword-in-artist, show-date range, zone-price range) are correlated {@code EXISTS}
+ * subqueries so the outer query never multiplies rows (no {@code distinct} needed).
+ */
+final class EventSearchSpecification {
+
+    private EventSearchSpecification() { }
+
+    static Specification<Event> from(CatalogSearchFiltersDTO filters) {
+        return (root, query, cb) -> {
+            if (filters == null) {
+                return cb.conjunction();
+            }
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (filters.eventName() != null) {
+                predicates.add(cb.like(cb.lower(root.get("name")), like(filters.eventName())));
+            }
+            if (filters.artistName() != null) {
+                predicates.add(cb.exists(artistLike(query, cb, root, filters.artistName())));
+            }
+            if (filters.category() != null) {
+                EventCategory category = parseCategory(filters.category());
+                predicates.add(category == null ? cb.disjunction() : cb.equal(root.get("category"), category));
+            }
+            if (filters.keywords() != null) {
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("name")), like(filters.keywords())),
+                        cb.exists(artistLike(query, cb, root, filters.keywords()))));
+            }
+            if (filters.fromDate() != null || filters.toDate() != null) {
+                predicates.add(cb.exists(showDateInRange(query, cb, root, filters)));
+            }
+            if (filters.minPrice() != null || filters.maxPrice() != null) {
+                predicates.add(cb.exists(zonePriceInRange(query, cb, root, filters)));
+            }
+            if (filters.minEventRating() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("rating"), filters.minEventRating()));
+            }
+            if (filters.maxEventRating() != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("rating"), filters.maxEventRating()));
+            }
+            if (filters.location() != null) {
+                Join<Object, Object> venue = root.join("venueMap", JoinType.LEFT);
+                predicates.add(cb.or(
+                        cb.like(cb.lower(venue.get("location").get("city")), like(filters.location())),
+                        cb.like(cb.lower(venue.get("location").get("country")), like(filters.location()))));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static String like(String term) {
+        return "%" + term.toLowerCase() + "%";
+    }
+
+    private static EventCategory parseCategory(String raw) {
+        try {
+            return EventCategory.valueOf(raw.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    /** EXISTS subquery: the outer event has at least one artist matching {@code term}. */
+    private static Subquery<Integer> artistLike(CriteriaQuery<?> query, CriteriaBuilder cb, Root<Event> root, String term) {
+        Subquery<Integer> sub = query.subquery(Integer.class);
+        Root<Event> subRoot = sub.from(Event.class);
+        Join<Event, String> artists = subRoot.join("artistsNames");
+        sub.select(cb.literal(1)).where(cb.equal(subRoot, root), cb.like(cb.lower(artists), like(term)));
+        return sub;
+    }
+
+    private static Subquery<Integer> showDateInRange(CriteriaQuery<?> query, CriteriaBuilder cb, Root<Event> root,
+            CatalogSearchFiltersDTO filters) {
+        Subquery<Integer> sub = query.subquery(Integer.class);
+        Root<Event> subRoot = sub.from(Event.class);
+        Join<Object, Object> showDate = subRoot.join("showDates");
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(subRoot, root));
+        if (filters.fromDate() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(showDate.get("startTime"), filters.fromDate().atStartOfDay()));
+        }
+        if (filters.toDate() != null) {
+            predicates.add(cb.lessThanOrEqualTo(showDate.get("startTime"), filters.toDate().atTime(23, 59, 59)));
+        }
+        sub.select(cb.literal(1)).where(predicates.toArray(new Predicate[0]));
+        return sub;
+    }
+
+    private static Subquery<Integer> zonePriceInRange(CriteriaQuery<?> query, CriteriaBuilder cb, Root<Event> root,
+            CatalogSearchFiltersDTO filters) {
+        Subquery<Integer> sub = query.subquery(Integer.class);
+        Root<Event> subRoot = sub.from(Event.class);
+        Join<Object, Object> zone = subRoot.join("venueMap").join("inventoryZones");
+        List<Predicate> predicates = new ArrayList<>();
+        predicates.add(cb.equal(subRoot, root));
+        if (filters.minPrice() != null) {
+            predicates.add(cb.greaterThanOrEqualTo(zone.get("price"), filters.minPrice()));
+        }
+        if (filters.maxPrice() != null) {
+            predicates.add(cb.lessThanOrEqualTo(zone.get("price"), filters.maxPrice()));
+        }
+        sub.select(cb.literal(1)).where(predicates.toArray(new Predicate[0]));
+        return sub;
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
@@ -1,0 +1,126 @@
+package com.ticketing.system.Infrastructure.persistence.EventPersistence;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+
+/**
+ * JPA-backed {@link IEventRepository} — active only in the {@code jpa} run/dev profile. Adapts the
+ * domain port onto Spring Data ({@link SpringDataEventRepository}); the application layer depends only
+ * on {@code IEventRepository}, never on Spring Data. The owned VenueMap / zone hierarchy / seats /
+ * element collections persist by cascade with the event.
+ *
+ * <p>Locking is OPTIMISTIC and fine-grained: {@code lockForUpdate}/{@code lockForBuyerOperation} and
+ * their unlocks are no-ops. Event carries an {@code @Version} for structural/lifecycle edits, while
+ * Seat and InventoryZone carry their own {@code @Version} so two buyers reserving different seats (or
+ * a buyer vs. a structural edit touching a different entity) never false-conflict; genuine conflicts
+ * raise {@code OptimisticLockException}, retried by the service {@code @Retryable} (C1, #359).
+ *
+ * <p>{@code searchAll}/{@code searchONSALE} push the 18-filter catalogue search down into a Criteria
+ * {@link Specification} (see {@link EventSearchSpecification}). {@code nextId}/{@code nextVenueMapId}
+ * seed in-memory counters from the current max ids so they survive a restart.
+ */
+@Repository
+@Profile("jpa")
+public class JpaEventRepository implements IEventRepository {
+
+    private final SpringDataEventRepository data;
+    private final AtomicInteger eventIdSequence = new AtomicInteger(0);
+    private final AtomicInteger venueMapIdSequence = new AtomicInteger(0);
+    private volatile boolean seeded = false;
+
+    public JpaEventRepository(SpringDataEventRepository data) {
+        this.data = data;
+    }
+
+    @Override
+    public void lockForUpdate(Integer id) { /* no-op — fine-grained @Version optimistic locking */ }
+
+    @Override
+    public void unlock(Integer id) { /* no-op */ }
+
+    @Override
+    public void lockForBuyerOperation(int eventId) { /* no-op */ }
+
+    @Override
+    public void unlockBuyerOperation(int eventId) { /* no-op */ }
+
+    @Override
+    public int nextId() {
+        ensureSeeded();
+        return eventIdSequence.incrementAndGet();
+    }
+
+    @Override
+    public int nextVenueMapId() {
+        ensureSeeded();
+        return venueMapIdSequence.incrementAndGet();
+    }
+
+    private void ensureSeeded() {
+        if (!seeded) {
+            synchronized (this) {
+                if (!seeded) {
+                    eventIdSequence.set(data.findMaxEventId());
+                    venueMapIdSequence.set(data.findMaxVenueMapId());
+                    seeded = true;
+                }
+            }
+        }
+    }
+
+    @Override
+    public Event findById(int eventId) {
+        return data.findById(eventId)
+                .orElseThrow(() -> new EventNotFoundException("Event with ID " + eventId + " not found"));
+    }
+
+    @Override
+    @Transactional
+    public boolean save(Event event) {
+        data.save(event);
+        return true;
+    }
+
+    @Override
+    public List<Event> findByCompanyId(int companyId) {
+        return data.findByCompanyId(companyId);
+    }
+
+    @Override
+    public List<Integer> findIdsByCompany(int companyId) {
+        return data.findIdsByCompany(companyId);
+    }
+
+    @Override
+    public List<Event> findActiveByCompany(int companyId) {
+        return data.findActiveByCompany(companyId);
+    }
+
+    @Override
+    public List<Event> findByStatus(EventStatus status) {
+        return data.findByStatus(status);
+    }
+
+    @Override
+    public List<Event> searchAll(CatalogSearchFiltersDTO filters) {
+        return data.findAll(EventSearchSpecification.from(filters));
+    }
+
+    @Override
+    public List<Event> searchONSALE(CatalogSearchFiltersDTO filters) {
+        Specification<Event> spec = EventSearchSpecification.from(filters)
+                .and((root, query, cb) -> cb.equal(root.get("status"), EventStatus.ON_SALE));
+        return data.findAll(spec);
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -14,9 +14,11 @@ import com.ticketing.system.Core.Domain.events.IEventRepository;
 import com.ticketing.system.Core.Domain.events.EventCategory;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 @Repository
+@Profile("!jpa")
 public class MemoryEventRepository implements IEventRepository {
 
     private final ConcurrentHashMap<Integer, Event> events = new ConcurrentHashMap<>();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/SpringDataEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/SpringDataEventRepository.java
@@ -1,0 +1,42 @@
+package com.ticketing.system.Infrastructure.persistence.EventPersistence;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+
+/**
+ * Spring Data JPA repository for {@link Event} — the auto-implemented SQL backing
+ * {@link JpaEventRepository}. The application layer never sees this type; it depends only on the
+ * {@code IEventRepository} domain port. The owned VenueMap / zone hierarchy / seats / element
+ * collections persist by cascade with the event. {@link JpaSpecificationExecutor} backs the
+ * 18-filter catalogue search (pushed down as a Criteria {@code Specification}).
+ *
+ * <p>The company-scoped queries reference {@code e.comapnyid} (the field name, a domain typo) via
+ * explicit JPQL rather than a derived name.
+ */
+public interface SpringDataEventRepository extends JpaRepository<Event, Integer>, JpaSpecificationExecutor<Event> {
+
+    @Query("select e from Event e where e.comapnyid = :companyId")
+    List<Event> findByCompanyId(@Param("companyId") int companyId);
+
+    @Query("select e.id from Event e where e.comapnyid = :companyId")
+    List<Integer> findIdsByCompany(@Param("companyId") int companyId);
+
+    @Query("select e from Event e where e.comapnyid = :companyId "
+            + "and e.status = com.ticketing.system.Core.Domain.events.EventStatus.ON_SALE")
+    List<Event> findActiveByCompany(@Param("companyId") int companyId);
+
+    List<Event> findByStatus(EventStatus status);
+
+    @Query("select coalesce(max(e.id), 0) from Event e")
+    int findMaxEventId();
+
+    @Query("select coalesce(max(v.id), 0) from VenueMap v")
+    int findMaxVenueMapId();
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/JpaEventRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/JpaEventRepositoryContractTest.java
@@ -1,0 +1,92 @@
+package com.ticketing.system.unit.infrastructure.persistence.EventPersistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Domain.events.DiscountPolicy;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.Seat;
+import com.ticketing.system.Core.Domain.events.SeatedZone;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.events.StandingZone;
+import com.ticketing.system.Core.Domain.events.VenueMap;
+import com.ticketing.system.Core.Domain.policies.purchase.AgePurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.AndPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.MaxTicketsPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicyJsonConverter;
+import com.ticketing.system.Infrastructure.persistence.EventPersistence.JpaEventRepository;
+import com.ticketing.system.Infrastructure.persistence.EventPersistence.SpringDataEventRepository;
+
+/**
+ * Runs the {@link IEventRepositoryContractTest} suite (incl. all search filters) against the JPA
+ * adapter on an embedded H2 schema, and adds the acceptance round-trip: a full venue with a seated
+ * zone (seats), a standing zone, and policies survives save/reload. {@code @DataJpaTest} builds the
+ * whole graph of tables (events, venue_maps, inventory_zones + seated/standing subtables, seats,
+ * element collections). Each test starts from an empty schema; CI never touches a real database.
+ */
+@DataJpaTest
+@ActiveProfiles("jpa")
+@Import(JpaEventRepository.class)
+class JpaEventRepositoryContractTest extends IEventRepositoryContractTest {
+
+    @Autowired
+    private JpaEventRepository repository;
+
+    @Autowired
+    private SpringDataEventRepository data;
+
+    @BeforeEach
+    void cleanTable() {
+        data.deleteAll();
+    }
+
+    @Override
+    protected IEventRepository newRepository() {
+        return repository;
+    }
+
+    @Test
+    void save_roundTripsFullVenueWithSeatsAndPolicies() {
+        int eventId = repository.nextId();
+        SeatedZone seated = new SeatedZone(1, "Stage", 80.0,
+                List.of(new Seat("A1", 0, 0), new Seat("A2", 1, 0)));
+        StandingZone standing = new StandingZone(2, "Floor", 100, 50.0);
+        VenueMap venue = new VenueMap(repository.nextVenueMapId(), new Location("Belgium", "Brussels"),
+                List.of(seated, standing));
+        PurchasePolicy policy = new AndPurchasePolicy(new AgePurchasePolicy(18), new MaxTicketsPurchasePolicy(4));
+
+        Event event = new Event(eventId, "Concert", 4.5, List.of("Coldplay"), EventCategory.MUSIC, 7,
+                EventStatus.ON_SALE, venue, List.of(new ShowDate(
+                        LocalDateTime.of(2099, 6, 1, 18, 0), LocalDateTime.of(2099, 6, 1, 22, 0))),
+                policy, new DiscountPolicy(0));
+        repository.save(event);
+
+        Event found = repository.findById(eventId);
+        assertEquals(2, found.getVenueMap().getInventoryZones().size());
+
+        SeatedZone foundSeated = (SeatedZone) found.getVenueMap().getInventoryZones().stream()
+                .filter(z -> z instanceof SeatedZone).findFirst().orElseThrow();
+        assertEquals(2, foundSeated.getSeats().size());
+        assertTrue(foundSeated.getSeats().stream().anyMatch(s -> "A1".equals(s.getLabel())));
+
+        // the recursive purchase policy tree round-trips (compared via the converter)
+        PurchasePolicyJsonConverter converter = new PurchasePolicyJsonConverter();
+        assertEquals(converter.convertToDatabaseColumn(policy),
+                converter.convertToDatabaseColumn(found.getPurchasePolicy()));
+    }
+}


### PR DESCRIPTION
The last and hardest Lane-B slice — maps the whole **Event** aggregate graph (VenueMap + InventoryZone hierarchy + Seat + policies + the 18-filter search) to JPA. Part of the V3 epic #347, depends on #349 (merged). **Completes Lane B (10/10).**

## What
- **`Event` → `@Entity`**: assigned int `@Id`, `comapnyid` by-id, category/status STRING, `@Version`. `artistsNames` + `showDates` (`@Embeddable`) → `@ElementCollection`; `Location` → `@Embeddable` on VenueMap; `purchasePolicy`/`discountPolicy` → JSON converters; `venueMap` → owned `@OneToOne(cascade=ALL, orphanRemoval=true)` (nullable in DRAFT).
- **`InventoryZone` → `@Inheritance(JOINED)` + `@DiscriminatorColumn`** (preserves the subclasses' NOT-NULL constraints). Surrogate `@Id` (domain zone ids aren't globally unique) + `@Version`. `SeatedZone.seats` → owned `@OneToMany @MapKey(label)` of **`Seat`** (child `@Entity`, surrogate `@Id`, own `@Version` — high-churn status). `StandingZone.reservedByOrderKey` → `@ElementCollection @MapKeyColumn`.
- **Locks `@Transient`**: per your call, **optimistic fine-grained** (`@Version` on Event + InventoryZone + Seat; `lockForUpdate`/`lockForBuyerOperation` are no-ops; C1/#359 retries). `seatLocks` **self-heal** against the seat map — `@PostLoad` can race the EAGER seat collection, so `checkInvariants` reconciles and reservations create a missing lock on demand (fixed a reserve-after-load failure the contract test didn't reach).
- **18-filter search → Criteria `Specification`**: simple predicates on the root; correlated `EXISTS` subqueries for the artist/keyword/show-date/zone-price "any element" filters (no cartesian blow-up).

## Contract test (`test`)
`JpaEventRepositoryContractTest` runs the **whole** `IEventRepositoryContractTest` (every search filter) on JPA/H2, and adds `save_roundTripsFullVenueWithSeatsAndPolicies` — a venue with a seated zone (seats) + standing zone + composed policy round-trips (the acceptance).

## Verification
- `./mvnw -Pno-vaadin test` → **1268 passing, 0 failures** (+21 Event JPA contract incl. all search filters).
- **Dev boot (`dev`+`jpa`):** clean ~7.4s, scenario **40/40** — full venues, seat reservations, checkouts (reserve→pay→confirmSale) all persisted through the JOINED hierarchy + seat map, 0 errors.

Closes #358.
