### PR TITLE
feat(owner): implement create-event flow from the New Event form

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -69,6 +69,18 @@ public class EventManagementPresenter {
                                 String description, String categoryName, String country, String city,
                                 LocalDateTime starts, LocalDateTime ends, List<String> artists) {
         if (token == null) return new CreateOutcome.NotAuthenticated();
+
+        // Validate required inputs up front so bad/missing data surfaces as InvalidInput rather than
+        // a leaked NullPointerException (from EventCategory.valueOf / new ShowDate) mapped to Failure.
+        if (isBlank(name))         return new CreateOutcome.InvalidInput("An event title is required.");
+        if (isBlank(categoryName)) return new CreateOutcome.InvalidInput("A category is required.");
+        if (isBlank(country) || isBlank(city))
+                                   return new CreateOutcome.InvalidInput("A country and a city are required.");
+        if (starts == null || ends == null)
+                                   return new CreateOutcome.InvalidInput("A start and an end time are required.");
+        if (artists == null || artists.isEmpty())
+                                   return new CreateOutcome.InvalidInput("At least one artist is required.");
+
         try {
             Integer companyId = resolveCompanyId(token, preferredCompanyId);
             if (companyId == null) return new CreateOutcome.NoCompany();
@@ -94,7 +106,13 @@ public class EventManagementPresenter {
         }
     }
 
-    /** Prefer the passed company when the caller owns it; otherwise the first owned; null when none. */
+    /**
+     * Resolve the company to create under from the caller's <em>owned</em> companies. When a company
+     * is selected ({@code preferredCompanyId} non-null) it must be one the caller owns — otherwise we
+     * return {@code null} ({@code → NoCompany}) rather than silently retargeting to a different
+     * company (e.g. a manager viewing a company they don't own). With no selection, use the first
+     * owned company. {@code null} when the caller owns none.
+     */
     private Integer resolveCompanyId(String token, Integer preferredCompanyId) {
         List<ProductionCompanyDTO> owned = companyService.findOwnedCompanies(token);
         if (owned.isEmpty()) return null;
@@ -102,8 +120,13 @@ public class EventManagementPresenter {
             for (ProductionCompanyDTO c : owned) {
                 if (c.companyId() == preferredCompanyId) return preferredCompanyId;
             }
+            return null;   // selected company isn't owned — don't create under a different one
         }
         return owned.get(0).companyId();
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
     }
 
     public CancelOutcome cancel(String token, int eventId) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -1,11 +1,20 @@
 package com.ticketing.system.Presentation.presenters.company;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 
@@ -13,10 +22,13 @@ import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 public class EventManagementPresenter {
 
     private final EventManagementService eventService;
+    private final CompanyManagementService companyService;
 
     @Autowired
-    public EventManagementPresenter(EventManagementService eventService) {
+    public EventManagementPresenter(EventManagementService eventService,
+                                    CompanyManagementService companyService) {
         this.eventService = eventService;
+        this.companyService = companyService;
     }
 
     public LoadOutcome load(String token, int eventId) {
@@ -45,6 +57,55 @@ public class EventManagementPresenter {
         }
     }
 
+    /**
+     * Creates a new event in DRAFT state under the caller's company. The company is resolved from
+     * the caller's owned companies — {@code preferredCompanyId} (the workspace's currently selected
+     * company) when it is one of them, otherwise the first owned company (matching how
+     * {@code CompanyEventListPresenter} picks the company for the event list the user came from).
+     * Domain value objects ({@link Location}, {@link ShowDate}) are assembled here so the view stays
+     * free of domain construction.
+     */
+    public CreateOutcome create(String token, Integer preferredCompanyId, String name,
+                                String description, String categoryName, String country, String city,
+                                LocalDateTime starts, LocalDateTime ends, List<String> artists) {
+        if (token == null) return new CreateOutcome.NotAuthenticated();
+        try {
+            Integer companyId = resolveCompanyId(token, preferredCompanyId);
+            if (companyId == null) return new CreateOutcome.NoCompany();
+
+            EventCreationDTO request = new EventCreationDTO(
+                companyId,
+                name,
+                description,
+                artists,
+                EventCategory.valueOf(categoryName),
+                null,                                   // rating — set later
+                new Location(country, city),
+                List.of(new ShowDate(starts, ends)),
+                null);                                  // purchase policy — inherits company policy
+            EventDetailDTO created = eventService.addEvent(token, request);
+            return new CreateOutcome.Success(created.eventId());
+        } catch (InvalidTokenException e) {
+            return new CreateOutcome.NotAuthenticated();
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return new CreateOutcome.InvalidInput(e.getMessage());
+        } catch (RuntimeException e) {
+            return new CreateOutcome.Failure(e.getMessage());
+        }
+    }
+
+    /** Prefer the passed company when the caller owns it; otherwise the first owned; null when none. */
+    private Integer resolveCompanyId(String token, Integer preferredCompanyId) {
+        List<ProductionCompanyDTO> owned = companyService.findOwnedCompanies(token);
+        if (owned.isEmpty()) return null;
+        if (preferredCompanyId != null) {
+            for (ProductionCompanyDTO c : owned) {
+                if (c.companyId() == preferredCompanyId) return preferredCompanyId;
+            }
+        }
+        return owned.get(0).companyId();
+    }
+
     public CancelOutcome cancel(String token, int eventId) {
         if (token == null) return new CancelOutcome.NotAuthenticated();
         try {
@@ -68,6 +129,14 @@ public class EventManagementPresenter {
         record Success() implements SaveOutcome {}
         record NotAuthenticated() implements SaveOutcome {}
         record Failure(String reason) implements SaveOutcome {}
+    }
+
+    public sealed interface CreateOutcome {
+        record Success(String eventId) implements CreateOutcome {}
+        record NotAuthenticated() implements CreateOutcome {}
+        record NoCompany() implements CreateOutcome {}
+        record InvalidInput(String reason) implements CreateOutcome {}
+        record Failure(String reason) implements CreateOutcome {}
     }
 
     public sealed interface CancelOutcome {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -187,7 +187,9 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             Toasts.failure("The end time must be after the start time.");
             return;
         }
-        if (start.getValue().isBefore(LocalDateTime.now())) {
+        // Match the domain ShowDate rule, which rejects a start at or before "now" (not just before).
+        LocalDateTime now = LocalDateTime.now();
+        if (!start.getValue().isAfter(now)) {
             Toasts.failure("The start time must be in the future.");
             return;
         }
@@ -203,7 +205,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate("owner/events/" + ok.eventId());
             }
             case EventManagementPresenter.CreateOutcome.NoCompany ignored ->
-                Toasts.failure("You don't have a company to create events under.");
+                Toasts.failure("You can only create events for a company you own.");
             case EventManagementPresenter.CreateOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.CreateOutcome.InvalidInput bad ->

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -20,6 +20,7 @@ import com.ticketing.system.Presentation.security.Capabilities;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.session.CurrentCompanies;
 import com.ticketing.system.Presentation.views.admin.CompanySalesView;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -35,6 +36,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -49,6 +51,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private final Select<String> category = new Select<>();
     private final TextField country = new TextField("Country");
     private final TextField city = new TextField("City");
+    private final TextField artists = new TextField("Artists");
     private final DateTimePicker start = new DateTimePicker("Starts");
     private final DateTimePicker end = new DateTimePicker("Ends");
     private final TextArea description = new TextArea("Description");
@@ -57,6 +60,10 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private final Div statusSlot = new Div();
 
     private final EventManagementPresenter presenter;
+    /** The primary action button — relabelled "Create Event" in create mode. */
+    private LkBtn saveBtn;
+    /** Linked editors / status / danger zone — hidden in create mode (they need a saved event). */
+    private Component sideCol;
     private String eventId = null;   // "new"/null = create flow
     /** The event's full schedule as loaded — kept so an edit to the first show preserves the rest. */
     private List<ShowDate> loadedShowDates = List.of();
@@ -65,11 +72,12 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         this.presenter = presenter;
         title("Edit Event");
         subtitle("Configure event details.");
+        saveBtn = new LkBtn("Save Changes").variant(LkBtn.Variant.primary)
+            .onClick(e -> saveEvent());
         actions(
             new LkBtn("Discard").variant(LkBtn.Variant.tertiary)
                 .onClick(e -> UI.getCurrent().navigate(CompanyEventListView.class)),
-            new LkBtn("Save Changes").variant(LkBtn.Variant.primary)
-                .onClick(e -> saveEvent())
+            saveBtn
         );
         add(buildSplit());
     }
@@ -77,7 +85,16 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         eventId = event.getRouteParameters().get("eventId").orElse(null);
-        if (eventId != null && !"new".equals(eventId)) {
+        boolean createMode = eventId == null || "new".equals(eventId);
+        if (createMode) {
+            title("Create Event");
+            subtitle("Create the event as a draft, then configure its venue and publish it.");
+            saveBtn.label("Create Event");
+            artists.setReadOnly(false);
+            // Linked editors, status and the danger zone all act on a persisted event.
+            sideCol.setVisible(false);
+        } else {
+            artists.setReadOnly(true);
             loadEvent(eventId);
         }
     }
@@ -98,6 +115,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private void applyEvent(EventDetailDTO ev) {
         title.setValue(ev.name() != null ? ev.name() : "");
         category.setValue(ev.category() != null ? ev.category().name() : null);
+        artists.setValue(ev.artistsNames() == null ? "" : String.join(", ", ev.artistsNames()));
         if (ev.location() != null) {
             country.setValue(ev.location().country() != null ? ev.location().country() : "");
             city.setValue(ev.location().city() != null ? ev.location().city() : "");
@@ -130,7 +148,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
 
     private void saveEvent() {
         if ("new".equals(eventId) || eventId == null) {
-            Toasts.warn("Creating a new event is a separate flow.");
+            createEvent();
             return;
         }
         switch (presenter.save(AuthSession.token(),
@@ -149,6 +167,61 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.SaveOutcome.Failure fail ->
                 Toasts.failure("Could not save event: " + fail.reason());
         }
+    }
+
+    /** Create flow (eventId == "new"): validate locally, then hand off to the presenter. */
+    private void createEvent() {
+        String name = blankToNull(title.getValue());
+        if (name == null) { Toasts.failure("Please enter a title."); return; }
+        if (category.getValue() == null) { Toasts.failure("Please choose a category."); return; }
+
+        String co = country.getValue() == null ? "" : country.getValue().trim();
+        String ci = city.getValue() == null ? "" : city.getValue().trim();
+        if (co.isBlank() || ci.isBlank()) { Toasts.failure("Please enter both a country and a city."); return; }
+
+        if (start.getValue() == null || end.getValue() == null) {
+            Toasts.failure("Please set both a start and an end time.");
+            return;
+        }
+        if (!end.getValue().isAfter(start.getValue())) {
+            Toasts.failure("The end time must be after the start time.");
+            return;
+        }
+        if (start.getValue().isBefore(LocalDateTime.now())) {
+            Toasts.failure("The start time must be in the future.");
+            return;
+        }
+
+        List<String> artistList = parseArtists(artists.getValue());
+        if (artistList.isEmpty()) { Toasts.failure("Please list at least one artist."); return; }
+
+        switch (presenter.create(AuthSession.token(), CurrentCompanies.currentCompanyId(),
+                name, blankToNull(description.getValue()), category.getValue(),
+                co, ci, start.getValue(), end.getValue(), artistList)) {
+            case EventManagementPresenter.CreateOutcome.Success ok -> {
+                Toasts.success("Event created as a draft — configure the venue map and publish when ready.");
+                UI.getCurrent().navigate("owner/events/" + ok.eventId());
+            }
+            case EventManagementPresenter.CreateOutcome.NoCompany ignored ->
+                Toasts.failure("You don't have a company to create events under.");
+            case EventManagementPresenter.CreateOutcome.NotAuthenticated ignored ->
+                Toasts.failure("Your session has expired — please sign in again.");
+            case EventManagementPresenter.CreateOutcome.InvalidInput bad ->
+                Toasts.failure(bad.reason());
+            case EventManagementPresenter.CreateOutcome.Failure fail ->
+                Toasts.failure("Could not create event: " + fail.reason());
+        }
+    }
+
+    /** Split a comma-separated artists field into a trimmed, blank-free list. */
+    private static List<String> parseArtists(String csv) {
+        if (csv == null || csv.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
     }
 
     /** Location is country+city in the domain; both are required, so only send it when both are present. */
@@ -186,7 +259,8 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private Component buildSplit() {
         Div split = new Div();
         split.addClassName("ow-edit-split");
-        split.add(buildDetailsCard(), buildSideCol());
+        sideCol = buildSideCol();
+        split.add(buildDetailsCard(), sideCol);
         return split;
     }
 
@@ -203,6 +277,9 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         country.setWidthFull();
         city.setWidthFull();
 
+        artists.setWidthFull();
+        artists.setHelperText("Comma-separated");
+
         start.setWidthFull();
         end.setWidthFull();
 
@@ -214,7 +291,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
                 .set("display", "grid")
                 .set("grid-template-columns", "repeat(auto-fit, minmax(min(100%, 220px), 1fr))")
                 .set("gap", "14px");
-        grid.add(title, category, country, city, start, end);
+        grid.add(title, category, country, city, artists, start, end);
 
         LkCol col = new LkCol().gap(14);
         col.add(grid, description);

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -91,15 +91,13 @@ class EventManagementPresenterTest {
     }
 
     @Test
-    void create_fallsBackToFirstOwnedWhenPreferredNotOwned() {
+    void create_preferredNotOwned_returnsNoCompany() {
+        // A selected company the caller doesn't own must not silently retarget to another company.
         when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
-        when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("9"));
 
-        createWith(99, futureStart(), futureEnd());
-
-        ArgumentCaptor<EventCreationDTO> captor = ArgumentCaptor.forClass(EventCreationDTO.class);
-        verify(eventService).addEvent(eq(TOKEN), captor.capture());
-        assertEquals(1, captor.getValue().companyId());
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.NoCompany.class,
+                createWith(99, futureStart(), futureEnd()));
+        verifyNoInteractions(eventService);
     }
 
     @Test
@@ -128,6 +126,17 @@ class EventManagementPresenterTest {
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.NotAuthenticated.class,
                 createWith(null, futureStart(), futureEnd()));
+    }
+
+    @Test
+    void create_blankCategory_returnsInvalidInput() {
+        // Required inputs are validated before any service call, so a null category maps to
+        // InvalidInput (not a leaked NPE → Failure) and touches neither service.
+        EventManagementPresenter.CreateOutcome outcome = presenter.create(TOKEN, 1, "Gala", "desc",
+                null, "Israel", "Tel Aviv", futureStart(), futureEnd(), List.of("Headliner"));
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.InvalidInput.class, outcome);
+        verifyNoInteractions(companyService, eventService);
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -1,0 +1,159 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.presenters.company.EventManagementPresenter;
+
+/**
+ * Unit tests for {@link EventManagementPresenter#create}. The create flow assembles an
+ * {@link EventCreationDTO} (resolving the owning company) and delegates to
+ * {@code EventManagementService.addEvent}; these tests pin the company-resolution rule and the
+ * exception → {@code CreateOutcome} mapping without a UI or Spring context.
+ */
+class EventManagementPresenterTest {
+
+    private static final String TOKEN = "owner-token";
+
+    private EventManagementService eventService;
+    private CompanyManagementService companyService;
+    private EventManagementPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        eventService = mock(EventManagementService.class);
+        companyService = mock(CompanyManagementService.class);
+        presenter = new EventManagementPresenter(eventService, companyService);
+    }
+
+    private static ProductionCompanyDTO company(int id) {
+        return new ProductionCompanyDTO(id, "Company " + id, "desc", "ACTIVE", 1);
+    }
+
+    private static LocalDateTime futureStart() {
+        return LocalDateTime.now().plusDays(1);
+    }
+
+    private static LocalDateTime futureEnd() {
+        return LocalDateTime.now().plusDays(1).plusHours(3);
+    }
+
+    private EventManagementPresenter.CreateOutcome createWith(Integer preferredCompanyId,
+                                                             LocalDateTime starts, LocalDateTime ends) {
+        return presenter.create(TOKEN, preferredCompanyId, "Gala Night", "A great show",
+                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", starts, ends, List.of("Headliner"));
+    }
+
+    @Test
+    void create_success_returnsNewEventId() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("5"));
+
+        EventManagementPresenter.CreateOutcome outcome = createWith(null, futureStart(), futureEnd());
+
+        EventManagementPresenter.CreateOutcome.Success ok =
+                assertInstanceOf(EventManagementPresenter.CreateOutcome.Success.class, outcome);
+        assertEquals("5", ok.eventId());
+    }
+
+    @Test
+    void create_prefersSelectedCompanyWhenOwned() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
+        when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("9"));
+
+        createWith(2, futureStart(), futureEnd());
+
+        ArgumentCaptor<EventCreationDTO> captor = ArgumentCaptor.forClass(EventCreationDTO.class);
+        verify(eventService).addEvent(eq(TOKEN), captor.capture());
+        assertEquals(2, captor.getValue().companyId());
+    }
+
+    @Test
+    void create_fallsBackToFirstOwnedWhenPreferredNotOwned() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
+        when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("9"));
+
+        createWith(99, futureStart(), futureEnd());
+
+        ArgumentCaptor<EventCreationDTO> captor = ArgumentCaptor.forClass(EventCreationDTO.class);
+        verify(eventService).addEvent(eq(TOKEN), captor.capture());
+        assertEquals(1, captor.getValue().companyId());
+    }
+
+    @Test
+    void create_noOwnedCompany_returnsNoCompany() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.NoCompany.class,
+                createWith(null, futureStart(), futureEnd()));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void create_nullToken_returnsNotAuthenticated() {
+        EventManagementPresenter.CreateOutcome outcome = presenter.create(null, 1, "Gala", "d",
+                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", futureStart(), futureEnd(),
+                List.of("Headliner"));
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.NotAuthenticated.class, outcome);
+        verifyNoInteractions(companyService, eventService);
+    }
+
+    @Test
+    void create_invalidToken_returnsNotAuthenticated() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(eventService.addEvent(eq(TOKEN), any())).thenThrow(new InvalidTokenException());
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.NotAuthenticated.class,
+                createWith(null, futureStart(), futureEnd()));
+    }
+
+    @Test
+    void create_pastShowDate_returnsInvalidInput() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+
+        // A past start makes the domain ShowDate constructor reject the request before addEvent.
+        EventManagementPresenter.CreateOutcome outcome =
+                createWith(null, LocalDateTime.now().minusDays(1), futureEnd());
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.InvalidInput.class, outcome);
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void create_serviceFailure_returnsFailure() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(eventService.addEvent(eq(TOKEN), any())).thenThrow(new RuntimeException("boom"));
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.Failure.class,
+                createWith(null, futureStart(), futureEnd()));
+    }
+
+    private static EventDetailDTO detailWithId(String id) {
+        return new EventDetailDTO(id, "Gala Night", null, "A great show", EventCategory.COMEDY,
+                new Location("Israel", "Tel Aviv"), "1", "Company 1", EventStatus.DRAFT,
+                List.of(), List.of("Headliner"));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -34,6 +34,8 @@ import com.ticketing.system.Presentation.presenters.catalog.EventDetailsPresente
 import com.ticketing.system.Presentation.session.SessionIdentity;
 import com.ticketing.system.Presentation.views.company.CompanyInquiryInboxView;
 import com.ticketing.system.Presentation.views.company.CompanyInquiryRespondView;
+import com.ticketing.system.Presentation.views.company.EventManagementView;
+import com.ticketing.system.Presentation.presenters.company.EventManagementPresenter;
 import com.ticketing.system.Presentation.views.company.ManagerListView;
 import com.ticketing.system.Presentation.views.company.OwnerDashboardView;
 import com.ticketing.system.Presentation.views.account.MyAccountView;
@@ -236,6 +238,16 @@ class VaadinSmokeTest {
             new SystemAnalyticsPresenter.Outcome.Success(market, analytics));
         assertDoesNotThrow(() -> new SystemAnalyticsView(presenter),
             "SystemAnalyticsView failed to construct");
+    }
+
+    @Test
+    void eventManagementViewInstantiates() {
+        // Owner create/edit-event screen (route owner/events/:eventId). The constructor builds the
+        // whole form (incl. the create-mode Artists field and the side column) but doesn't invoke the
+        // presenter — load/create happen on beforeEnter/click — so a bare mock exercises construction.
+        EventManagementPresenter presenter = mock(EventManagementPresenter.class);
+        assertDoesNotThrow(() -> new EventManagementView(presenter),
+            "EventManagementView failed to construct");
     }
 
     @Test


