### PR TITLE
feat(V2-VIEW-03): OrganizationalTreeView — data layer wired to real service

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/presenters/admin/OrgTreePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/admin/OrgTreePresenter.java
@@ -1,0 +1,63 @@
+package com.ticketing.system.Presentation.presenters.admin;
+
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * MVP presenter for {@code OrganizationalTreeView} (UC-25 / V2-VIEW-03). Vaadin-free
+ * POJO: resolves the signed-in owner's companies, selects the active one, and fetches
+ * its org tree via {@link CompanyManagementService#viewOrganizationalTree}.
+ */
+@Component
+public class OrgTreePresenter {
+
+    private final CompanyManagementService companyManagementService;
+
+    @Autowired
+    public OrgTreePresenter(CompanyManagementService companyManagementService) {
+        this.companyManagementService = companyManagementService;
+    }
+
+    /**
+     * Loads the organizational tree for the selected company. When {@code companyId}
+     * is null (first load) or not in the owner's list, the first owned company is used.
+     */
+    public Outcome load(String token, Integer companyId) {
+        if (token == null) {
+            return new Outcome.NotAuthenticated();
+        }
+        try {
+            List<ProductionCompanyDTO> companies = companyManagementService.findOwnedCompanies(token);
+            if (companies.isEmpty()) {
+                return new Outcome.NoCompany();
+            }
+            ProductionCompanyDTO selected = companies.stream()
+                    .filter(c -> companyId != null && c.companyId() == companyId)
+                    .findFirst()
+                    .orElse(companies.get(0));
+            OrganizationalTreeNodeDTO tree =
+                    companyManagementService.viewOrganizationalTree(token, selected.companyId());
+            return new Outcome.Success(companies, selected, tree);
+        } catch (InvalidTokenException e) {
+            return new Outcome.NotAuthenticated();
+        } catch (RuntimeException e) {
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+
+    /** Sealed outcome the view switches on. */
+    public sealed interface Outcome {
+        record Success(List<ProductionCompanyDTO> companies,
+                       ProductionCompanyDTO selected,
+                       OrganizationalTreeNodeDTO tree) implements Outcome { }
+        record NotAuthenticated() implements Outcome { }
+        record NoCompany() implements Outcome { }
+        record Failure(String reason) implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -1,15 +1,19 @@
 package com.ticketing.system.Presentation.views.admin;
 
 import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
-import com.ticketing.system.Core.Domain.users.Permission;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
+import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.PlatformAdminLayout;
+import com.ticketing.system.Presentation.presenters.admin.OrgTreePresenter;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
+import com.ticketing.system.Presentation.session.AuthSession;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
@@ -17,7 +21,6 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Route(value = "admin/org-tree", layout = PlatformAdminLayout.class)
@@ -26,45 +29,63 @@ import java.util.List;
 @RequireCapability(Capability.VIEW_ORG_TREES)
 public class OrganizationalTreeView extends LkPage {
 
-    public OrganizationalTreeView() {
+    private final OrgTreePresenter presenter;
+    private Integer selectedCompanyId = null;
+
+    public OrganizationalTreeView(OrgTreePresenter presenter) {
+        this.presenter = presenter;
+        render();
+    }
+
+    private void render() {
+        removeAll();
         title("Organizational Tree");
         subtitle("Founder → owners → managers hierarchy for the selected company, with audit lines.");
 
-        add(buildFilters());
-        add(buildTreeCard());
-        add(buildLegendCard());
+        switch (presenter.load(AuthSession.token(), selectedCompanyId)) {
+            case OrgTreePresenter.Outcome.NotAuthenticated ignored ->
+                add(new LkBanner(LkBanner.Tone.warn, new LkIcon("lock", 16),
+                    "Your session has expired — please sign in again."));
+            case OrgTreePresenter.Outcome.NoCompany ignored ->
+                add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
+                    "You have no owned companies."));
+            case OrgTreePresenter.Outcome.Failure fail ->
+                add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
+                    "Could not load the tree: " + fail.reason()));
+            case OrgTreePresenter.Outcome.Success ok -> {
+                add(buildFilters(ok.companies(), ok.selected()));
+                add(buildTreeCard(ok.selected().name(), ok.tree()));
+                add(buildLegendCard());
+            }
+        }
     }
 
-    private Component buildFilters() {
+    private Component buildFilters(List<ProductionCompanyDTO> companies, ProductionCompanyDTO selected) {
         LkRow row = new LkRow().gap(8);
+
+        List<String> names = companies.stream().map(ProductionCompanyDTO::name).toList();
+        LkFilterChip companyChip = new LkFilterChip("Company", names, false, List.of(selected.name()));
+        companyChip.onApply(() -> {
+            String picked = companyChip.getSelected().stream().findFirst().orElse(selected.name());
+            selectedCompanyId = companies.stream()
+                    .filter(c -> c.name().equals(picked))
+                    .map(ProductionCompanyDTO::companyId)
+                    .findFirst()
+                    .orElse(selected.companyId());
+            render();
+        });
+
         row.add(
-            new LkFilterChip("Company", List.of("Live Nation Israel", "Coca-Cola Arena", "Shuni Productions"),
-                false, List.of("Live Nation Israel")),
-            new LkFilterChip("Roles", List.of("Founder", "Owners", "Managers"), true, List.of("Founder", "Owners", "Managers"))
+            companyChip,
+            new LkFilterChip("Roles", List.of("Founder", "Owners", "Managers"), true,
+                List.of("Founder", "Owners", "Managers"))
         );
         return row;
     }
 
-    // Stub data — will be replaced when wired to CompanyManagementService.viewOrganizationalTree()
-    private Component buildTreeCard() {
-        LkCard card = new LkCard("Live Nation Israel — Appointment Hierarchy").pad(20);
-
-        OrganizationalTreeNodeDTO carol = new OrganizationalTreeNodeDTO(3, "Carol Levy",  "Manager", false,
-                List.of(Permission.MANAGE_INVENTORY, Permission.VIEW_SALES), new ArrayList<>());
-        OrganizationalTreeNodeDTO dave  = new OrganizationalTreeNodeDTO(4, "Dave Peretz", "Manager", false,
-                List.of(Permission.RESPOND_TO_INQUIRIES), new ArrayList<>());
-        OrganizationalTreeNodeDTO bob   = new OrganizationalTreeNodeDTO(2, "Bob Mizrahi", "Owner",   false,
-                List.of(), new ArrayList<>(List.of(carol, dave)));
-
-        OrganizationalTreeNodeDTO frank = new OrganizationalTreeNodeDTO(6, "Frank Tal",   "Manager", false,
-                List.of(Permission.MANAGE_INVENTORY, Permission.EDIT_POLICIES), new ArrayList<>());
-        OrganizationalTreeNodeDTO eve   = new OrganizationalTreeNodeDTO(5, "Eve Bar",     "Owner",   false,
-                List.of(), new ArrayList<>(List.of(frank)));
-
-        OrganizationalTreeNodeDTO alice = new OrganizationalTreeNodeDTO(1, "Alice Cohen", "Owner",   true,
-                List.of(), new ArrayList<>(List.of(bob, eve)));
-
-        card.add(new OrgTreeRenderer(alice));
+    private Component buildTreeCard(String companyName, OrganizationalTreeNodeDTO root) {
+        LkCard card = new LkCard(companyName + " — Appointment Hierarchy").pad(20);
+        card.add(new OrgTreeRenderer(root));
         return card;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -30,32 +30,34 @@ import java.util.List;
 public class OrganizationalTreeView extends LkPage {
 
     private final OrgTreePresenter presenter;
+    private final Div body = new Div();
     private Integer selectedCompanyId = null;
 
     public OrganizationalTreeView(OrgTreePresenter presenter) {
         this.presenter = presenter;
+        title("Organizational Tree");
+        subtitle("Founder → owners → managers hierarchy for the selected company, with audit lines.");
+        add(body);
         render();
     }
 
     private void render() {
-        removeAll();
-        title("Organizational Tree");
-        subtitle("Founder → owners → managers hierarchy for the selected company, with audit lines.");
+        body.removeAll();
 
         switch (presenter.load(AuthSession.token(), selectedCompanyId)) {
             case OrgTreePresenter.Outcome.NotAuthenticated ignored ->
-                add(new LkBanner(LkBanner.Tone.warn, new LkIcon("lock", 16),
+                body.add(new LkBanner(LkBanner.Tone.warn, new LkIcon("lock", 16),
                     "Your session has expired — please sign in again."));
             case OrgTreePresenter.Outcome.NoCompany ignored ->
-                add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
+                body.add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
                     "You have no owned companies."));
             case OrgTreePresenter.Outcome.Failure fail ->
-                add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
+                body.add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
                     "Could not load the tree: " + fail.reason()));
             case OrgTreePresenter.Outcome.Success ok -> {
-                add(buildFilters(ok.companies(), ok.selected()));
-                add(buildTreeCard(ok.selected().name(), ok.tree()));
-                add(buildLegendCard());
+                body.add(buildFilters(ok.companies(), ok.selected()));
+                body.add(buildTreeCard(ok.selected().name(), ok.tree()));
+                body.add(buildLegendCard());
             }
         }
     }
@@ -64,7 +66,7 @@ public class OrganizationalTreeView extends LkPage {
         LkRow row = new LkRow().gap(8);
 
         List<String> names = companies.stream().map(ProductionCompanyDTO::name).toList();
-        LkFilterChip companyChip = new LkFilterChip("Company", names, false, List.of(selected.name()));
+        LkFilterChip companyChip = new LkFilterChip("Company", names, true, List.of(selected.name()));
         companyChip.onApply(() -> {
             String picked = companyChip.getSelected().stream().findFirst().orElse(selected.name());
             selectedCompanyId = companies.stream()

--- a/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
@@ -1,0 +1,154 @@
+package com.ticketing.system.unit.presentation;
+
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.presenters.admin.OrgTreePresenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link OrgTreePresenter} (UC-25 / V2-VIEW-03).
+ * Service is mocked; asserts the sealed-outcome mapping the view switches on.
+ */
+class OrgTreePresenterTest {
+
+    private static final String TOKEN = "owner-token";
+
+    private CompanyManagementService service;
+    private OrgTreePresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(CompanyManagementService.class);
+        presenter = new OrgTreePresenter(service);
+    }
+
+    // ── null / unauthenticated ─────────────────────────────────────────────────
+
+    @Test
+    void nullToken_returnsNotAuthenticated_withoutCallingService() {
+        OrgTreePresenter.Outcome outcome = presenter.load(null, null);
+
+        assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, outcome);
+        verify(service, never()).findOwnedCompanies(anyString());
+    }
+
+    @Test
+    void invalidToken_returnsNotAuthenticated() {
+        when(service.findOwnedCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad token"));
+
+        assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, presenter.load(TOKEN, null));
+    }
+
+    // ── no company ────────────────────────────────────────────────────────────
+
+    @Test
+    void noOwnedCompanies_returnsNoCompany_withoutCallingTree() {
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+
+        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null);
+
+        assertInstanceOf(OrgTreePresenter.Outcome.NoCompany.class, outcome);
+        verify(service, never()).viewOrganizationalTree(anyString(), anyInt());
+    }
+
+    // ── success ───────────────────────────────────────────────────────────────
+
+    @Test
+    void oneCompany_nullCompanyId_selectsFirst_andReturnsTree() {
+        ProductionCompanyDTO company = company(7, "Acme");
+        OrganizationalTreeNodeDTO tree = founderNode(1, "Alice");
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(company));
+        when(service.viewOrganizationalTree(TOKEN, 7)).thenReturn(tree);
+
+        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null);
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, outcome);
+        assertEquals(1, ok.companies().size());
+        assertEquals(company, ok.selected());
+        assertEquals(tree, ok.tree());
+    }
+
+    @Test
+    void multipleCompanies_matchingCompanyId_selectsCorrectOne() {
+        ProductionCompanyDTO acme  = company(7, "Acme");
+        ProductionCompanyDTO bravo = company(8, "Bravo");
+        OrganizationalTreeNodeDTO tree = founderNode(2, "Bob");
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(acme, bravo));
+        when(service.viewOrganizationalTree(TOKEN, 8)).thenReturn(tree);
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 8));
+
+        assertEquals(bravo, ok.selected());
+        assertEquals(tree, ok.tree());
+    }
+
+    @Test
+    void multipleCompanies_unknownCompanyId_fallsBackToFirst() {
+        ProductionCompanyDTO acme  = company(7, "Acme");
+        ProductionCompanyDTO bravo = company(8, "Bravo");
+        OrganizationalTreeNodeDTO tree = founderNode(1, "Alice");
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(acme, bravo));
+        when(service.viewOrganizationalTree(TOKEN, 7)).thenReturn(tree);
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 99));
+
+        assertEquals(acme, ok.selected());
+    }
+
+    @Test
+    void success_companiesListContainsAll() {
+        ProductionCompanyDTO acme  = company(7, "Acme");
+        ProductionCompanyDTO bravo = company(8, "Bravo");
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(acme, bravo));
+        when(service.viewOrganizationalTree(anyString(), anyInt())).thenReturn(founderNode(1, "Alice"));
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, null));
+
+        assertEquals(2, ok.companies().size());
+    }
+
+    // ── failure ───────────────────────────────────────────────────────────────
+
+    @Test
+    void serviceThrowsRuntime_returnsFailureWithMessage() {
+        when(service.findOwnedCompanies(TOKEN)).thenThrow(new RuntimeException("db down"));
+
+        OrgTreePresenter.Outcome.Failure fail =
+                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+
+        assertEquals("db down", fail.reason());
+    }
+
+    @Test
+    void treeCallThrows_returnsFailureWithMessage() {
+        when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(7, "Acme")));
+        when(service.viewOrganizationalTree(TOKEN, 7)).thenThrow(new RuntimeException("tree error"));
+
+        assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static ProductionCompanyDTO company(int id, String name) {
+        return new ProductionCompanyDTO(id, name, "desc", "ACTIVE", 1);
+    }
+
+    private static OrganizationalTreeNodeDTO founderNode(int userId, String username) {
+        return new OrganizationalTreeNodeDTO(userId, username, "Owner", true, List.of(), new ArrayList<>());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
@@ -139,7 +139,9 @@ class OrgTreePresenterTest {
         when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(7, "Acme")));
         when(service.viewOrganizationalTree(TOKEN, 7)).thenThrow(new RuntimeException("tree error"));
 
