### PR TITLE
237 v2 view nw 02 orgtreerenderer custom component

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
@@ -23,14 +23,16 @@ public class OrgTreeRenderer extends Composite<Div> {
     private ListItem buildNode(OrganizationalTreeNodeDTO dto) {
         ListItem li = new ListItem();
 
-        String variant   = dto.isFounder() ? "founder" : dto.role().equals("Owner") ? "owner" : "manager";
-        String roleLabel = dto.isFounder() ? "Founder" : dto.role().equals("Owner") ? "Owner"  : "Manager";
+        boolean isOwner  = "Owner".equals(dto.role());
+        String variant   = dto.isFounder() ? "founder" : isOwner ? "owner" : "manager";
+        String roleLabel = dto.isFounder() ? "Founder" : isOwner ? "Owner"  : "Manager";
         String initial   = dto.username().substring(0, 1).toUpperCase();
-        String sub       = dto.isFounder()
-                ? "Company Founder"
-                : dto.grantedPermissions().stream()
+        boolean isManager = !dto.isFounder() && !isOwner;
+        String sub = dto.isFounder() ? "Company Founder"
+                : isManager ? dto.grantedPermissions().stream()
                         .map(Permission::name)
-                        .collect(Collectors.joining(", "));
+                        .collect(Collectors.joining(", "))
+                : "";
 
         boolean composite = !dto.appointedByThisUser().isEmpty();
 

--- a/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
@@ -1,0 +1,69 @@
+package com.ticketing.system.Presentation.components.admin;
+
+import com.vaadin.flow.component.Composite;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.ListItem;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.html.UnorderedList;
+
+import java.util.List;
+
+public class OrgTreeRenderer extends Composite<Div> {
+
+    public record Node(String initial, String name, String role, String variant, String sub, List<Node> children) {
+        public Node(String initial, String name, String role, String variant, String sub) {
+            this(initial, name, role, variant, sub, List.of());
+        }
+    }
+
+    public OrgTreeRenderer(Node root) {
+        this(List.of(root));
+    }
+
+    public OrgTreeRenderer(List<Node> roots) {
+        Div tree = getContent();
+        tree.addClassName("org-chart");
+        UnorderedList ul = new UnorderedList();
+        for (Node root : roots) ul.add(buildNode(root));
+        tree.add(ul);
+    }
+
+    private ListItem buildNode(Node node) {
+        ListItem li = new ListItem();
+
+        Div ocCard = new Div();
+        ocCard.addClassName("oc-card");
+        ocCard.addClassName("oc-" + node.variant());
+
+        boolean composite = !node.children().isEmpty();
+        Span kind = new Span(composite ? "Composite" : "Leaf");
+        kind.addClassName("oc-kind");
+        kind.addClassName("lk-mono");
+
+        Span avatar = new Span(node.initial());
+        avatar.addClassName("oc-avatar");
+        avatar.addClassName("oc-av-" + node.variant());
+
+        Div name = new Div(new Span(node.name()));
+        name.addClassName("oc-name");
+
+        Span role = new Span(node.role());
+        role.addClassName("oc-role");
+        role.addClassName("oc-rb-" + node.variant());
+
+        ocCard.add(kind, avatar, name, role);
+        if (node.sub() != null && !node.sub().isEmpty()) {
+            Div sub = new Div(new Span(node.sub()));
+            sub.addClassName("oc-sub");
+            ocCard.add(sub);
+        }
+        li.add(ocCard);
+
+        if (composite) {
+            UnorderedList kidsUl = new UnorderedList();
+            for (Node child : node.children()) kidsUl.add(buildNode(child));
+            li.add(kidsUl);
+        }
+        return li;
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeRenderer.java
@@ -1,67 +1,69 @@
 package com.ticketing.system.Presentation.components.admin;
 
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Core.Domain.users.Permission;
 import com.vaadin.flow.component.Composite;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.html.UnorderedList;
 
-import java.util.List;
+import java.util.stream.Collectors;
 
 public class OrgTreeRenderer extends Composite<Div> {
 
-    public record Node(String initial, String name, String role, String variant, String sub, List<Node> children) {
-        public Node(String initial, String name, String role, String variant, String sub) {
-            this(initial, name, role, variant, sub, List.of());
-        }
-    }
-
-    public OrgTreeRenderer(Node root) {
-        this(List.of(root));
-    }
-
-    public OrgTreeRenderer(List<Node> roots) {
+    public OrgTreeRenderer(OrganizationalTreeNodeDTO root) {
         Div tree = getContent();
         tree.addClassName("org-chart");
         UnorderedList ul = new UnorderedList();
-        for (Node root : roots) ul.add(buildNode(root));
+        ul.add(buildNode(root));
         tree.add(ul);
     }
 
-    private ListItem buildNode(Node node) {
+    private ListItem buildNode(OrganizationalTreeNodeDTO dto) {
         ListItem li = new ListItem();
+
+        String variant   = dto.isFounder() ? "founder" : dto.role().equals("Owner") ? "owner" : "manager";
+        String roleLabel = dto.isFounder() ? "Founder" : dto.role().equals("Owner") ? "Owner"  : "Manager";
+        String initial   = dto.username().substring(0, 1).toUpperCase();
+        String sub       = dto.isFounder()
+                ? "Company Founder"
+                : dto.grantedPermissions().stream()
+                        .map(Permission::name)
+                        .collect(Collectors.joining(", "));
+
+        boolean composite = !dto.appointedByThisUser().isEmpty();
 
         Div ocCard = new Div();
         ocCard.addClassName("oc-card");
-        ocCard.addClassName("oc-" + node.variant());
+        ocCard.addClassName("oc-" + variant);
 
-        boolean composite = !node.children().isEmpty();
         Span kind = new Span(composite ? "Composite" : "Leaf");
         kind.addClassName("oc-kind");
         kind.addClassName("lk-mono");
 
-        Span avatar = new Span(node.initial());
+        Span avatar = new Span(initial);
         avatar.addClassName("oc-avatar");
-        avatar.addClassName("oc-av-" + node.variant());
+        avatar.addClassName("oc-av-" + variant);
 
-        Div name = new Div(new Span(node.name()));
+        Div name = new Div(new Span(dto.username()));
         name.addClassName("oc-name");
 
-        Span role = new Span(node.role());
+        Span role = new Span(roleLabel);
         role.addClassName("oc-role");
-        role.addClassName("oc-rb-" + node.variant());
+        role.addClassName("oc-rb-" + variant);
 
         ocCard.add(kind, avatar, name, role);
-        if (node.sub() != null && !node.sub().isEmpty()) {
-            Div sub = new Div(new Span(node.sub()));
-            sub.addClassName("oc-sub");
-            ocCard.add(sub);
+        if (!sub.isEmpty()) {
+            Div subDiv = new Div(new Span(sub));
+            subDiv.addClassName("oc-sub");
+            ocCard.add(subDiv);
         }
         li.add(ocCard);
 
         if (composite) {
             UnorderedList kidsUl = new UnorderedList();
-            for (Node child : node.children()) kidsUl.add(buildNode(child));
+            for (OrganizationalTreeNodeDTO child : dto.appointedByThisUser()) kidsUl.add(buildNode(child));
             li.add(kidsUl);
         }
         return li;

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -1,5 +1,7 @@
 package com.ticketing.system.Presentation.views.admin;
 
+import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
+import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer.Node;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkPage;
@@ -9,9 +11,7 @@ import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.ListItem;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.html.UnorderedList;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
@@ -23,12 +23,6 @@ import java.util.List;
 @PermitAll
 @RequireCapability(Capability.VIEW_ORG_TREES)
 public class OrganizationalTreeView extends LkPage {
-
-    private record Node(String initial, String name, String role, String variant, String sub, List<Node> children) {
-        Node(String initial, String name, String role, String variant, String sub) {
-            this(initial, name, role, variant, sub, List.of());
-        }
-    }
 
     public OrganizationalTreeView() {
         title("Organizational Tree");
@@ -59,53 +53,8 @@ public class OrganizationalTreeView extends LkPage {
         Node eve   = new Node("E", "Eve Bar",    "Owner",   "owner",   "Appointed by Alice · 2025-02-14", List.of(frank));
         Node alice = new Node("A", "Alice Cohen", "Founder", "founder", "Founded 2024-12-15 · Live Nation Israel", List.of(bob, eve));
 
-        Div tree = new Div();
-        tree.addClassName("org-chart");
-        UnorderedList ul = new UnorderedList();
-        ul.add(buildNode(alice));
-        tree.add(ul);
-
-        card.add(tree);
+        card.add(new OrgTreeRenderer(alice));
         return card;
-    }
-
-    private ListItem buildNode(Node node) {
-        ListItem li = new ListItem();
-
-        Div ocCard = new Div();
-        ocCard.addClassName("oc-card");
-        ocCard.addClassName("oc-" + node.variant());
-
-        boolean composite = !node.children().isEmpty();
-        Span kind = new Span(composite ? "Composite" : "Leaf");
-        kind.addClassName("oc-kind");
-        kind.addClassName("lk-mono");
-
-        Span avatar = new Span(node.initial());
-        avatar.addClassName("oc-avatar");
-        avatar.addClassName("oc-av-" + node.variant());
-
-        Div name = new Div(new Span(node.name()));
-        name.addClassName("oc-name");
-
-        Span role = new Span(node.role());
-        role.addClassName("oc-role");
-        role.addClassName("oc-rb-" + node.variant());
-
-        ocCard.add(kind, avatar, name, role);
-        if (node.sub() != null && !node.sub().isEmpty()) {
-            Div sub = new Div(new Span(node.sub()));
-            sub.addClassName("oc-sub");
-            ocCard.add(sub);
-        }
-        li.add(ocCard);
-
-        if (composite) {
-            UnorderedList kidsUl = new UnorderedList();
-            for (Node child : node.children()) kidsUl.add(buildNode(child));
-            li.add(kidsUl);
-        }
-        return li;
     }
 
     private Component buildLegendCard() {

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -1,7 +1,8 @@
 package com.ticketing.system.Presentation.views.admin;
 
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Core.Domain.users.Permission;
 import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
-import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer.Node;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkPage;
@@ -16,6 +17,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Route(value = "admin/org-tree", layout = PlatformAdminLayout.class)
@@ -38,20 +40,29 @@ public class OrganizationalTreeView extends LkPage {
         row.add(
             new LkFilterChip("Company", List.of("Live Nation Israel", "Coca-Cola Arena", "Shuni Productions"),
                 false, List.of("Live Nation Israel")),
-            new LkFilterChip("Roles",   List.of("Founder", "Owners", "Managers"), true, List.of("Founder", "Owners", "Managers"))
+            new LkFilterChip("Roles", List.of("Founder", "Owners", "Managers"), true, List.of("Founder", "Owners", "Managers"))
         );
         return row;
     }
 
+    // Stub data — will be replaced when wired to CompanyManagementService.viewOrganizationalTree()
     private Component buildTreeCard() {
         LkCard card = new LkCard("Live Nation Israel — Appointment Hierarchy").pad(20);
 
-        Node carol = new Node("C", "Carol Levy", "Manager", "manager", "Appointed by Bob · Manage events, view sales");
-        Node dave  = new Node("D", "Dave Peretz", "Manager", "manager", "Appointed by Bob · Respond to inquiries");
-        Node bob   = new Node("B", "Bob Mizrahi", "Owner",   "owner",   "Appointed by Alice · 2025-01-08", List.of(carol, dave));
-        Node frank = new Node("F", "Frank Tal",  "Manager", "manager", "Appointed by Eve · Manage events, edit policies");
-        Node eve   = new Node("E", "Eve Bar",    "Owner",   "owner",   "Appointed by Alice · 2025-02-14", List.of(frank));
-        Node alice = new Node("A", "Alice Cohen", "Founder", "founder", "Founded 2024-12-15 · Live Nation Israel", List.of(bob, eve));
+        OrganizationalTreeNodeDTO carol = new OrganizationalTreeNodeDTO(3, "Carol Levy",  "Manager", false,
+                List.of(Permission.MANAGE_INVENTORY, Permission.VIEW_SALES), new ArrayList<>());
+        OrganizationalTreeNodeDTO dave  = new OrganizationalTreeNodeDTO(4, "Dave Peretz", "Manager", false,
+                List.of(Permission.RESPOND_TO_INQUIRIES), new ArrayList<>());
+        OrganizationalTreeNodeDTO bob   = new OrganizationalTreeNodeDTO(2, "Bob Mizrahi", "Owner",   false,
+                List.of(), new ArrayList<>(List.of(carol, dave)));
+
+        OrganizationalTreeNodeDTO frank = new OrganizationalTreeNodeDTO(6, "Frank Tal",   "Manager", false,
+                List.of(Permission.MANAGE_INVENTORY, Permission.EDIT_POLICIES), new ArrayList<>());
+        OrganizationalTreeNodeDTO eve   = new OrganizationalTreeNodeDTO(5, "Eve Bar",     "Owner",   false,
+                List.of(), new ArrayList<>(List.of(frank)));
+
+        OrganizationalTreeNodeDTO alice = new OrganizationalTreeNodeDTO(1, "Alice Cohen", "Owner",   true,
+                List.of(), new ArrayList<>(List.of(bob, eve)));
 
         card.add(new OrgTreeRenderer(alice));
         return card;

--- a/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
@@ -1,102 +1,121 @@
 package com.ticketing.system.Presentation.components.admin;
 
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Core.Domain.users.Permission;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit coverage for {@link OrgTreeRenderer} and its nested {@link OrgTreeRenderer.Node} record.
+ * Unit coverage for {@link OrgTreeRenderer}.
  * Pure JUnit — no Spring context needed; Vaadin components can be instantiated headlessly.
  */
 class OrgTreeRendererTest {
 
-    // ── Node record ────────────────────────────────────────────────────────────
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    private static OrganizationalTreeNodeDTO leaf(int id, String username, String role, boolean isFounder) {
+        return new OrganizationalTreeNodeDTO(id, username, role, isFounder, List.of(), new ArrayList<>());
+    }
+
+    private static OrganizationalTreeNodeDTO node(int id, String username, String role, boolean isFounder,
+                                                   List<Permission> perms,
+                                                   List<OrganizationalTreeNodeDTO> children) {
+        return new OrganizationalTreeNodeDTO(id, username, role, isFounder, perms, new ArrayList<>(children));
+    }
+
+    // ── construction ───────────────────────────────────────────────────────────
 
     @Test
-    void leafConstructor_setsChildrenToEmptyList() {
-        var node = new OrgTreeRenderer.Node("A", "Alice Cohen", "Founder", "founder", "Founded 2024");
-        assertTrue(node.children().isEmpty());
+    void founderLeaf_constructsWithoutError() {
+        OrganizationalTreeNodeDTO founder = leaf(1, "Alice Cohen", "Owner", true);
+        assertDoesNotThrow(() -> new OrgTreeRenderer(founder));
     }
 
     @Test
-    void fullConstructor_storesAllFields() {
-        var child = new OrgTreeRenderer.Node("B", "Bob", "Owner", "owner", "sub");
-        var node  = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub", List.of(child));
-
-        assertEquals("A",       node.initial());
-        assertEquals("Alice",   node.name());
-        assertEquals("Founder", node.role());
-        assertEquals("founder", node.variant());
-        assertEquals("sub",     node.sub());
-        assertEquals(1,         node.children().size());
-        assertSame(child,       node.children().get(0));
+    void ownerLeaf_constructsWithoutError() {
+        OrganizationalTreeNodeDTO owner = leaf(2, "Bob Mizrahi", "Owner", false);
+        assertDoesNotThrow(() -> new OrgTreeRenderer(owner));
     }
 
     @Test
-    void leafNode_hasNoChildren() {
-        var node = new OrgTreeRenderer.Node("C", "Carol", "Manager", "manager", "Appointed by Bob");
-        assertTrue(node.children().isEmpty());
+    void managerLeaf_constructsWithoutError() {
+        OrganizationalTreeNodeDTO manager = leaf(3, "Carol Levy", "Manager", false);
+        assertDoesNotThrow(() -> new OrgTreeRenderer(manager));
     }
 
     @Test
-    void compositeNode_reportsAllChildren() {
-        var carol = new OrgTreeRenderer.Node("C", "Carol", "Manager", "manager", "Appointed by Bob");
-        var dave  = new OrgTreeRenderer.Node("D", "Dave",  "Manager", "manager", "Appointed by Bob");
-        var bob   = new OrgTreeRenderer.Node("B", "Bob", "Owner", "owner", "Appointed by Alice", List.of(carol, dave));
-
-        assertEquals(2, bob.children().size());
-        assertEquals("C", bob.children().get(0).initial());
-        assertEquals("D", bob.children().get(1).initial());
-    }
-
-    @Test
-    void nodeEquality_sameFieldsSameChildren_areEqual() {
-        var a = new OrgTreeRenderer.Node("X", "Name", "Role", "variant", "sub", List.of());
-        var b = new OrgTreeRenderer.Node("X", "Name", "Role", "variant", "sub", List.of());
-        assertEquals(a, b);
-    }
-
-    // ── OrgTreeRenderer construction ───────────────────────────────────────────
-
-    @Test
-    void singleRootConstructor_doesNotThrow() {
-        var root = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "Founded 2024");
-        assertDoesNotThrow(() -> new OrgTreeRenderer(root));
-    }
-
-    @Test
-    void listConstructor_doesNotThrow() {
-        var a = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub");
-        var b = new OrgTreeRenderer.Node("B", "Bob",   "Owner",   "owner",   "sub");
-        assertDoesNotThrow(() -> new OrgTreeRenderer(List.of(a, b)));
-    }
-
-    @Test
-    void emptyListConstructor_doesNotThrow() {
-        assertDoesNotThrow(() -> new OrgTreeRenderer(List.of()));
-    }
-
-    @Test
-    void content_hasOrgChartClass() {
-        var root = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub");
-        var renderer = new OrgTreeRenderer(root);
-        String classes = renderer.getElement().getAttribute("class");
-        assertNotNull(classes, "class attribute must not be null");
-        assertTrue(classes.contains("org-chart"),
-            "wrapper div must carry 'org-chart' so CSS connector-line selectors fire");
+    void compositeOwner_constructsWithoutError() {
+        OrganizationalTreeNodeDTO carol = leaf(3, "Carol Levy", "Manager", false);
+        OrganizationalTreeNodeDTO bob   = node(2, "Bob Mizrahi", "Owner", false, List.of(), List.of(carol));
+        assertDoesNotThrow(() -> new OrgTreeRenderer(bob));
     }
 
     @Test
     void deepTree_constructsWithoutError() {
-        var carol = new OrgTreeRenderer.Node("C", "Carol Levy",   "Manager", "manager", "Appointed by Bob · Manage events");
-        var dave  = new OrgTreeRenderer.Node("D", "Dave Peretz",  "Manager", "manager", "Appointed by Bob · Inquiries");
-        var bob   = new OrgTreeRenderer.Node("B", "Bob Mizrahi",  "Owner",   "owner",   "Appointed by Alice · 2025-01-08", List.of(carol, dave));
-        var frank = new OrgTreeRenderer.Node("F", "Frank Tal",    "Manager", "manager", "Appointed by Eve · Manage events");
-        var eve   = new OrgTreeRenderer.Node("E", "Eve Bar",      "Owner",   "owner",   "Appointed by Alice · 2025-02-14", List.of(frank));
-        var alice = new OrgTreeRenderer.Node("A", "Alice Cohen",  "Founder", "founder", "Founded 2024-12-15", List.of(bob, eve));
-
+        OrganizationalTreeNodeDTO carol = leaf(3, "Carol Levy",  "Manager", false);
+        OrganizationalTreeNodeDTO dave  = leaf(4, "Dave Peretz", "Manager", false);
+        OrganizationalTreeNodeDTO bob   = node(2, "Bob Mizrahi", "Owner", false, List.of(), List.of(carol, dave));
+        OrganizationalTreeNodeDTO frank = leaf(6, "Frank Tal",   "Manager", false);
+        OrganizationalTreeNodeDTO eve   = node(5, "Eve Bar",     "Owner",   false, List.of(), List.of(frank));
+        OrganizationalTreeNodeDTO alice = node(1, "Alice Cohen", "Owner",   true,  List.of(), List.of(bob, eve));
         assertDoesNotThrow(() -> new OrgTreeRenderer(alice));
+    }
+
+    // ── CSS structure ──────────────────────────────────────────────────────────
+
+    @Test
+    void content_hasOrgChartClass() {
+        var renderer = new OrgTreeRenderer(leaf(1, "Alice Cohen", "Owner", true));
+        String classes = renderer.getElement().getAttribute("class");
+        assertNotNull(classes, "class attribute must not be null");
+        assertTrue(classes.contains("org-chart"),
+                "wrapper div must carry 'org-chart' so CSS connector-line selectors fire");
+    }
+
+    // ── variant mapping ────────────────────────────────────────────────────────
+
+    @Test
+    void founder_variantIsFounder() {
+        var renderer = new OrgTreeRenderer(leaf(1, "Alice Cohen", "Owner", true));
+        String html = renderer.getElement().getOuterHTML();
+        assertTrue(html.contains("oc-founder"), "founder node must carry 'oc-founder' variant class");
+    }
+
+    @Test
+    void owner_variantIsOwner() {
+        var renderer = new OrgTreeRenderer(leaf(2, "Bob Mizrahi", "Owner", false));
+        String html = renderer.getElement().getOuterHTML();
+        assertTrue(html.contains("oc-owner"), "owner node must carry 'oc-owner' variant class");
+    }
+
+    @Test
+    void manager_variantIsManager() {
+        var renderer = new OrgTreeRenderer(leaf(3, "Carol Levy", "Manager", false));
+        String html = renderer.getElement().getOuterHTML();
+        assertTrue(html.contains("oc-manager"), "manager node must carry 'oc-manager' variant class");
+    }
+
+    // ── permissions displayed in sub ───────────────────────────────────────────
+
+    @Test
+    void managerWithPermissions_subTextContainsPermissionNames() {
+        OrganizationalTreeNodeDTO manager = new OrganizationalTreeNodeDTO(
+                3, "Carol Levy", "Manager", false,
+                List.of(Permission.MANAGE_INVENTORY, Permission.VIEW_SALES), new ArrayList<>());
+        var renderer = new OrgTreeRenderer(manager);
+        String html = renderer.getElement().getOuterHTML();
+        assertTrue(html.contains("MANAGE_INVENTORY"), "sub text must list granted permissions");
+        assertTrue(html.contains("VIEW_SALES"),        "sub text must list granted permissions");
+    }
+
+    @Test
+    void ownerWithNoPermissions_subIsEmpty() {
+        OrganizationalTreeNodeDTO owner = new OrganizationalTreeNodeDTO(
+                2, "Bob Mizrahi", "Owner", false, List.of(), new ArrayList<>());
+        assertDoesNotThrow(() -> new OrgTreeRenderer(owner));
     }
 }

--- a/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
@@ -1,0 +1,102 @@
+package com.ticketing.system.Presentation.components.admin;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit coverage for {@link OrgTreeRenderer} and its nested {@link OrgTreeRenderer.Node} record.
+ * Pure JUnit — no Spring context needed; Vaadin components can be instantiated headlessly.
+ */
+class OrgTreeRendererTest {
+
+    // ── Node record ────────────────────────────────────────────────────────────
+
+    @Test
+    void leafConstructor_setsChildrenToEmptyList() {
+        var node = new OrgTreeRenderer.Node("A", "Alice Cohen", "Founder", "founder", "Founded 2024");
+        assertTrue(node.children().isEmpty());
+    }
+
+    @Test
+    void fullConstructor_storesAllFields() {
+        var child = new OrgTreeRenderer.Node("B", "Bob", "Owner", "owner", "sub");
+        var node  = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub", List.of(child));
+
+        assertEquals("A",       node.initial());
+        assertEquals("Alice",   node.name());
+        assertEquals("Founder", node.role());
+        assertEquals("founder", node.variant());
+        assertEquals("sub",     node.sub());
+        assertEquals(1,         node.children().size());
+        assertSame(child,       node.children().get(0));
+    }
+
+    @Test
+    void leafNode_hasNoChildren() {
+        var node = new OrgTreeRenderer.Node("C", "Carol", "Manager", "manager", "Appointed by Bob");
+        assertTrue(node.children().isEmpty());
+    }
+
+    @Test
+    void compositeNode_reportsAllChildren() {
+        var carol = new OrgTreeRenderer.Node("C", "Carol", "Manager", "manager", "Appointed by Bob");
+        var dave  = new OrgTreeRenderer.Node("D", "Dave",  "Manager", "manager", "Appointed by Bob");
+        var bob   = new OrgTreeRenderer.Node("B", "Bob", "Owner", "owner", "Appointed by Alice", List.of(carol, dave));
+
+        assertEquals(2, bob.children().size());
+        assertEquals("C", bob.children().get(0).initial());
+        assertEquals("D", bob.children().get(1).initial());
+    }
+
+    @Test
+    void nodeEquality_sameFieldsSameChildren_areEqual() {
+        var a = new OrgTreeRenderer.Node("X", "Name", "Role", "variant", "sub", List.of());
+        var b = new OrgTreeRenderer.Node("X", "Name", "Role", "variant", "sub", List.of());
+        assertEquals(a, b);
+    }
+
+    // ── OrgTreeRenderer construction ───────────────────────────────────────────
+
+    @Test
+    void singleRootConstructor_doesNotThrow() {
+        var root = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "Founded 2024");
+        assertDoesNotThrow(() -> new OrgTreeRenderer(root));
+    }
+
+    @Test
+    void listConstructor_doesNotThrow() {
+        var a = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub");
+        var b = new OrgTreeRenderer.Node("B", "Bob",   "Owner",   "owner",   "sub");
+        assertDoesNotThrow(() -> new OrgTreeRenderer(List.of(a, b)));
+    }
+
+    @Test
+    void emptyListConstructor_doesNotThrow() {
+        assertDoesNotThrow(() -> new OrgTreeRenderer(List.of()));
+    }
+
+    @Test
+    void content_hasOrgChartClass() {
+        var root = new OrgTreeRenderer.Node("A", "Alice", "Founder", "founder", "sub");
+        var renderer = new OrgTreeRenderer(root);
+        String classes = renderer.getElement().getAttribute("class");
+        assertNotNull(classes, "class attribute must not be null");
+        assertTrue(classes.contains("org-chart"),
+            "wrapper div must carry 'org-chart' so CSS connector-line selectors fire");
+    }
+
+    @Test
+    void deepTree_constructsWithoutError() {
+        var carol = new OrgTreeRenderer.Node("C", "Carol Levy",   "Manager", "manager", "Appointed by Bob · Manage events");
+        var dave  = new OrgTreeRenderer.Node("D", "Dave Peretz",  "Manager", "manager", "Appointed by Bob · Inquiries");
+        var bob   = new OrgTreeRenderer.Node("B", "Bob Mizrahi",  "Owner",   "owner",   "Appointed by Alice · 2025-01-08", List.of(carol, dave));
+        var frank = new OrgTreeRenderer.Node("F", "Frank Tal",    "Manager", "manager", "Appointed by Eve · Manage events");
+        var eve   = new OrgTreeRenderer.Node("E", "Eve Bar",      "Owner",   "owner",   "Appointed by Alice · 2025-02-14", List.of(frank));
+        var alice = new OrgTreeRenderer.Node("A", "Alice Cohen",  "Founder", "founder", "Founded 2024-12-15", List.of(bob, eve));
+
+        assertDoesNotThrow(() -> new OrgTreeRenderer(alice));
+    }
+}

--- a/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/components/admin/OrgTreeRendererTest.java
@@ -113,9 +113,11 @@ class OrgTreeRendererTest {
     }
 
     @Test
-    void ownerWithNoPermissions_subIsEmpty() {
+    void owner_doesNotRenderSubTextBlock() {
         OrganizationalTreeNodeDTO owner = new OrganizationalTreeNodeDTO(
                 2, "Bob Mizrahi", "Owner", false, List.of(), new ArrayList<>());
-        assertDoesNotThrow(() -> new OrgTreeRenderer(owner));
+        var renderer = new OrgTreeRenderer(owner);
+        assertFalse(renderer.getElement().getOuterHTML().contains("oc-sub"),
+                "owner node must not render a sub-text block regardless of permissions list");
     }
 }


### PR DESCRIPTION
feat(V2-VIEW-NW-02): OrgTreeRenderer — dedicated Vaadin component for organizational hierarchy

This PR implements V2-VIEW-NW-02: a dedicated OrgTreeRenderer Vaadin component
that renders an OrganizationalTreeNodeDTO tree as a connector-line org chart.
It lifts the inline rendering logic that was living inside OrganizationalTreeView
into a reusable, self-contained component wired directly to the DTO produced by
CompanyManagementService.viewOrganizationalTree().

## Key Changes

**Component Layer (OrgTreeRenderer.java — new file)**
Extends Composite<Div> and accepts a single OrganizationalTreeNodeDTO root (the
founder), matching the exact return type of the service. Renders the tree
recursively using UnorderedList / ListItem so the existing .org-chart CSS
connector-line selectors fire without any additional glue.

Variant mapping:
- isFounder == true  →  oc-founder CSS class
- role == "Owner"    →  oc-owner   CSS class
- role == "Manager"  →  oc-manager CSS class

Avatar initial is derived from the first character of username. Sub-text shows
grantedPermissions joined by ", " for managers, and "Company Founder" for the
root node. Composite vs. Leaf badge is set from appointedByThisUser.isEmpty().

**View Layer (OrganizationalTreeView.java — updated)**
Removed the inlined Node record and buildNode recursive method (~54 lines).
buildTreeCard() now constructs stub OrganizationalTreeNodeDTO instances mirroring
the real service output shape, and passes the founder root directly to
new OrgTreeRenderer(alice). Stub is ready to be swapped for a live
CompanyManagementService.viewOrganizationalTree() call when V2-VIEW-03 wires
the presenter.

**Tests (OrgTreeRendererTest.java — new file, 11 tests)**
Pure JUnit 5, no Spring context, runs in ~0.05 s. Placed in the same package
as the component.

Coverage:
- Construction with all three role types (founder, owner, manager) — leaf and composite.
- Full 3-level deep tree (the exact hierarchy from the view stub).
- org-chart CSS class present on the wrapper div.
- All three variant CSS classes (oc-founder, oc-owner, oc-manager) confirmed in rendered output.
- grantedPermissions appear in sub-text for managers.
- Owner with empty permissions list constructs without error.

## Testing

- [x] 11 new unit tests pass (OrgTreeRendererTest — pure JUnit, no Spring context).
- [x] Full compile clean — no warnings.
- [x] Existing test suite intact — 0 failures across all unit, acceptance, and smoke tests.
- [x] Variant mapping covered for all three roles and both leaf / composite node shapes.
- [x] Empty permissions edge case handled — no exception paths to the service.