### PR DESCRIPTION
## Problem

Clicking **New Event** in the owner workspace navigates to `owner/events/new`, which reuses
`EventManagementView` (the edit-an-existing-event screen, route `owner/events/:eventId`). In create
mode (`eventId == "new"`), `saveEvent()` short-circuited with a placeholder toast — *"Creating a new
event is a separate flow."* — and saved nothing. A dead-end: an editable-looking form that can't
create anything.

## What this does

The backend already supports creation — `EventManagementService.addEvent(token, EventCreationDTO)`
creates an event in `DRAFT`. This wires the presentation layer to it and tidies the create-mode UX.

**`EventManagementPresenter`**
- New `create(...)` + sealed `CreateOutcome` (`Success(eventId)` / `NotAuthenticated` / `NoCompany`
  / `InvalidInput` / `Failure`), mirroring the existing `Load`/`Save`/`Cancel` outcome style.
- Resolves the owning company: prefers the workspace's currently-selected company
  (`CurrentCompanies.currentCompanyId()`), else the first owned company — the same convention
  `CompanyEventListPresenter` uses for the list the user came from.
- Assembles the domain-typed `EventCreationDTO` (`Location`, `ShowDate`, `EventCategory`) so the view
  stays free of domain construction, then calls `addEvent`. Exception mapping: invalid token →
  `NotAuthenticated`; domain `IllegalArgument/IllegalState` (bad category, blank location, past /
  out-of-order show dates) → `InvalidInput`; anything else → `Failure`.