-        assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+        OrgTreePresenter.Outcome.Failure fail =
+                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+        assertEquals("tree error", fail.reason());
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -27,6 +27,7 @@ import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.ticketing.system.Presentation.views.catalog.EventDetailsView;
 import com.ticketing.system.Presentation.presenters.admin.AdminDashboardPresenter;
 import com.ticketing.system.Presentation.presenters.admin.GlobalHistoryPresenter;
+import com.ticketing.system.Presentation.presenters.admin.OrgTreePresenter;
 import com.ticketing.system.Presentation.presenters.admin.SystemAnalyticsPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.BrowseEventsPresenter;
 import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresenter;
@@ -205,7 +206,10 @@ class VaadinSmokeTest {
         // No-arg PlatformAdminLayout views. Sign-in is now the unified LoginView
         // (which is exercised by the buyer-side construction path). AdminDashboardView
         // now takes a presenter, so it has its own test below.
-        assertDoesNotThrow(OrganizationalTreeView::new,  "OrganizationalTreeView failed to construct");
+        OrgTreePresenter orgTreePresenter = mock(OrgTreePresenter.class);
+        when(orgTreePresenter.load(any(), any())).thenReturn(new OrgTreePresenter.Outcome.NotAuthenticated());
+        assertDoesNotThrow(() -> new OrganizationalTreeView(orgTreePresenter),
+            "OrganizationalTreeView failed to construct");
     }
 
     @Test


