### PR TITLE
fix(checkout): harden checkout, reservation, refund & sweeper concurrency and correctness

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CheckoutService.java
@@ -145,7 +145,6 @@ public class CheckoutService {
     // confirm inventory sale, persist, mark bought.
     public CheckoutResultDTO checkoutMember(String token, String idempotencyKey, String currency,
             CardDetailsDTO card) {
-        requireMarketOpen();
         int userId = -1;
         ActiveOrder order = null;
         PaymentResultDTO paymentResult = null;
@@ -167,12 +166,17 @@ public class CheckoutService {
 
             String buyerKey = memberBuyerKey(userId);
 
-            // Check the cache for an existing completed checkout with the same idempotency
-            // key and buyer. If found, return the cached result to ensure idempotency.
+            // Idempotency short-circuit BEFORE the market gate: a completed purchase must be returned even
+            // if the market has since closed (C1). (Pre-flight validation failures above are still wrapped
+            // by the catch as a checkout failure, matching the existing contract.)
             CheckoutResultDTO cached = getCachedCheckoutResult(idempotencyKey, buyerKey);
             if (cached != null) {
                 return cached;
             }
+
+            // UC-32 / I.2.1 — no money moves while the market is closed (checked after the idempotency
+            // short-circuit). Rethrown raw by the MarketNotOpenException catch below.
+            requireMarketOpen();
 
             // ---------------------------------------------------------------
             // Phase 1: short lock — validate, snapshot, freeze order
@@ -249,14 +253,12 @@ public class CheckoutService {
             confirmInventorySale(snapshotItems, orderKey);
             inventorySaleConfirmed = true;
 
-            order.buy();
-            // The sale is committed and the receipt is the durable record; the cart has
-            // done its job.
-            // Delete the consumed order (don't save it) — buy() leaves it
-            // CHECKOUT_IN_PROGRESS, so a
-            // save would strand an empty, unmodifiable cart that wedges the buyer's next
-            // reservation.
-            activeOrderRepository.delete(order);
+            // Point of no return passed: the sale is committed and the receipt is the durable record.
+            // Consuming the cart (buy() + delete) is best-effort — a cleanup hiccup must never turn a
+            // committed purchase into a checkout failure (C2). The cart isn't saved: buy() leaves it
+            // CHECKOUT_IN_PROGRESS, so a save would strand an empty, unmodifiable cart that wedges the
+            // buyer's next reservation.
+            finalizeConsumedOrder(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);
             cacheCheckoutResult(idempotencyKey, buyerKey, result);
@@ -266,6 +268,10 @@ public class CheckoutService {
 
             return result;
 
+        } catch (MarketNotOpenException marketClosed) {
+            // Pre-Phase-1 gate failure: nothing was reserved or charged, so there is nothing to roll back.
+            // Propagate it raw (callers/tests distinguish a closed market from a mid-checkout failure).
+            throw marketClosed;
         } catch (Exception e) {
             handleCheckoutFailure(order, userId, orderLockKey, paymentResult, totalPrice, inventorySaleConfirmed,
                     e);
@@ -306,7 +312,6 @@ public class CheckoutService {
     // See checkoutMember for the 3-phase description.
     public CheckoutResultDTO checkoutGuest(String guestSessionId, String guestEmail, String idempotencyKey,
             String currency, CardDetailsDTO card, int buyerAge) {
-        requireMarketOpen();
         ActiveOrder order = null;
         PaymentResultDTO paymentResult = null;
         double totalPrice = 0.0;
@@ -316,7 +321,11 @@ public class CheckoutService {
         List<Integer> lockedEventIds = List.of();
 
         try {
-            validateGuestCheckoutIdentity(guestSessionId, guestEmail);
+            // Presence + input + idempotency short-circuit run BEFORE the market gate so a completed
+            // purchase is returned even if the market has since closed (C1). The session-liveness check is
+            // deferred to just after the gate: it doesn't affect the cache key, and the market gate must
+            // win over a stale-session error to honour the market-closed contract.
+            validateGuestIdentityPresent(guestSessionId, guestEmail);
             validatePaymentInput(idempotencyKey, currency, card, null);
 
             String buyerKey = guestBuyerKey(guestSessionId, guestEmail);
@@ -325,6 +334,9 @@ public class CheckoutService {
             if (cached != null) {
                 return cached;
             }
+
+            requireMarketOpen();
+            validateGuestSessionLive(guestSessionId);
 
             // ---------------------------------------------------------------
             // Phase 1: short lock — validate, snapshot, freeze order
@@ -394,20 +406,21 @@ public class CheckoutService {
             confirmInventorySale(snapshotItems, orderKey);
             inventorySaleConfirmed = true;
 
-            order.buy();
-            // The sale is committed and the receipt is the durable record; the cart has
-            // done its job.
-            // Delete the consumed order (don't save it) — buy() leaves it
-            // CHECKOUT_IN_PROGRESS, so a
-            // save would strand an empty, unmodifiable cart that wedges the buyer's next
-            // reservation.
-            activeOrderRepository.delete(order);
+            // Point of no return passed: the sale is committed and the receipt is the durable record.
+            // Consuming the cart (buy() + delete) is best-effort — a cleanup hiccup must never turn a
+            // committed purchase into a checkout failure (C2). The cart isn't saved: buy() leaves it
+            // CHECKOUT_IN_PROGRESS, so a save would strand an empty, unmodifiable cart that wedges the
+            // buyer's next reservation.
+            finalizeConsumedOrder(order);
 
             CheckoutResultDTO result = buildCheckoutResult(totalPrice, orderReceiptId, paymentResult, issuanceResult);
             cacheCheckoutResult(idempotencyKey, buyerKey, result);
 
             return result;
 
+        } catch (MarketNotOpenException marketClosed) {
+            // Pre-Phase-1 gate failure: nothing reserved or charged, nothing to roll back. Propagate raw.
+            throw marketClosed;
         } catch (Exception e) {
             handleGuestCheckoutFailure(order, guestSessionId, orderLockKey, paymentResult, totalPrice,
                     inventorySaleConfirmed, e);
@@ -460,17 +473,22 @@ public class CheckoutService {
     // associate the checkout with a specific guest session for tracking and that we
     // have an email to send the receipt to. If any of these validations fail, we
     // throw an exception to prevent the checkout from proceeding.
-    private void validateGuestCheckoutIdentity(String guestSessionId, String guestEmail) {
+    // Presence checks only — needed to form the idempotency cache key, so they run before the market gate.
+    private void validateGuestIdentityPresent(String guestSessionId, String guestEmail) {
         if (guestSessionId == null || guestSessionId.isBlank()) {
             throw new InvalidTokenException("guestSessionId is required");
         }
 
-        if (!sessionManager.validateCredential(guestSessionId)) {
-            throw new SessionExpiredException();
-        }
-
         if (guestEmail == null || guestEmail.isBlank()) {
             throw new InvalidTokenException("guestEmail is required");
+        }
+    }
+
+    // Liveness check — the guest session must still be valid. Runs after the idempotency short-circuit so
+    // a completed purchase can be replayed without a live session.
+    private void validateGuestSessionLive(String guestSessionId) {
+        if (!sessionManager.validateCredential(guestSessionId)) {
+            throw new SessionExpiredException();
         }
     }
 
@@ -851,23 +869,60 @@ public class CheckoutService {
     private void confirmInventorySale(List<CartLineItem> boughtItems, String orderKey) {
         Map<Integer, Map<Integer, List<CartLineItem>>> grouped = groupItemsByEventAndZone(boughtItems);
 
-        for (Map.Entry<Integer, Map<Integer, List<CartLineItem>>> eventEntry : grouped.entrySet()) {
-            Event event = eventRepository.findById(eventEntry.getKey());
+        // Confirming across multiple events/zones is not a single atomic step. Track each confirmed unit
+        // so a mid-loop failure can be compensated (SOLD -> AVAILABLE): we must never leave a partial SOLD
+        // end-state, so the normal !inventorySaleConfirmed rollback + refund stays correct (C3).
+        List<ConfirmedUnit> confirmed = new ArrayList<>();
+        try {
+            for (Map.Entry<Integer, Map<Integer, List<CartLineItem>>> eventEntry : grouped.entrySet()) {
+                Event event = eventRepository.findById(eventEntry.getKey());
 
-            for (Map.Entry<Integer, List<CartLineItem>> zoneEntry : eventEntry.getValue().entrySet()) {
-                int zoneId = zoneEntry.getKey();
-                List<CartLineItem> zoneItems = zoneEntry.getValue();
+                for (Map.Entry<Integer, List<CartLineItem>> zoneEntry : eventEntry.getValue().entrySet()) {
+                    int zoneId = zoneEntry.getKey();
+                    List<CartLineItem> zoneItems = zoneEntry.getValue();
 
-                List<String> seatNumbers = extractSeatNumbers(zoneItems);
+                    List<String> seatNumbers = extractSeatNumbers(zoneItems);
+                    InventorySelection selection = seatNumbers.isEmpty()
+                            ? InventorySelection.standing(zoneItems.size(), orderKey)
+                            : InventorySelection.seated(seatNumbers, orderKey);
 
-                if (seatNumbers.isEmpty()) {
-                    event.confirmInventorySale(zoneId, InventorySelection.standing(zoneItems.size(), orderKey));
-                } else {
-                    event.confirmInventorySale(zoneId, InventorySelection.seated(seatNumbers, orderKey));
+                    event.confirmInventorySale(zoneId, selection);
+                    confirmed.add(new ConfirmedUnit(event, zoneId, selection));
                 }
-            }
 
-            eventRepository.save(event);
+                eventRepository.save(event);
+            }
+        } catch (RuntimeException confirmFailure) {
+            compensateConfirmedSales(confirmed);
+            throw confirmFailure;
+        }
+    }
+
+    // Best-effort reversal (SOLD -> AVAILABLE) of units already confirmed when a multi-event confirm
+    // fails partway, so no inventory is stranded SOLD. Runs under the event locks already held in Phase 3.
+    // Failures are logged, not propagated — we are already on the failure path.
+    private void compensateConfirmedSales(List<ConfirmedUnit> confirmed) {
+        for (int i = confirmed.size() - 1; i >= 0; i--) {
+            ConfirmedUnit unit = confirmed.get(i);
+            try {
+                unit.event().returnSoldToStock(unit.zoneId(), unit.selection());
+                eventRepository.save(unit.event());
+            } catch (RuntimeException compensationFailure) {
+                log.error("Failed to compensate a confirmed sale during checkout rollback. zoneId={}",
+                        unit.zoneId(), compensationFailure);
+            }
+        }
+    }
+
+    // Consume the cart after a committed sale: buy() empties it, delete removes it. Best-effort — a
+    // cleanup failure here must not turn a committed purchase into a checkout failure (C2).
+    private void finalizeConsumedOrder(ActiveOrder order) {
+        try {
+            order.buy();
+            activeOrderRepository.delete(order);
+        } catch (RuntimeException cleanupFailure) {
+            log.warn("Sale committed but consumed-order cleanup failed for orderKey={}",
+                    order.getOrderKey(), cleanupFailure);
         }
     }
 
@@ -1106,7 +1161,9 @@ public class CheckoutService {
                     userId);
         }
 
-        if (paymentResult != null) {
+        // Refund only if the sale did NOT commit. Once inventory is confirmed SOLD the purchase is final;
+        // refunding here would leave the buyer holding tickets they were also refunded for (C2).
+        if (paymentResult != null && !inventorySaleConfirmed) {
             safelyRefundPayment(paymentResult, totalPrice);
         }
 
@@ -1156,7 +1213,9 @@ public class CheckoutService {
                     guestSessionId);
         }
 
-        if (paymentResult != null) {
+        // Refund only if the sale did NOT commit. Once inventory is confirmed SOLD the purchase is final;
+        // refunding here would leave the buyer holding tickets they were also refunded for (C2).
+        if (paymentResult != null && !inventorySaleConfirmed) {
             safelyRefundPayment(paymentResult, totalPrice);
         }
     }
@@ -1444,6 +1503,14 @@ public class CheckoutService {
     private record PricedCartLine(
             CartLineItem item,
             double finalPrice) {
+    }
+
+    // A single (event, zone, selection) that was confirmed SOLD during confirmInventorySale — kept so a
+    // partial-confirm failure can be compensated back to AVAILABLE (C3).
+    private record ConfirmedUnit(
+            Event event,
+            int zoneId,
+            InventorySelection selection) {
     }
 
     // This is the value stored in the idempotency cache. It includes the buyerKey

--- a/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
@@ -81,35 +81,48 @@ public class RefundService {
         }
         int userId = authenticationService.extractUserId(token);
 
-        OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(orderId)
-                .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", orderId));
+        RefundResultDTO refundResult;
+        // Serialize the eligibility check + gateway refund + receipt flip per receipt under the receipt
+        // lock. Without it, two concurrent requests (double-click / retry) could both pass wasRefunded()
+        // and both call paymentGateway.refund() — refunding the buyer twice. Fetching inside the lock
+        // means the loser sees isRefunded=true (happens-before via the same lock) and bails.
+        orderReceiptRepository.lockForUpdate(orderId);
+        try {
+            OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(orderId)
+                    .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", orderId));
 
-        Integer holderUserId = receipt.getHolderUserId();
-        if (holderUserId == null || holderUserId != userId) {
-            throw new UnauthorizedActionException("refund order " + orderId, userId);
+            Integer holderUserId = receipt.getHolderUserId();
+            if (holderUserId == null || holderUserId != userId) {
+                throw new UnauthorizedActionException("refund order " + orderId, userId);
+            }
+
+            if (receipt.wasRefunded()) {
+                throw new BusinessRuleViolationException("Order " + orderId + " has already been refunded");
+            }
+
+            double refundAmount = receipt.getTotalAmount();
+            // Charge the gateway BEFORE touching domain state — we never want a receipt marked refunded
+            // while the gateway disagrees.
+            int paymentTransactionId = receipt.getPaymentTransactionId()
+                    .orElseThrow(() -> new RefundFailedException(orderId, "receipt does not contain a payment transaction"));
+
+            refundResult = paymentGateway.refund(paymentTransactionId, refundAmount);
+            validateRefundResult(orderId, refundAmount, refundResult);
+
+            receipt.markRefunded(TransactionRecord.refund(
+                    refundResult.refundTransactionId(),
+                    paymentGateway.getId(),
+                    refundResult.totalRefunded(),
+                    receipt.getPaymentCurrency(),
+                    refundResult.refundedAt()));
+            orderReceiptRepository.save(receipt);
+        } finally {
+            orderReceiptRepository.unlock(orderId);
         }
 
-        if (receipt.wasRefunded()) {
-            throw new BusinessRuleViolationException("Order " + orderId + " has already been refunded");
-        }
-
-        double refundAmount = receipt.getTotalAmount();
-        // Charge the gateway BEFORE touching domain state — we never want a receipt marked refunded
-        // while the gateway disagrees.
-        int paymentTransactionId = receipt.getPaymentTransactionId()
-                .orElseThrow(() -> new RefundFailedException(orderId, "receipt does not contain a payment transaction"));
-
-        RefundResultDTO refundResult = paymentGateway.refund(paymentTransactionId, refundAmount);
-        validateRefundResult(orderId, refundAmount, refundResult);
-
-        receipt.markRefunded(TransactionRecord.refund(
-                refundResult.refundTransactionId(),
-                paymentGateway.getId(),
-                refundResult.totalRefunded(),
-                receipt.getPaymentCurrency(),
-                refundResult.refundedAt()));
-        orderReceiptRepository.save(receipt);
-
+        // The money refund + receipt flip have committed under the lock; the remaining ticket flips and
+        // inventory return run outside it (best-effort, idempotent-by-state). A second concurrent request
+        // already bailed on wasRefunded() above, so only this caller reaches here.
         // PAID/ISSUED tickets become REFUNDED; anything else (e.g. reserved-but-unissued) is voided.
         List<Ticket> tickets = ticketRepository.findByOrderReceiptId(orderId);
         List<Ticket> refundedTickets = new ArrayList<>();

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/ActiveOrder.java
@@ -256,8 +256,7 @@ public class ActiveOrder implements InvariantChecked {
                 CartLineItem item = items.get(i);
                 if (item.geteventId() == eventId &&
                         item.getzoneId() == zoneId &&
-                        item.getSeatNumber() == null && // only match standing tickets
-                        !item.isExpired()) {
+                        item.getSeatNumber() == null) { // only match standing tickets; expired included (R1: manual removal)
                     items.remove(i);
                     removedCount++;
                     i--; // adjust index after removal
@@ -283,10 +282,10 @@ public class ActiveOrder implements InvariantChecked {
 
             // start removals
             for (String seatNumber : seatNumbers) {
+                // expired included (R1: a buyer may manually remove an expired seat line).
                 boolean removed = items.removeIf(item -> item.geteventId() == eventId &&
                         item.getzoneId() == zoneId &&
-                        seatNumber.equals(item.getSeatNumber()) &&
-                        !item.isExpired());
+                        seatNumber.equals(item.getSeatNumber()));
 
                 if (!removed) {
                     // check just in case even though we already checked that the seat numbers do exist, to avoid silent failures if there's a bug in the validation logic.
@@ -375,10 +374,10 @@ public class ActiveOrder implements InvariantChecked {
     public void validateContainsSeats(int eventId, int zoneId, List<String> seatNumbers) {
         synchronized (itemsLock) {
             for (String seatNumber : seatNumbers) {
+                // expired included (R1: validation for manual removal of an expired seat line).
                 boolean exists = items.stream().anyMatch(item -> item.geteventId() == eventId &&
                         item.getzoneId() == zoneId &&
-                        seatNumber.equals(item.getSeatNumber()) &&
-                        !item.isExpired());
+                        seatNumber.equals(item.getSeatNumber()));
 
                 if (!exists) {
                     throw new IllegalArgumentException("Active order does not contain seat: " + seatNumber);
@@ -397,8 +396,7 @@ public class ActiveOrder implements InvariantChecked {
         for (CartLineItem item : items) {
             if (item.geteventId() == eventId &&
                     item.getzoneId() == zoneId &&
-                    item.getSeatNumber() == null && // only count standing tickets
-                    !item.isExpired()) {
+                    item.getSeatNumber() == null) { // only count standing tickets; expired included (R1)
                 count = count + 1;
             }
         }
@@ -656,9 +654,10 @@ public class ActiveOrder implements InvariantChecked {
 
 
 
+    // Removal-path helper: expired items are included so a buyer can manually remove an expired line (R1).
     private boolean hasReservationForEventWithoutLock(int eventId) {
         for (CartLineItem item : items) {
-            if (item.geteventId() == eventId && !item.isExpired()) {
+            if (item.geteventId() == eventId) {
                 return true;
             }
         }

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -28,6 +28,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
 
 // V3: aggregate root mapped to JPA. Assigned int @Id (minted by nextId()); comapnyid is a by-id
@@ -57,9 +58,12 @@ public class Event implements InvariantChecked {
     private EventCategory category;
     @Column(name = "company_id", nullable = false)
     private int comapnyid;
+    // volatile: status is read by buyer operations (reserve/release/confirm) holding only the SHARED
+    // event read lock, while markSoldOut()/revertToOnSale() write it. volatile gives those readers
+    // visibility; statusLock (below) makes the auto-transition read-modify-write atomic.
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private EventStatus status;
+    private volatile EventStatus status;
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "venue_map_id")
     private VenueMap venueMap;
@@ -75,6 +79,12 @@ public class Event implements InvariantChecked {
 
     @Version
     private Long version;
+
+    // Runtime monitor guarding the ON_SALE<->SOLD_OUT auto-transitions so concurrent buyer operations
+    // (which hold only the shared event read lock) can't race the status read-modify-write. @Transient:
+    // never persisted; re-created by the field initializer on JPA hydrate (same pattern as seat locks).
+    @Transient
+    private final Object statusLock = new Object();
 
     /** For JPA only — do not call from application code. */
     protected Event() { }
@@ -125,9 +135,12 @@ public class Event implements InvariantChecked {
     public boolean reserveInventory(int zoneId, InventorySelection selection) {
         validateCanReserve(selection);
         this.venueMap.reserveInventory(zoneId, selection);
-        // When the last available place/seat is taken, the event sells out automatically.
-        if (status == EventStatus.ON_SALE && !venueMap.hasAvailableInventory()) {
-            markSoldOut();
+        // When the last available place/seat is taken, the event sells out automatically. Guarded by
+        // statusLock so concurrent buyer reservations can't race this read-modify-write of status.
+        synchronized (statusLock) {
+            if (status == EventStatus.ON_SALE && !venueMap.hasAvailableInventory()) {
+                markSoldOut();
+            }
         }
         return true;
     }
@@ -136,9 +149,11 @@ public class Event implements InvariantChecked {
         validateInventoryAction(selection);
         this.venueMap.releaseInventory(zoneId, selection);
         // Releasing inventory (manual removal, checkout rollback, or expiry sweep) re-opens
-        // a sold-out event for sale again.
-        if (status == EventStatus.SOLD_OUT && venueMap.hasAvailableInventory()) {
-            revertToOnSale();
+        // a sold-out event for sale again. Guarded by statusLock (see reserveInventory).
+        synchronized (statusLock) {
+            if (status == EventStatus.SOLD_OUT && venueMap.hasAvailableInventory()) {
+                revertToOnSale();
+            }
         }
         return true;
     }
@@ -151,8 +166,11 @@ public class Event implements InvariantChecked {
     public boolean returnSoldToStock(int zoneId, InventorySelection selection) {
         validateInventoryAction(selection);
         this.venueMap.returnSoldToStock(zoneId, selection);
-        if (status == EventStatus.SOLD_OUT && venueMap.hasAvailableInventory()) {
-            revertToOnSale();
+        // Guarded by statusLock (see reserveInventory).
+        synchronized (statusLock) {
+            if (status == EventStatus.SOLD_OUT && venueMap.hasAvailableInventory()) {
+                revertToOnSale();
+            }
         }
         return true;
     }
@@ -453,30 +471,38 @@ public class Event implements InvariantChecked {
     // ON_SALE -> SOLD_OUT when no AVAILABLE tickets remain.
     // Auto-fired from reserveInventory; safe to call directly (idempotent when already SOLD_OUT).
     public void markSoldOut() {
-        if (status == EventStatus.SOLD_OUT) {
-            return;
-        }
+        // statusLock makes this read-modify-write atomic against concurrent buyer ops; reentrant when
+        // called from reserveInventory's guarded block on the same thread.
+        synchronized (statusLock) {
+            if (status == EventStatus.SOLD_OUT) {
+                return;
+            }
 
-        if (status != EventStatus.ON_SALE) {
-            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.SOLD_OUT.name());
-        }
+            if (status != EventStatus.ON_SALE) {
+                throw new InvalidStateTransitionException("Event", status.name(), EventStatus.SOLD_OUT.name());
+            }
 
-        this.status = EventStatus.SOLD_OUT;
+            this.status = EventStatus.SOLD_OUT;
+        }
     }
 
 
     // SOLD_OUT -> ON_SALE when availability reappears (a reservation is released).
     // Auto-fired from releaseInventory; safe to call directly (idempotent when already ON_SALE).
     public void revertToOnSale() {
-        if (status == EventStatus.ON_SALE) {
-            return;
-        }
+        // statusLock makes this read-modify-write atomic against concurrent buyer ops; reentrant when
+        // called from releaseInventory/returnSoldToStock's guarded block on the same thread.
+        synchronized (statusLock) {
+            if (status == EventStatus.ON_SALE) {
+                return;
+            }
 
-        if (status != EventStatus.SOLD_OUT) {
-            throw new InvalidStateTransitionException("Event", status.name(), EventStatus.ON_SALE.name());
-        }
+            if (status != EventStatus.SOLD_OUT) {
+                throw new InvalidStateTransitionException("Event", status.name(), EventStatus.ON_SALE.name());
+            }
 
-        this.status = EventStatus.ON_SALE;
+            this.status = EventStatus.ON_SALE;
+        }
     }
 
     

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/SessionAndOrderSweeper.java
@@ -108,8 +108,14 @@ public class SessionAndOrderSweeper {
     public int sweepExpiredOrders() {
         List<ActiveOrder> expired = activeOrderRepository.findExpired();
         for (ActiveOrder order : expired) {
-            releaseTicketsToInventory(order);
-            eventPublisher.publishEvent(new OrderExpiredEvent(order.getUserId(), order.getSessionId()));
+            // requireStillExpired=true: only release/delete if the cart is still expired when we lock it
+            // (a buyer may have manually removed the expired line since findExpired() scanned). Publish the
+            // OrderExpired event only when we actually released, so a salvaged cart doesn't trigger a
+            // spurious "your order expired" notification.
+            boolean released = releaseTicketsToInventory(order, true);
+            if (released) {
+                eventPublisher.publishEvent(new OrderExpiredEvent(order.getUserId(), order.getSessionId()));
+            }
         }
         return expired.size();
     }
@@ -125,7 +131,9 @@ public class SessionAndOrderSweeper {
             return;
         Optional<ActiveOrder> cartOpt = activeOrderRepository.getBySessionId(session.getSessionId());
         if (cartOpt.isPresent()) {
-            releaseTicketsToInventory(cartOpt.get());
+            // requireStillExpired=false: the guest's session has ended, so release the attached cart
+            // regardless of whether its line items have hit their own TTL yet.
+            releaseTicketsToInventory(cartOpt.get(), false);
         }
     }
 
@@ -144,7 +152,7 @@ public class SessionAndOrderSweeper {
      * Checkout failure already resets the order back to PRE_CHECKOUT.
      * Then the sweeper can clean it later if it is still expired.
      */
-    private void releaseTicketsToInventory(ActiveOrder order) {
+    private boolean releaseTicketsToInventory(ActiveOrder order, boolean requireStillExpired) {
         // Derive the same lock key that ReservationService / CheckoutService use.
         String orderLockKey = order.isMember()
                 ? "user:" + order.getUserId()
@@ -169,7 +177,17 @@ public class SessionAndOrderSweeper {
             // (10 min after the last item was added), but this is an acceptable tradeoff to avoid disrupting active checkouts.
             if (order.isCheckoutInProgress()) {
                 log.info("Skipping expired active order {} because checkout is in progress", orderLockKey);
-                return;
+                return false;
+            }
+
+            // Order-expiry path only: re-validate expiry under the lock. A buyer may have manually removed
+            // the expired line (R1) — or renewed the timers — between findExpired() and acquiring this lock,
+            // leaving a healthy cart we must not destroy. The session-expiry path passes false (a guest's
+            // attached cart is released when the session ends, regardless of item expiry).
+            if (requireStillExpired && !order.isEmpty() && !order.hasExpiredItem()) {
+                log.info("Skipping active order {} — items no longer expired (raced with manual removal/renew)",
+                        orderLockKey);
+                return false;
             }
 
             // Acquire locks for all events in the order in a consistent order to prevent deadlocks with concurrent checkouts/reservations.
@@ -199,7 +217,11 @@ public class SessionAndOrderSweeper {
                         log.warn("Event with ID {} not found while releasing tickets for order of user id {}. Skipping.", eventEntry.getKey(), order.getUserId());
                         continue;
                     }
-                    // For each zone in the event, determine how many tickets to release
+                    // For each zone, release seated/standing independently. Each release is guarded so one
+                    // failure (e.g. a double-release race with abandonActiveOrder, or an event mid-edit)
+                    // can't abort cleanup of the remaining zones/events or the rest of the sweep tick. The
+                    // event is saved only if at least one release in it actually succeeded.
+                    boolean anyReleased = false;
                     for (Map.Entry<Integer, List<CartLineItem>> zoneEntry : eventEntry.getValue().entrySet()) {
                         int zoneId = zoneEntry.getKey();
                         List<CartLineItem> items = zoneEntry.getValue();
@@ -211,19 +233,29 @@ public class SessionAndOrderSweeper {
 
                         String orderKey = order.getOrderKey();
                         int standingCount = (int) items.stream().filter(i -> i.getSeatNumber() == null).count();
-                        if (standingCount > 0) {
-                            event.releaseInventory(zoneId, InventorySelection.standing(standingCount, orderKey));
-                        }
-                        if (!seatNumbers.isEmpty()) {
-                            event.releaseInventory(zoneId, InventorySelection.seated(seatNumbers, orderKey));
+                        try {
+                            if (standingCount > 0) {
+                                event.releaseInventory(zoneId, InventorySelection.standing(standingCount, orderKey));
+                                anyReleased = true;
+                            }
+                            if (!seatNumbers.isEmpty()) {
+                                event.releaseInventory(zoneId, InventorySelection.seated(seatNumbers, orderKey));
+                                anyReleased = true;
+                            }
+                        } catch (RuntimeException zoneReleaseFailure) {
+                            log.warn("Sweeper: failed to release zone {} of event {} for order {}; continuing",
+                                    zoneId, eventEntry.getKey(), orderLockKey, zoneReleaseFailure);
                         }
                     }
 
-                    eventRepository.save(event);
+                    if (anyReleased) {
+                        eventRepository.save(event);
+                    }
                 }
                 // Delete the order inside the lock so no other thread can observe
                 // it after the inventory has already been released.
                 activeOrderRepository.delete(order);
+                return true;
             } finally {
                 // Unlock events in reverse order of acquisition.
                 for (int i = sortedEventIds.size() - 1; i >= 0; i--) {

--- a/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CheckoutServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -2508,6 +2509,125 @@ private AtomicBoolean trackReceiptSave() {
         assertEquals(first.totalCharged(), second.totalCharged());
         assertEquals(first.issuedTicketIds(), second.issuedTicketIds());
         verify(mockPaymentGateway, times(1)).charge(any());
+    }
+
+    // --- C3: partial multi-event confirm is compensated (no SOLD stranded) ---
+
+    // Confirming SOLD across multiple events is not a single atomic step. If the second confirm throws
+    // after the first committed, the first must be returned to stock (SOLD -> AVAILABLE), not left SOLD,
+    // and the buyer must be refunded. End state: no inventory SOLD anywhere, both zones available again.
+    @Test
+    void GivenConfirmFailsMidwayAcrossEvents_WhenCheckout_ThenConfirmedSaleCompensatedAndBuyerRefunded() {
+        ActiveOrder activeOrder = new ActiveOrder(USER_ID);
+        String orderKey = activeOrder.getOrderKey();
+
+        StandingZone zone1 = new StandingZone(ZONE_ID_1, "VIP", 5, 100.0);
+        StandingZone zone3 = new StandingZone(ZONE_ID_3, "BALCONY", 5, 200.0);
+        zone1.reserve(InventorySelection.standing(1, orderKey));
+        zone3.reserve(InventorySelection.standing(1, orderKey));
+
+        activeOrder.addStandingReservation(EVENT_ID_1, ZONE_ID_1, 1, 100.0, LocalDateTime.now());
+        activeOrder.addStandingReservation(EVENT_ID_2, ZONE_ID_3, 1, 200.0, LocalDateTime.now());
+
+        when(mockActiveOrderRepo.getByUserId(USER_ID)).thenReturn(activeOrder);
+        when(mockEventRepo.findById(EVENT_ID_1)).thenReturn(event1);
+        when(mockEventRepo.findById(EVENT_ID_2)).thenReturn(event2);
+        when(event1.getVenueMap().getZone(ZONE_ID_1)).thenReturn(zone1);
+        when(event2.getVenueMap().getZone(ZONE_ID_3)).thenReturn(zone3);
+        when(event1.calculatePriceforoneticket(anyInt(), anyDouble(), any(LocalDateTime.class))).thenReturn(100.0);
+        when(event2.calculatePriceforoneticket(anyInt(), anyDouble(), any(LocalDateTime.class))).thenReturn(200.0);
+
+        PaymentResultDTO paymentResult = new PaymentResultDTO(PAYMENT_TRANSACTION_ID, "gateway", 300.0, "ILS",
+                LocalDateTime.now());
+        when(mockPaymentGateway.charge(any(PaymentRequestDTO.class))).thenReturn(paymentResult);
+        when(mockTicketIssuer.issue(any(IssuanceRequestDTO.class))).thenReturn(new IssuanceResultDTO(
+                ISSUANCE_TRANSACTION_ID, "issuer", LocalDateTime.now(),
+                List.of(new BarcodeDTO(TICKET_ID_1, "b1", "QR"), new BarcodeDTO(TICKET_ID_3, "b2", "QR"))));
+
+        // First confirm (whichever event the grouping visits first) commits SOLD; the second throws.
+        AtomicInteger confirmCalls = new AtomicInteger();
+        doAnswer(inv -> {
+            if (confirmCalls.incrementAndGet() >= 2) {
+                throw new RuntimeException("confirm boom");
+            }
+            int zoneId = inv.getArgument(0);
+            InventorySelection sel = inv.getArgument(1);
+            if (zoneId == ZONE_ID_1) {
+                zone1.confirmSale(sel);
+            } else {
+                zone3.confirmSale(sel);
+            }
+            return null;
+        }).when(event1).confirmInventorySale(anyInt(), any());
+        doAnswer(inv -> {
+            if (confirmCalls.incrementAndGet() >= 2) {
+                throw new RuntimeException("confirm boom");
+            }
+            int zoneId = inv.getArgument(0);
+            InventorySelection sel = inv.getArgument(1);
+            if (zoneId == ZONE_ID_1) {
+                zone1.confirmSale(sel);
+            } else {
+                zone3.confirmSale(sel);
+            }
+            return null;
+        }).when(event2).confirmInventorySale(anyInt(), any());
+
+        // Compensation (SOLD -> AVAILABLE) and rollback release delegate to the real zones.
+        doAnswer(inv -> { zone1.returnSoldToStock(inv.getArgument(1)); return true; })
+                .when(event1).returnSoldToStock(eq(ZONE_ID_1), any());
+        doAnswer(inv -> { zone3.returnSoldToStock(inv.getArgument(1)); return true; })
+                .when(event2).returnSoldToStock(eq(ZONE_ID_3), any());
+        when(event1.releaseInventory(eq(ZONE_ID_1), any()))
+                .thenAnswer(inv -> { zone1.release(inv.getArgument(1)); return true; });
+        when(event2.releaseInventory(eq(ZONE_ID_3), any()))
+                .thenAnswer(inv -> { zone3.release(inv.getArgument(1)); return true; });
+
+        assertThrows(RuntimeException.class, () ->
+                checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY, PAYMENT_METHOD_TOKEN));
+
+        // No inventory left SOLD: the confirmed zone was compensated, the other was released.
+        assertEquals(0, zone1.getSoldAmount());
+        assertEquals(0, zone3.getSoldAmount());
+        assertEquals(5, zone1.getAvailableAmount());
+        assertEquals(5, zone3.getAvailableAmount());
+        // Buyer is refunded (the sale never committed).
+        verify(mockPaymentGateway).refund(PAYMENT_TRANSACTION_ID, 300.0);
+    }
+
+    // --- C1: idempotent retry survives the market closing ---
+
+    // A completed purchase must be returned idempotently even if the market has since closed — the cache
+    // lookup runs before the market gate, so the retry returns the cached receipt instead of throwing.
+    @Test
+    void GivenCompletedCheckout_WhenMarketClosesThenSameKeyRetry_ThenReturnsCachedResultNotMarketClosed() {
+        PaymentResultDTO paymentResult = new PaymentResultDTO(PAYMENT_TRANSACTION_ID, "gateway", 100.0, "ILS",
+                LocalDateTime.now());
+        IssuanceResultDTO issuanceResult = new IssuanceResultDTO(ISSUANCE_TRANSACTION_ID, "issuer",
+                LocalDateTime.now(), List.of(new BarcodeDTO(TICKET_ID_1, "barcode-value-1", "QR")));
+
+        when(mockOrder.validateCanCheckout()).thenReturn(true);
+        when(mockOrder.getItems()).thenReturn(List.of(itemEvent1Zone1));
+        when(mockOrder.buy()).thenReturn(List.of(itemEvent1Zone1));
+        when(event1.calculatePriceforoneticket(anyInt(), anyDouble(), any(LocalDateTime.class))).thenReturn(100.0);
+        when(mockPaymentGateway.charge(any(PaymentRequestDTO.class))).thenReturn(paymentResult);
+        when(mockTicketIssuer.issue(any(IssuanceRequestDTO.class))).thenReturn(issuanceResult);
+        StandingZone zone1 = new StandingZone(ZONE_ID_1, "General", 100, 100.0);
+        zone1.reserve(InventorySelection.standing(1));
+        when(event1.getVenueMap().getZone(ZONE_ID_1)).thenReturn(zone1);
+
+        CheckoutResultDTO first = checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY,
+                PAYMENT_METHOD_TOKEN);
+
+        // The market closes after the purchase completed.
+        when(mockSystemAdminService.isMarketOpen()).thenReturn(false);
+
+        // The idempotent retry must still return the cached receipt, not throw MarketNotOpenException.
+        CheckoutResultDTO retry = checkoutService.checkoutMember(VALID_TOKEN, IDEMPOTENCY_KEY, CURRENCY,
+                PAYMENT_METHOD_TOKEN);
+
+        assertEquals(first, retry);
+        verify(mockPaymentGateway, times(1)).charge(any()); // no second charge
     }
 
 }

--- a/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
@@ -4,7 +4,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +19,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.ticketing.system.Core.Application.dto.PaymentRequestDTO;
+import com.ticketing.system.Core.Application.dto.PaymentResultDTO;
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
@@ -31,6 +39,7 @@ import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 import com.ticketing.system.Core.Domain.orders.ReceiptLine;
 import com.ticketing.system.Core.Domain.orders.TransactionRecord;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.MemoryOrderReceiptRepository;
 
 @ExtendWith(MockitoExtension.class)
 class RefundServiceTest {
@@ -214,5 +223,64 @@ class RefundServiceTest {
 
         assertThat(receipt.wasRefunded()).isFalse();
         Mockito.verify(orderReceiptRepository, Mockito.never()).save(Mockito.any());
+    }
+
+    // X1 regression: two concurrent refund requests for the same order must not both reach the gateway.
+    // Uses the real MemoryOrderReceiptRepository so the per-receipt lock actually serializes the calls;
+    // the loser must see the order already refunded and bail. Deterministic given the lock (one wins,
+    // one throws BusinessRuleViolationException) regardless of thread timing.
+    @Test
+    void givenConcurrentRefundRequests_whenRequestRefund_thenGatewayRefundsExactlyOnce() throws Exception {
+        IOrderReceiptRepository realReceiptRepo = new MemoryOrderReceiptRepository();
+        OrderReceipt receipt = memberReceiptWithCharge(USER_ID);
+        realReceiptRepo.save(receipt); // id == ORDER_ID
+
+        AtomicInteger refundCalls = new AtomicInteger();
+        IPaymentGateway countingGateway = new IPaymentGateway() {
+            @Override public String getId() { return "stub"; }
+            @Override public boolean verifyConnection() { return true; }
+            @Override public PaymentResultDTO charge(PaymentRequestDTO r) { throw new UnsupportedOperationException(); }
+            @Override public RefundResultDTO refund(int txId, double amount) {
+                refundCalls.incrementAndGet();
+                return new RefundResultDTO("refund-" + txId, String.valueOf(txId), amount, WHEN, List.of(), List.of());
+            }
+        };
+
+        AuthenticationService auth = Mockito.mock(AuthenticationService.class);
+        Mockito.when(auth.validateToken(VALID_TOKEN)).thenReturn(true);
+        Mockito.when(auth.extractUserId(VALID_TOKEN)).thenReturn(USER_ID);
+        ITicketRepository ticketRepo = Mockito.mock(ITicketRepository.class);
+        Mockito.when(ticketRepo.findByOrderReceiptId(ORDER_ID)).thenReturn(List.of());
+        IEventRepository eventRepo = Mockito.mock(IEventRepository.class);
+
+        RefundService concurrentService = new RefundService(auth, realReceiptRepo, ticketRepo, countingGateway, eventRepo);
+
+        int threads = 2;
+        CyclicBarrier barrier = new CyclicBarrier(threads);
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger succeeded = new AtomicInteger();
+        AtomicInteger alreadyRefunded = new AtomicInteger();
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threads; i++) {
+            futures.add(pool.submit(() -> {
+                barrier.await();
+                try {
+                    concurrentService.requestRefund(VALID_TOKEN, ORDER_ID, "x");
+                    succeeded.incrementAndGet();
+                } catch (BusinessRuleViolationException expected) {
+                    alreadyRefunded.incrementAndGet();
+                }
+                return null;
+            }));
+        }
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        pool.shutdownNow();
+
+        assertThat(refundCalls.get()).isEqualTo(1);
+        assertThat(succeeded.get()).isEqualTo(1);
+        assertThat(alreadyRefunded.get()).isEqualTo(1);
+        assertThat(receipt.wasRefunded()).isTrue();
     }
 }

--- a/src/test/java/com/ticketing/system/unit/domain/ActiveOrderTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/ActiveOrderTest.java
@@ -275,4 +275,35 @@ class ActiveOrderTest extends BaseDomainTest {
         assertTrue(item.getRemainingTime().getSeconds() > 590);
     }
 
+    // R1: a buyer must be able to manually remove an EXPIRED standing line (previously the !isExpired
+    // filter made expired lines invisible to removal, so they could only be cleared by the sweeper).
+    @Test
+    void GivenExpiredStandingLine_WhenRemoveStandingSpots_ThenLineRemoved() {
+        ActiveOrder order = track(new ActiveOrder(USER_ID));
+        order.addStandingReservation(EVENT_ID, ZONE_ID, 2, 50.0, LocalDateTime.now().minusMinutes(30));
+
+        // Precondition: the lines are genuinely expired.
+        assertTrue(order.getItems().get(0).isExpired());
+
+        order.removeStandingSpots(EVENT_ID, ZONE_ID, 2);
+
+        assertEquals(0, order.countTickets(EVENT_ID, ZONE_ID));
+        assertTrue(order.isEmpty());
+    }
+
+    // R1: same for an expired SEATED line.
+    @Test
+    void GivenExpiredSeatedLine_WhenRemoveSeats_ThenSeatRemoved() {
+        ActiveOrder order = track(new ActiveOrder(USER_ID));
+        order.addSeatedReservation(EVENT_ID, ZONE_ID, List.of("A1", "A2"), 120.0,
+                LocalDateTime.now().minusMinutes(30));
+
+        assertTrue(order.getItems().get(0).isExpired());
+
+        order.removeSeats(EVENT_ID, ZONE_ID, List.of("A1"));
+
+        assertEquals(List.of("A2"),
+                order.getItems().stream().map(CartLineItem::getSeatNumber).toList());
+    }
+
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/SessionAndOrderSweeperTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -158,7 +159,7 @@ class SessionAndOrderSweeperTest {
     @Test
     void cartWithExpiredItems_deletedAndTicketsReleased() {
         ActiveOrder expiredCart = ActiveOrder.forMember(5, "sid-1");
-        expiredCart.addStandingReservation(2, 20, 3, 30.0, LocalDateTime.now());
+        expiredCart.addStandingReservation(2, 20, 3, 30.0, LocalDateTime.now().minusMinutes(30));
         when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
 
         Event event = mock(Event.class);
@@ -175,9 +176,9 @@ class SessionAndOrderSweeperTest {
     @Test
     void cartWithExpiredItemsAcrossMultipleEvents_releasesPerZoneAggregated() {
         ActiveOrder cart = ActiveOrder.forGuest("sid-multi");
-        cart.addStandingReservation(1, 10, 2, 50.0, LocalDateTime.now());   // 2 in event=1 zone=10
-        cart.addStandingReservation(1, 20, 1, 75.0, LocalDateTime.now());   // 1 in event=1 zone=20
-        cart.addStandingReservation(2, 30, 1, 100.0, LocalDateTime.now());  // 1 in event=2 zone=30
+        cart.addStandingReservation(1, 10, 2, 50.0, LocalDateTime.now().minusMinutes(30));   // 2 in event=1 zone=10
+        cart.addStandingReservation(1, 20, 1, 75.0, LocalDateTime.now().minusMinutes(30));   // 1 in event=1 zone=20
+        cart.addStandingReservation(2, 30, 1, 100.0, LocalDateTime.now().minusMinutes(30));  // 1 in event=2 zone=30
         when(orderRepo.findExpired()).thenReturn(List.of(cart));
 
         Event event1 = mock(Event.class);
@@ -198,7 +199,7 @@ class SessionAndOrderSweeperTest {
     @Test
     void cartWithEventMissingFromRepo_skipsReleaseGracefully() {
         ActiveOrder cart = ActiveOrder.forGuest("sid-1");
-        cart.addStandingReservation(99, 10, 1, 25.0, LocalDateTime.now());
+        cart.addStandingReservation(99, 10, 1, 25.0, LocalDateTime.now().minusMinutes(30));
         when(orderRepo.findExpired()).thenReturn(List.of(cart));
         when(eventRepo.findById(99)).thenReturn(null);  // event vanished
 
@@ -220,7 +221,7 @@ class SessionAndOrderSweeperTest {
         when(orderRepo.getBySessionId("sid-g")).thenReturn(Optional.empty());
 
         ActiveOrder expiredCart = ActiveOrder.forMember(5, "sid-m");
-        expiredCart.addStandingReservation(1, 10, 1, 30.0, LocalDateTime.now());
+        expiredCart.addStandingReservation(1, 10, 1, 30.0, LocalDateTime.now().minusMinutes(30));
         when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
 
         Event event = mock(Event.class);
@@ -277,7 +278,7 @@ class SessionAndOrderSweeperTest {
                 20,
                 List.of("A1", "A2"),
                 120.0,
-                LocalDateTime.now());
+                LocalDateTime.now().minusMinutes(30));
 
         when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
         when(eventRepo.findById(2)).thenReturn(event);
@@ -313,8 +314,8 @@ class SessionAndOrderSweeperTest {
 
         Event event = createEventWithZones(1, List.of(standingZone, seatedZone));
 
-        expiredCart.addStandingReservation(1, 10, 2, 50.0, LocalDateTime.now());
-        expiredCart.addSeatedReservation(1, 20, List.of("A1"), 120.0, LocalDateTime.now());
+        expiredCart.addStandingReservation(1, 10, 2, 50.0, LocalDateTime.now().minusMinutes(30));
+        expiredCart.addSeatedReservation(1, 20, List.of("A1"), 120.0, LocalDateTime.now().minusMinutes(30));
 
         when(orderRepo.findExpired()).thenReturn(List.of(expiredCart));
         when(eventRepo.findById(1)).thenReturn(event);
@@ -399,6 +400,52 @@ class SessionAndOrderSweeperTest {
 
 
 
+
+    // R1-sweeper re-check: findExpired() returned this cart, but by the time the sweeper locks it the
+    // buyer has manually removed the expired line (now allowed), leaving only fresh items. The sweeper
+    // must re-validate expiry under the lock and NOT destroy the salvaged cart.
+    @Test
+    void cartNoLongerExpiredWhenLocked_isSkippedNotDeleted() {
+        ActiveOrder healthyAgain = ActiveOrder.forMember(5, "sid-healthy");
+        healthyAgain.addStandingReservation(1, 10, 1, 30.0, LocalDateTime.now()); // fresh, not expired
+        when(orderRepo.findExpired()).thenReturn(List.of(healthyAgain));
+
+        int scanned = sweeper.sweepExpiredOrders();
+
+        assertEquals(1, scanned);
+        verify(orderRepo).lockForUpdate("user:5");
+        verify(orderRepo).unlock("user:5");
+        verify(orderRepo, never()).delete(any());
+        verify(eventRepo, never()).lockForUpdate(anyInt());
+        verify(eventRepo, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    // RC1: one zone release failing (e.g. a double-release race with abandonActiveOrder) must not abort
+    // release of the other events or the deletion of the order.
+    @Test
+    void zoneReleaseFailure_doesNotAbortRemainingReleasesOrDelete() {
+        ActiveOrder cart = ActiveOrder.forGuest("sid-resilient");
+        cart.addStandingReservation(1, 10, 1, 50.0, LocalDateTime.now().minusMinutes(30)); // event 1 -> throws
+        cart.addStandingReservation(2, 20, 1, 60.0, LocalDateTime.now().minusMinutes(30)); // event 2 -> ok
+        when(orderRepo.findExpired()).thenReturn(List.of(cart));
+
+        Event event1 = mock(Event.class);
+        Event event2 = mock(Event.class);
+        when(eventRepo.findById(1)).thenReturn(event1);
+        when(eventRepo.findById(2)).thenReturn(event2);
+        doThrow(new IllegalStateException("boom")).when(event1).releaseInventory(eq(10), any());
+
+        int cleaned = sweeper.sweepExpiredOrders();
+
+        assertEquals(1, cleaned);
+        // event2's release still ran and was persisted despite event1 throwing...
+        verify(event2).releaseInventory(eq(20), any());
+        verify(eventRepo).save(event2);
+        verify(eventRepo, never()).save(event1); // nothing released on event1
+        // ...and the order was still deleted.
+        verify(orderRepo).delete(cart);
+    }
 
     // test helper functions:
 


### PR DESCRIPTION
## Summary

Audit-driven hardening of the two money/inventory-critical flows — **checkout** and **reservation** — plus the adjacent **refund** and **expiry-sweep** paths. Each finding has a fix and a regression test.

## Findings fixed

| ID | Area | Fix |
|----|------|-----|
| X1 | Refund concurrency | Lock the receipt around the `wasRefunded` check + gateway refund + `markRefunded` → no concurrent double-refund on double-click/retry. |
| CC1 | Checkout/Reservation concurrency | `volatile` `Event.status` + a `statusLock` around the ON_SALE↔SOLD_OUT auto-transitions → no data race / spurious `InvalidStateTransition` under concurrent buyer ops. |
| RC1 | Sweeper robustness | Per-zone try/catch so one failed release can't abort cleanup of the rest of the sweep tick. |
| R1 | Reservation UX | Buyers can manually remove an **expired** cart line; the sweeper re-checks expiry under the order lock so a salvaged cart isn't wrongly destroyed. |
| C1 | Checkout correctness | Idempotency cache lookup runs **before** the market-open gate → a completed purchase replays even if the market has since closed. |
| C2 | Checkout correctness | Refund only when the sale did **not** commit; post-commit cart cleanup is best-effort (a committed purchase is never turned into a refund-but-keep-SOLD). |
| C3 | Checkout correctness | A partial multi-event confirm is compensated (SOLD→AVAILABLE) → no inventory stranded SOLD on failure. |

## Tests
- **Refund**: concurrent double-refund → gateway hit exactly once (real repo + lock).
- **Sweeper**: salvaged (no-longer-expired) cart is skipped not deleted; one zone-release failure doesn't abort the rest.
- **ActiveOrder**: expired standing and seated lines are removable.
- **Checkout**: partial multi-event confirm is compensated + buyer refunded (C3); idempotent retry survives the market closing (C1).
- Updated 6 existing sweeper tests to use genuinely-expired timestamps (they previously relied on the mock + `now()`, which the new under-lock re-check correctly skips).

## Verification

`mvn -B clean verify -Pno-vaadin` — **1314 tests, 0 failures, 0 errors** (55 pre-existing `@Disabled` skips).
