### PR TITLE
fix(owner): make Purchase Policies route params optional so the owner workspace loads

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -39,7 +39,7 @@ import com.vaadin.flow.router.RouteParameters;
 
 import jakarta.annotation.security.PermitAll;
 
-@Route(value = "owner/policies/:companyId/:eventId", layout = WorkspaceLayout.class)
+@Route(value = "owner/policies/:companyId?/:eventId?", layout = WorkspaceLayout.class)
 @PageTitle("Purchase Policies · TicketHub")
 @PermitAll
 @RequireCapability(Capability.EDIT_PURCHASE_POLICIES)

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -7,6 +7,7 @@ import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkConfirm;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkSearchPanel;
+import com.ticketing.system.Presentation.components.kit.LkSideNav;
 import com.ticketing.system.Presentation.components.venue.VkQuantitySelector;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
@@ -65,11 +66,15 @@ import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.dto.ConversationDTO;
 import com.ticketing.system.Core.Application.dto.MessageDTO;
 import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
+import com.vaadin.flow.router.Route;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -150,6 +155,42 @@ class VaadinSmokeTest {
         // navigating to a route in a browser.
         assertNotNull(MainLayout.class, "MainLayout class did not load");
         assertNotNull(WorkspaceLayout.class, "WorkspaceLayout class did not load");
+    }
+
+    @Test
+    void workspaceDrawerTargetsAreNavigableWithoutParameters() throws Exception {
+        // Regression for the /owner workspace crash. WorkspaceLayout's drawer builds one
+        // RouterLink per entry via LkSideNav.items() -> link.setRoute(target). Vaadin's
+        // RouterLink.setRoute(Class) throws when the target's @Route template carries a
+        // *mandatory* parameter (e.g. "owner/policies/:companyId/:eventId"), and that throw
+        // propagated out of the layout constructor ("Constructor threw exception"), so every
+        // owner route 500'd. A drawer target must be reachable with no params — its @Route
+        // may only contain optional (":x?") or wildcard (":x*") parameter segments.
+        Field field = WorkspaceLayout.class.getDeclaredField("DRAWER_ITEMS");
+        field.setAccessible(true);
+        List<?> entries = (List<?>) field.get(null);
+
+        for (Object entry : entries) {
+            Method itemAccessor = entry.getClass().getDeclaredMethod("item");
+            itemAccessor.setAccessible(true);
+            LkSideNav.Item item = (LkSideNav.Item) itemAccessor.invoke(entry);
+            Class<?> target = item.target();
+
+            Route route = target.getAnnotation(Route.class);
+            assertNotNull(route,
+                target.getSimpleName() + " (a WorkspaceLayout drawer target) has no @Route");
+
+            for (String segment : route.value().split("/")) {
+                if (segment.startsWith(":")) {
+                    assertTrue(segment.endsWith("?") || segment.endsWith("*"),
+                        target.getSimpleName() + " is a WorkspaceLayout drawer target, but its @Route \""
+                            + route.value() + "\" has the mandatory parameter \"" + segment
+                            + "\" — RouterLink.setRoute() throws when the drawer is built. Make the"
+                            + " parameter optional (\"" + segment + "?\") or point the drawer at a"
+                            + " parameterless route.");
+                }
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem

Entering the owner workspace crashed. Navigating to `/owner` (and any `owner/*` route) returned a 500:

> Could not navigate to 'owner'
> Reason: Error creating bean with name 'com.ticketing.system.Presentation.layouts.WorkspaceLayout': Failed to instantiate ... Constructor threw exception

This affected every **Founder, Co-owner, or policy-editing Manager** — i.e. anyone who could actually use the workspace.

## Root cause

`WorkspaceLayout`'s left drawer builds one `RouterLink` per entry via `LkSideNav.items()` → `link.setRoute(target)`.

One drawer target, `PurchasePolicyEditorView`, declared a route with **mandatory** URL parameters:

```java
@Route(value = "owner/policies/:companyId/:eventId", layout = WorkspaceLayout.class)
```

Vaadin's `RouterLink.setRoute(Class)` throws when the target's template carries a mandatory `:param`, and that exception propagated straight out of the layout constructor. Because the "Purchase Policies" drawer entry is gated by `EDIT_PURCHASE_POLICIES` (which owners hold), the entire workspace shell failed to construct.

The other 7 drawer targets are plain parameterless routes — which is why `MainLayout` and `/my-companies` were unaffected. Server logs confirmed all capability/`listForUser` checks **succeeded** immediately before the throw, ruling out the service layer.

## Fix

Make the parameters **optional**:

```java
@Route(value = "owner/policies/:companyId?/:eventId?", layout = WorkspaceLayout.class)
```

- Parameterless `setRoute()` / `navigate()` now resolve to `owner/policies` instead of throwing.
- Deep-links with parameters still work (`owner/policies/5/9`).
- The view already tolerates absent params: `beforeEnter` reads them via `ifPresent`, and `loadExistingPolicy()` / `savePolicy()` guard on `companyId <= 0`.

This is the documented Vaadin pattern for "navigable with or without a parameter", and it also stops the **click-time** crashes on the parameterless `navigate(PurchasePolicyEditorView.class)` calls in `CompanyEventListView`, `EventManagementView`, and `OwnerDashboardView`.

## Tests

Adds `VaadinSmokeTest.workspaceDrawerTargetsAreNavigableWithoutParameters` — reflects over `WorkspaceLayout`'s drawer targets and asserts each `@Route` is reachable without parameters (no mandatory `:param`). Confirmed it fails against the old route (naming the exact cause) and passes after the fix.

- `mvn -B -Pno-vaadin clean verify` → **BUILD SUCCESS**, 1335 tests, 0 failures, 0 errors.

## Follow-up (not in this PR)

The per-event "Policies" buttons (`CompanyEventListView`, `EventManagementView`) now land on the editor with no event context. A separate change should have them pass the row's `companyId`/`eventId` via `RouteParameters` so the editor opens scoped to that event.