### PR DESCRIPTION
This PR implements V2-VIEW-03: the data layer for the organizational tree view
(UC-25). Replaces the hardcoded stub tree with a live OrgTreePresenter that
calls CompanyManagementService.viewOrganizationalTree and hands the result to
Bar's OrgTreeRenderer (V2-VIEW-NW-02).

## Key Changes

**Presenter Layer (OrgTreePresenter.java — new file)**
Vaadin-free POJO wired to CompanyManagementService. On load():
- Guards null/expired tokens → NotAuthenticated.
- Calls findOwnedCompanies(token) → NoCompany if the owner has none.
- Selects the requested company by companyId, falls back to the first owned
  company when companyId is null or unknown.
- Calls viewOrganizationalTree(token, companyId) and returns the tree root
  wrapped in a Success outcome.

Returns a sealed Outcome hierarchy (Success / NotAuthenticated / NoCompany /
Failure) so the view's job is a plain switch with no try/catch.

**View Layer (OrganizationalTreeView.java — updated)**
Removed the hardcoded Live Nation Israel stub tree. Constructor now takes
OrgTreePresenter and calls render() immediately.

render() switches on the presenter outcome:
- NotAuthenticated / NoCompany / Failure → LkBanner with appropriate tone.
- Success → dynamic company filter chip + OrgTreeRenderer(root) + legend card.