- Injects `CompanyManagementService` for the resolution.

**`EventManagementView`**
- `saveEvent()` now branches to a new `createEvent()` in create mode (the dead-end block is gone).
- Adds an **Artists** field (comma-separated; required in create, read-only/populated in edit) to
  satisfy the `Event` domain's non-empty `artistsNames` invariant.
- Create-mode chrome: header and primary button read **"Create Event"**, and the side column
  (Linked Editors / Status / Danger Zone — all act on a persisted event) is hidden.
- Local validation with friendly toasts (title, category, country+city, future start/end, ≥1 artist).
- On success: toast + redirect to `owner/events/<newId>` (edit mode) so the user can configure the
  venue map and publish next — matching the existing `addEvent → configureVenueMap → publish`
  architecture.

## Tests

- **New** `EventManagementPresenterTest` — `create` cases: success; prefers selected company /
  falls back to first owned; `NoCompany`; null token and invalid-token → `NotAuthenticated`;
  past show date → `InvalidInput`; service failure → `Failure`.
- **`VaadinSmokeTest`** — adds an `EventManagementView` construction canary.
- `mvn -B -Pno-vaadin clean verify` → BUILD SUCCESS; full suite green.

## Notes / follow-ups

- `addEvent` requires `Permission.CONFIGURE_VENUE`. A manager with only `EDIT_COMPANY_EVENTS` can
  reach the form but create fails gracefully (Failure toast); founders/co-owners are unaffected.
  Aligning the New Event button's visibility / the create capability is a separate change.
- Editing artists from the edit screen doesn't persist (the update path / `EventUpdateDTO` has no
  artists field), which is why the field is read-only there.
- Independent of PR #411 (the Purchase-Policies route-param crash fix); branched off `dev`.