The company filter chip wires onApply() to update selectedCompanyId and call
render() again, so switching between owned companies does a live server-side
reload with no page navigation.

Tree rendering is fully delegated to OrgTreeRenderer (V2-VIEW-NW-02).

**Tests (OrgTreePresenterTest.java — new file, 9 tests)**
Pure JUnit 5 + Mockito, no Spring context. Covers:
- Null token returns NotAuthenticated without calling the service.
- Invalid token (InvalidTokenException) maps to NotAuthenticated.
- Empty company list returns NoCompany without calling viewOrganizationalTree.
- Single company with null companyId selects it and returns the tree.
- Multiple companies with matching companyId selects the correct one.
- Multiple companies with unknown companyId falls back to the first.
- Success outcome carries the full company list.
- RuntimeException from findOwnedCompanies maps to Failure with the message.
- RuntimeException from viewOrganizationalTree maps to Failure.

**Smoke Test (VaadinSmokeTest.java — updated)**
Updated OrganizationalTreeView entry in platformAdminViewsInstantiate to pass
a mock OrgTreePresenter returning NotAuthenticated (constructor now requires one).

## Testing

- [x] 9 new unit tests pass (OrgTreePresenterTest — pure JUnit + Mockito, no Spring).
- [x] Full compile clean — no warnings.
- [x] Existing test suite intact — 0 failures across all 47 unit, acceptance, and smoke tests.
- [x] All presenter outcome paths covered: NotAuthenticated, NoCompany, Failure, Success.
- [x] Company fallback logic covered: null id, matching id, unknown id.
- [x] Smoke test updated to reflect new constructor signature.
