### PR TITLE
Fixed v2

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -492,7 +492,8 @@ public class CompanyManagementService {
         if (company == null) {
             throw new CompanyNotFoundException(config.companyId());
         }
-        company.checkowner(userId);
+       User user = userRepository.getUserById(userId);
+        user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
         PurchasePolicy policy = buildPurchasePolicyFromDTO(config.defaultPurchasePolicy());
         company.setPurchasePolicy(policy);
         companyRepository.save(company);

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -507,7 +507,10 @@ public class CompanyManagementService {
         if (company == null) {
             throw new CompanyNotFoundException(config.companyId());
         }
-       User user = userRepository.getUserById(userId);
+        User user = userRepository.getUserById(userId);
+        if (user == null) {
+            throw new RuntimeException("User not found");
+        }
         user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
         PurchasePolicy policy = buildPurchasePolicyFromDTO(config.defaultPurchasePolicy());
         company.setPurchasePolicy(policy);
@@ -805,7 +808,10 @@ public class CompanyManagementService {
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null)
             throw new RuntimeException("Company not found");
-        company.checkowner(userId);
+        User user = userRepository.getUserById(userId);
+        if (user == null)
+            throw new RuntimeException("User not found");
+        user.requirePermissionInCompany(companyId, Permission.EDIT_POLICIES);
         return policyToDTO(company.getPurchasePolicy());
     }
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -989,8 +989,11 @@ public class EventManagementService {
             }
 
             User user = userRepository.getUserById(userId);
+            if (user == null) {
+                throw new RuntimeException("User not found");
+            }
             user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
-            
+
             Event event = eventRepository.findById(config.eventId());
             if (event == null) {
                 throw new RuntimeException("Event not found");
@@ -1113,7 +1116,10 @@ public class EventManagementService {
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null)
             throw new RuntimeException("Company not found");
-        company.checkowner(userId);
+        User user = userRepository.getUserById(userId);
+        if (user == null)
+            throw new RuntimeException("User not found");
+        user.requirePermissionInCompany(companyId, Permission.EDIT_POLICIES);
         Event event = eventRepository.findById(eventId);
         if (event == null)
             throw new RuntimeException("Event not found");

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -921,8 +921,9 @@ public class EventManagementService {
                 throw new RuntimeException("Company not found");
             }
 
-            company.checkowner(userId);
-
+            User user = userRepository.getUserById(userId);
+            user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
+            
             Event event = eventRepository.findById(config.eventId());
             if (event == null) {
                 throw new RuntimeException("Event not found");

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
@@ -9,7 +9,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.CompanyPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
@@ -20,10 +22,10 @@ import com.ticketing.system.Presentation.session.SessionIdentity;
  * MVP presenter for the purchase-policy editor.
  *
  * <p>Owns ALL policy logic and the editable model ({@link Node}/{@link Group}/{@link Rule}):
- * identity, load/save, DTO&lt;-&gt;model conversion, structural mutations, the D3 tree JSON,
- * the plain-English description, and validation. Stays stateless (like CheckoutPresenter) —
- * the view holds a single {@link Group} root as its UI state and only renders what the
- * presenter returns; it performs no logic itself.
+ * identity, context resolution (which companies/events the owner can edit), load/save,
+ * DTO&lt;-&gt;model conversion, structural mutations, the D3 tree JSON, the plain-English
+ * description, and validation. Stays stateless (like CheckoutPresenter) — the view holds a
+ * single {@link Group} root as its UI state and only renders what the presenter returns.
  */
 @Component
 public class PurchasePolicyEditorPresenter {
@@ -48,7 +50,38 @@ public class PurchasePolicyEditorPresenter {
 
     public record Identity(String memberToken) { }
 
-  
+   
+
+    public ContextOutcome resolveContext(String token) {
+        if (token == null) return new ContextOutcome.NotAuthenticated();
+        try {
+            List<ProductionCompanyDTO> companies = companyManagementService.findOwnedCompanies(token);
+            if (companies.isEmpty()) return new ContextOutcome.NoCompany();
+            return new ContextOutcome.Ready(companies);
+        } catch (InvalidTokenException e) {
+            return new ContextOutcome.NotAuthenticated();
+        } catch (RuntimeException e) {
+            return new ContextOutcome.Failure(e.getMessage());
+        }
+    }
+
+    /** Events belonging to a company; empty (never null) if the call fails. */
+    public List<EventDetailDTO> listEvents(String token, int companyId) {
+        if (token == null || companyId <= 0) return List.of();
+        try {
+            return eventManagementService.listEventsForCompany(token, companyId);
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    public sealed interface ContextOutcome {
+        record Ready(List<ProductionCompanyDTO> companies) implements ContextOutcome { }
+        record NotAuthenticated() implements ContextOutcome { }
+        record NoCompany() implements ContextOutcome { }
+        record Failure(String reason) implements ContextOutcome { }
+    }
+
 
     public enum Op { AND, OR }
 

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
@@ -1,6 +1,9 @@
 package com.ticketing.system.Presentation.presenters.company;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -11,19 +14,237 @@ import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.session.SessionIdentity;
 
+/**
+ * MVP presenter for the purchase-policy editor.
+ *
+ * <p>Owns ALL policy logic and the editable model ({@link Node}/{@link Group}/{@link Rule}):
+ * identity, load/save, DTO&lt;-&gt;model conversion, structural mutations, the D3 tree JSON,
+ * the plain-English description, and validation. Stays stateless (like CheckoutPresenter) —
+ * the view holds a single {@link Group} root as its UI state and only renders what the
+ * presenter returns; it performs no logic itself.
+ */
 @Component
 public class PurchasePolicyEditorPresenter {
 
     private final CompanyManagementService companyManagementService;
-    private final EventManagementService eventManagementService;
+    private final EventManagementService   eventManagementService;
+    private final SessionIdentity          identity;
 
     @Autowired
     public PurchasePolicyEditorPresenter(CompanyManagementService companyManagementService,
-                                         EventManagementService eventManagementService) {
+                                         EventManagementService eventManagementService,
+                                         SessionIdentity identity) {
         this.companyManagementService = companyManagementService;
-        this.eventManagementService = eventManagementService;
+        this.eventManagementService   = eventManagementService;
+        this.identity                 = identity;
     }
+
+
+    public Identity resolveIdentity() {
+        return new Identity(identity.memberToken());
+    }
+
+    public record Identity(String memberToken) { }
+
+  
+
+    public enum Op { AND, OR }
+
+    public enum RuleType {
+        AgeAtLeast("years"),
+        QuantityAtLeast("tickets"),
+        QuantityAtMost("tickets");
+
+        private final String unit;
+        RuleType(String unit) { this.unit = unit; }
+        public String unit() { return unit; }
+
+        String prettyEnglish(String value) {
+            return switch (this) {
+                case AgeAtLeast      -> "Age at least " + value + " years";
+                case QuantityAtLeast -> "Quantity at least " + value + " tickets";
+                case QuantityAtMost  -> "Quantity at most "  + value + " tickets";
+            };
+        }
+    }
+
+    public sealed interface Node permits Group, Rule {
+        String id();
+    }
+
+    public static final class Group implements Node {
+        private final String id = newId();
+        private Op op;
+        private final List<Node> children = new ArrayList<>();
+        private Group(Op op) { this.op = op; }
+        public String id() { return id; }
+        public Op op() { return op; }
+        public List<Node> children() { return Collections.unmodifiableList(children); }
+    }
+
+    public static final class Rule implements Node {
+        private final String id = newId();
+        private RuleType type;
+        private String value;
+        private Rule(RuleType type, String value) { this.type = type; this.value = value; }
+        public String id() { return id; }
+        public RuleType type() { return type; }
+        public String value() { return value; }
+    }
+
+    private static String newId() {
+        return "n-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    /** A fresh, empty policy (AND of nothing). Replaces the old hard-coded sample. */
+    public Group emptyPolicy() {
+        return new Group(Op.AND);
+    }
+
+
+    public void addRule(Group root, String parentId) {
+        if (find(root, parentId) instanceof Group g) {
+            g.children.add(new Rule(RuleType.AgeAtLeast, "18"));
+        }
+    }
+
+    public void addGroup(Group root, String parentId) {
+        if (find(root, parentId) instanceof Group g) {
+            g.children.add(new Group(Op.AND));
+        }
+    }
+
+    public void updateRule(Group root, String nodeId, RuleType type, String value) {
+        if (find(root, nodeId) instanceof Rule r) {
+            r.type  = type;
+            r.value = value == null ? "" : value.trim();
+        }
+    }
+
+    public void updateGroupOp(Group root, String nodeId, Op op) {
+        if (find(root, nodeId) instanceof Group g) {
+            g.op = op;
+        }
+    }
+
+    public void deleteNode(Group root, String nodeId) {
+        Group parent = findParent(root, nodeId);
+        if (parent != null) {
+            parent.children.removeIf(child -> child.id().equals(nodeId));
+        }
+    }
+
+    /** The root has no parent and must never be deletable. */
+    public boolean canDelete(Group root, String nodeId) {
+        return findParent(root, nodeId) != null;
+    }
+
+
+    public Node findNode(Group root, String nodeId) {
+        return find(root, nodeId);
+    }
+
+    private Node find(Node node, String nodeId) {
+        if (node.id().equals(nodeId)) return node;
+        if (node instanceof Group g) {
+            for (Node child : g.children) {
+                Node hit = find(child, nodeId);
+                if (hit != null) return hit;
+            }
+        }
+        return null;
+    }
+
+    private Group findParent(Group root, String nodeId) {
+        for (Node child : root.children) {
+            if (child.id().equals(nodeId)) return root;
+            if (child instanceof Group g) {
+                Group hit = findParent(g, nodeId);
+                if (hit != null) return hit;
+            }
+        }
+        return null;
+    }
+
+
+    public String toTreeJson(Node n) {
+        if (n instanceof Rule r) {
+            return "{\"id\":\"" + r.id() + "\",\"kind\":\"rule\",\"label\":\""
+                 + escapeJson(r.type.prettyEnglish(r.value == null ? "" : r.value)) + "\"}";
+        }
+        Group g = (Group) n;
+        StringBuilder children = new StringBuilder();
+        for (int i = 0; i < g.children.size(); i++) {
+            if (i > 0) children.append(",");
+            children.append(toTreeJson(g.children.get(i)));
+        }
+        String desc = g.op == Op.AND ? "all of these" : "any of these";
+        return "{\"id\":\"" + g.id() + "\",\"kind\":\"comp\",\"op\":\""
+             + g.op + "\",\"label\":\"" + escapeJson(g.op + " · " + desc)
+             + "\",\"children\":[" + children + "]}";
+    }
+
+    public String toPlainEnglishHtml(Group root) {
+        if (root.children.isEmpty()) {
+            return "No restrictions yet — click the root group and add a rule to get started.";
+        }
+        return "Buyer must satisfy " + renderEnglish(root) + ".";
+    }
+
+    private String renderEnglish(Node node) {
+        if (node instanceof Rule r) {
+            return "<b>" + escape(r.type.prettyEnglish(r.value)) + "</b>";
+        }
+        Group g = (Group) node;
+        if (g.children.isEmpty()) {
+            return "<i>(empty " + g.op + " group)</i>";
+        }
+        String joiner = g.op == Op.AND ? "AND" : "OR";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < g.children.size(); i++) {
+            if (i > 0) sb.append(" <span class='or'>").append(joiner).append("</span> ");
+            Node ch = g.children.get(i);
+            if (ch instanceof Group) sb.append("(").append(renderEnglish(ch)).append(")");
+            else                     sb.append(renderEnglish(ch));
+        }
+        return sb.toString();
+    }
+
+
+    public Validity validate(Group root) {
+        return validateNode(root);
+    }
+
+    private Validity validateNode(Node node) {
+        if (node instanceof Rule r) {
+            if (r.value == null || r.value.isBlank()) {
+                return Validity.invalid("A rule is missing its value.");
+            }
+            try {
+                Integer.parseInt(r.value.trim());
+            } catch (NumberFormatException e) {
+                return Validity.invalid("Rule value must be a whole number.");
+            }
+            return Validity.OK;
+        }
+        Group g = (Group) node;
+        if (g.children.isEmpty()) {
+            return Validity.invalid("Empty " + g.op + " group — add at least one rule.");
+        }
+        for (Node child : g.children) {
+            Validity cv = validateNode(child);
+            if (!cv.valid()) return cv;
+        }
+        return Validity.OK;
+    }
+
+    public record Validity(boolean valid, String message) {
+        static final Validity OK = new Validity(true, "Valid");
+        static Validity invalid(String why) { return new Validity(false, why); }
+    }
+
 
     public LoadOutcome load(String token, int companyId, int eventId, boolean isEventLevel) {
         if (token == null) return new LoadOutcome.NotAuthenticated();
@@ -31,7 +252,7 @@ public class PurchasePolicyEditorPresenter {
             PurchasePolicyDTO dto = isEventLevel && eventId > 0
                 ? eventManagementService.getEventPurchasePolicy(token, companyId, eventId)
                 : companyManagementService.getCompanyPurchasePolicy(token, companyId);
-            return new LoadOutcome.Success(dto);
+            return new LoadOutcome.Success(dtoToRoot(dto));
         } catch (InvalidTokenException e) {
             return new LoadOutcome.NotAuthenticated();
         } catch (RuntimeException e) {
@@ -39,10 +260,42 @@ public class PurchasePolicyEditorPresenter {
         }
     }
 
-    public SaveOutcome save(String token, int companyId, int eventId, boolean isEventLevel,
-                            PurchasePolicyDTO dto) {
+    private Group dtoToRoot(PurchasePolicyDTO dto) {
+        if (dto == null || "NONE".equals(dto.type())) {
+            return emptyPolicy();
+        }
+        Node node = dtoToNode(dto);
+        if (node instanceof Group g) return g;
+        Group root = new Group(Op.AND);
+        root.children.add(node);
+        return root;
+    }
+
+    private Node dtoToNode(PurchasePolicyDTO dto) {
+        return switch (dto.type()) {
+            case "AGE"         -> new Rule(RuleType.AgeAtLeast,      String.valueOf(dto.minimumAge()));
+            case "MIN_TICKETS" -> new Rule(RuleType.QuantityAtLeast, String.valueOf(dto.minimumTickets()));
+            case "MAX_TICKETS" -> new Rule(RuleType.QuantityAtMost,  String.valueOf(dto.maximumTickets()));
+            case "AND", "OR"   -> {
+                Group g = new Group(Op.valueOf(dto.type()));
+                if (dto.children() != null) {
+                    for (PurchasePolicyDTO child : dto.children()) {
+                        g.children.add(dtoToNode(child));
+                    }
+                }
+                yield g;
+            }
+            default -> new Rule(RuleType.AgeAtLeast, "0");
+        };
+    }
+
+
+    public SaveOutcome save(String token, int companyId, int eventId, boolean isEventLevel, Group root) {
         if (token == null) return new SaveOutcome.NotAuthenticated();
+        Validity v = validate(root);
+        if (!v.valid()) return new SaveOutcome.Invalid(v.message());
         try {
+            PurchasePolicyDTO dto = nodeToDTO(root);
             if (isEventLevel) {
                 eventManagementService.setEventPolicies(token,
                         new EventPolicyConfigDTO(companyId, eventId, dto));
@@ -58,8 +311,38 @@ public class PurchasePolicyEditorPresenter {
         }
     }
 
+    private PurchasePolicyDTO nodeToDTO(Node node) {
+        if (node instanceof Rule r) {
+            int val = Integer.parseInt(r.value.trim()); // validate() guarantees this parses
+            return switch (r.type) {
+                case AgeAtLeast      -> new PurchasePolicyDTO("AGE",         val,  null, null, null);
+                case QuantityAtLeast -> new PurchasePolicyDTO("MIN_TICKETS", null, val,  null, null);
+                case QuantityAtMost  -> new PurchasePolicyDTO("MAX_TICKETS", null, null, val,  null);
+            };
+        }
+        Group g = (Group) node;
+        List<PurchasePolicyDTO> children = g.children.stream().map(this::nodeToDTO).toList();
+        // The backend requires AND/OR composites to carry >= 2 children; a single-child group
+        // is semantically just its child, so unwrap it instead of emitting an invalid AND/OR.
+        if (children.size() == 1) {
+            return children.get(0);
+        }
+        String type = g.op == Op.AND ? "AND" : "OR";
+        return new PurchasePolicyDTO(type, null, null, null, children);
+    }
+
+
+    private static String escape(String s) {
+        return s == null ? "" : s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    private static String escapeJson(String s) {
+        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+
     public sealed interface LoadOutcome {
-        record Success(PurchasePolicyDTO policy) implements LoadOutcome { }
+        record Success(Group root) implements LoadOutcome { }
         record NotAuthenticated() implements LoadOutcome { }
         record Failure(String reason) implements LoadOutcome { }
     }
@@ -67,6 +350,7 @@ public class PurchasePolicyEditorPresenter {
     public sealed interface SaveOutcome {
         record Success() implements SaveOutcome { }
         record NotAuthenticated() implements SaveOutcome { }
+        record Invalid(String reason) implements SaveOutcome { }
         record Failure(String reason) implements SaveOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
@@ -151,14 +151,14 @@ public class PurchasePolicyEditorPresenter {
 
     public void updateRule(Group root, String nodeId, RuleType type, String value) {
         if (find(root, nodeId) instanceof Rule r) {
-            r.type  = type;
+            if (type != null) r.type = type;   // ignore null type — keeps r.type non-null for toTreeJson/nodeToDTO
             r.value = value == null ? "" : value.trim();
         }
     }
 
     public void updateGroupOp(Group root, String nodeId, Op op) {
         if (find(root, nodeId) instanceof Group g) {
-            g.op = op;
+            if (op != null) g.op = op;          // ignore null op — downstream assumes a non-null operator
         }
     }
 
@@ -247,6 +247,10 @@ public class PurchasePolicyEditorPresenter {
 
 
     public Validity validate(Group root) {
+        // An empty root means "no restrictions" — a valid NONE policy (see nodeToDTO).
+        if (root.children.isEmpty()) {
+            return Validity.OK;
+        }
         return validateNode(root);
     }
 
@@ -354,6 +358,11 @@ public class PurchasePolicyEditorPresenter {
             };
         }
         Group g = (Group) node;
+        // An empty group is "no restrictions" — serialize to NONE rather than an invalid
+        // 0-child AND/OR (the backend rejects composites with < 2 children).
+        if (g.children.isEmpty()) {
+            return new PurchasePolicyDTO("NONE", null, null, null, null);
+        }
         List<PurchasePolicyDTO> children = g.children.stream().map(this::nodeToDTO).toList();
         // The backend requires AND/OR composites to carry >= 2 children; a single-child group
         // is semantically just its child, so unwrap it instead of emitting an invalid AND/OR.

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -36,7 +36,7 @@ import com.vaadin.flow.router.RouteParameters;
 
 import jakarta.annotation.security.PermitAll;
 
-@Route(value = "owner/policies/:companyId/:eventId", layout = WorkspaceLayout.class)
+@Route(value = "owner/policies/:companyId?/:eventId?", layout = WorkspaceLayout.class)
 @PageTitle("Purchase policies · TicketHub")
 @PermitAll
 @RequireCapability(Capability.EDIT_PURCHASE_POLICIES)

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -1,6 +1,18 @@
 package com.ticketing.system.Presentation.views.company;
 
+import java.util.List;
+
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
+import com.ticketing.system.Presentation.components.kit.LkBtn;
+import com.ticketing.system.Presentation.components.kit.LkIcon;
+import com.ticketing.system.Presentation.components.kit.LkPage;
+import com.ticketing.system.Presentation.components.policy.PolicyTreeMap;
+import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.ContextOutcome;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Group;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.LoadOutcome;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Node;
@@ -9,13 +21,6 @@ import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditor
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.RuleType;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.SaveOutcome;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Validity;
-import com.ticketing.system.Presentation.components.Toasts;
-import com.ticketing.system.Presentation.components.kit.LkBanner;
-import com.ticketing.system.Presentation.components.kit.LkBtn;
-import com.ticketing.system.Presentation.components.kit.LkIcon;
-import com.ticketing.system.Presentation.components.kit.LkPage;
-import com.ticketing.system.Presentation.components.policy.PolicyTreeMap;
-import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.vaadin.flow.component.Component;
@@ -45,37 +50,31 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     private final PurchasePolicyEditorPresenter presenter;
 
     private Group   root;
+    private String  memberToken;
     private int     companyId    = -1;
     private int     eventId      = -1;
-    private boolean isEventLevel = true;
-    private String  memberToken;
+    private boolean isEventLevel = false;          // default: company-level (fixes the old mislabel)
 
-    private Span          plainEnglishText;
-    private PolicyTreeMap mapPanel;
-    private Span          validityBadge;
-    private Span          scopeContextLabel;
-    private final Div     loadErrorSlot = new Div();
+    private Integer routeCompanyId;                // optional deep-link from the URL
+    private Integer routeEventId;
+
+    private Span                          plainEnglishText;
+    private PolicyTreeMap                 mapPanel;
+    private Span                          validityBadge;
+    private Span                          scopeContextLabel;
+    private final Div                     loadErrorSlot = new Div();
+    private Select<ProductionCompanyDTO>  companySelect;
+    private Select<EventDetailDTO>        eventSelect;
+    private NativeButton                  companyBtn;
+    private NativeButton                  eventBtn;
 
     public PurchasePolicyEditorView(PurchasePolicyEditorPresenter presenter) {
         this.presenter = presenter;
         this.root = presenter.emptyPolicy();
-    }
 
-
-    @Override
-    public void beforeEnter(BeforeEnterEvent event) {
-        RouteParameters params = event.getRouteParameters();
-        params.get("companyId").ifPresent(id -> {
-            try { this.companyId = Integer.parseInt(id); } catch (NumberFormatException ignored) { }
-        });
-        params.get("eventId").ifPresent(id -> {
-            try { this.eventId = Integer.parseInt(id); } catch (NumberFormatException ignored) { }
-        });
-
-        resolveIdentity();
-
+        // Build the static UI exactly once, in the constructor — beforeEnter() only loads data.
         title("Purchase policies");
-        subtitle("Click a node to edit it · drag the canvas to pan · scroll to zoom.");
+        subtitle("Pick a company (and optionally an event), then build the rules · click a node to edit · drag to pan · scroll to zoom.");
 
         add(buildScopeToolbar());
         add(loadErrorSlot);
@@ -83,59 +82,168 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         add(buildCanvas());
         add(buildActionBar());
         add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 18),
-            "Validation rejects empty groups and circular nesting before a policy can be saved."));
-
-        loadExistingPolicy();
-        rebuildTree();
+            "Validation rejects empty groups and non-numeric values before a policy can be saved."));
     }
 
-    private void resolveIdentity() {
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        RouteParameters params = event.getRouteParameters();
+        this.routeCompanyId = parseOpt(params.get("companyId").orElse(null));
+        this.routeEventId   = parseOpt(params.get("eventId").orElse(null));
+
         this.memberToken = presenter.resolveIdentity().memberToken();
+
+        initContext();
+    }
+
+    // ---------------------------------------------------------------------
+    // Context: resolve the owner's companies, then drive the selectors
+    // ---------------------------------------------------------------------
+
+    private void initContext() {
+        loadErrorSlot.removeAll();
+        switch (presenter.resolveContext(memberToken)) {
+            case ContextOutcome.NotAuthenticated na ->
+                disableEditing("Please sign in again to edit policies.");
+            case ContextOutcome.NoCompany nc ->
+                disableEditing("You don't own a company yet — register one to set purchase policies.");
+            case ContextOutcome.Failure f ->
+                showLoadError("Could not load your companies: " + f.reason(), this::initContext);
+            case ContextOutcome.Ready ready ->
+                populateCompanies(ready.companies());
+        }
+    }
+
+    private void populateCompanies(List<ProductionCompanyDTO> companies) {
+        companySelect.setEnabled(true);
+        companySelect.setItems(companies);
+
+        ProductionCompanyDTO chosen = companies.get(0);
+        if (routeCompanyId != null) {
+            for (ProductionCompanyDTO c : companies) {
+                if (c.companyId() == routeCompanyId) { chosen = c; break; }
+            }
+        }
+        companySelect.setValue(chosen);   // fires onCompanyChosen()
+    }
+
+    private void onCompanyChosen(ProductionCompanyDTO c) {
+        if (c == null) return;
+        this.companyId = c.companyId();
+
+        List<EventDetailDTO> events = presenter.listEvents(memberToken, companyId);
+        eventSelect.setItems(events);
+
+        EventDetailDTO preselect = null;
+        if (routeEventId != null) {
+            for (EventDetailDTO ev : events) {
+                if (parseId(ev.eventId()) == routeEventId) { preselect = ev; break; }
+            }
+            routeEventId = null;          // consume the deep-link once
+        }
+
+        if (preselect != null) {
+            isEventLevel = true;
+            setScopeButtons();
+            eventSelect.setEnabled(true);
+            eventSelect.setValue(preselect);   // fires onEventChosen() → loads the event policy
+        } else {
+            isEventLevel = false;
+            setScopeButtons();
+            eventSelect.setEnabled(false);
+            eventSelect.clear();
+            this.eventId = -1;
+            loadExistingPolicy();
+            rebuildTree();
+        }
+    }
+
+    private void onEventChosen(EventDetailDTO ev) {
+        if (ev == null) return;
+        this.eventId = parseId(ev.eventId());
+        if (isEventLevel) {
+            loadExistingPolicy();
+            rebuildTree();
+        }
+    }
+
+    private void disableEditing(String message) {
+        companySelect.setItems(List.of());
+        companySelect.setEnabled(false);
+        eventSelect.setItems(List.of());
+        eventSelect.setEnabled(false);
+        this.companyId = -1;
+        this.eventId = -1;
+        this.root = presenter.emptyPolicy();
+        loadErrorSlot.add(new LkBanner(LkBanner.Tone.error, new LkIcon("alert-circle", 16), message));
+        rebuildTree();
     }
 
     private void loadExistingPolicy() {
         loadErrorSlot.removeAll();
-        if (companyId <= 0) return;
+        if (companyId <= 0 || (isEventLevel && eventId <= 0)) {
+            this.root = presenter.emptyPolicy();
+            return;
+        }
         switch (presenter.load(memberToken, companyId, eventId, isEventLevel)) {
             case LoadOutcome.Success s -> this.root = s.root();
-            case LoadOutcome.NotAuthenticated na -> Toasts.warn("Please sign in again to edit policies.");
+            case LoadOutcome.NotAuthenticated na -> {
+                this.root = presenter.emptyPolicy();
+                Toasts.warn("Please sign in again to edit policies.");
+            }
             case LoadOutcome.Failure f -> {
-                LkBanner err = new LkBanner(LkBanner.Tone.error,
-                    new LkIcon("alert-circle", 16),
-                    "Could not load existing policy: " + f.reason());
-                LkBtn retry = new LkBtn("Retry").variant(LkBtn.Variant.secondary);
-                retry.addClickListener(ev -> { loadExistingPolicy(); rebuildTree(); });
-                err.setAction(retry);
-                loadErrorSlot.add(err);
+                this.root = presenter.emptyPolicy();
+                showLoadError("Could not load existing policy: " + f.reason(),
+                    () -> { loadExistingPolicy(); rebuildTree(); });
             }
         }
     }
 
+    private void showLoadError(String message, Runnable retry) {
+        LkBanner err = new LkBanner(LkBanner.Tone.error, new LkIcon("alert-circle", 16), message);
+        LkBtn retryBtn = new LkBtn("Retry").variant(LkBtn.Variant.secondary);
+        retryBtn.addClickListener(ev -> retry.run());
+        err.setAction(retryBtn);
+        loadErrorSlot.add(err);
+    }
+
+    // ---------------------------------------------------------------------
+    // Scope toolbar (company picker · scope toggle · event picker · status)
+    // ---------------------------------------------------------------------
 
     private Component buildScopeToolbar() {
         Div bar = new Div(); bar.addClassName("pe-toolbar");
 
         Div scope = new Div(); scope.addClassName("pe-scope");
+
+        companySelect = new Select<>();
+        companySelect.setLabel("Company");
+        companySelect.setItemLabelGenerator(ProductionCompanyDTO::name);
+        companySelect.setWidth("220px");
+        companySelect.setEnabled(false);
+        companySelect.addValueChangeListener(e -> onCompanyChosen(e.getValue()));
+        scope.add(companySelect);
+
         Span lbl = new Span("Scope"); lbl.addClassName("pe-scope-label");
         scope.add(lbl);
 
         Div seg = new Div(); seg.addClassName("pe-seg");
-        NativeButton companyBtn = new NativeButton("Company-level"); companyBtn.addClassName("pe-seg-opt");
-        NativeButton eventBtn   = new NativeButton("Event-level");   eventBtn.addClassName("pe-seg-opt");
-        if (isEventLevel) eventBtn.addClassName("on"); else companyBtn.addClassName("on");
-
-        companyBtn.addClickListener(e -> {
-            isEventLevel = false;
-            companyBtn.addClassName("on"); eventBtn.removeClassName("on");
-            loadExistingPolicy(); rebuildTree();
-        });
-        eventBtn.addClickListener(e -> {
-            isEventLevel = true;
-            eventBtn.addClassName("on"); companyBtn.removeClassName("on");
-            loadExistingPolicy(); rebuildTree();
-        });
+        companyBtn = new NativeButton("Company-level"); companyBtn.addClassName("pe-seg-opt");
+        eventBtn   = new NativeButton("Event-level");   eventBtn.addClassName("pe-seg-opt");
+        setScopeButtons();
+        companyBtn.addClickListener(e -> selectCompanyScope());
+        eventBtn.addClickListener(e -> selectEventScope());
         seg.add(companyBtn, eventBtn);
         scope.add(seg);
+
+        eventSelect = new Select<>();
+        eventSelect.setLabel("Event");
+        eventSelect.setItemLabelGenerator(EventDetailDTO::name);
+        eventSelect.setPlaceholder("Choose an event");
+        eventSelect.setWidth("220px");
+        eventSelect.setEnabled(false);
+        eventSelect.addValueChangeListener(e -> onEventChosen(e.getValue()));
+        scope.add(eventSelect);
 
         Div ctx = new Div(); ctx.addClassName("pe-scope-ctx");
         ctx.add(new LkIcon("ticket", 16));
@@ -151,11 +259,49 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         return bar;
     }
 
+    private void selectCompanyScope() {
+        isEventLevel = false;
+        setScopeButtons();
+        eventSelect.setEnabled(false);
+        loadExistingPolicy();
+        rebuildTree();
+    }
+
+    private void selectEventScope() {
+        isEventLevel = true;
+        setScopeButtons();
+        eventSelect.setEnabled(true);
+        if (eventId > 0) loadExistingPolicy();
+        else             this.root = presenter.emptyPolicy();
+        rebuildTree();
+    }
+
+    private void setScopeButtons() {
+        if (isEventLevel) { eventBtn.addClassName("on"); companyBtn.removeClassName("on"); }
+        else              { companyBtn.addClassName("on"); eventBtn.removeClassName("on"); }
+    }
+
     private void refreshScope() {
         if (scopeContextLabel == null) return;
-        scopeContextLabel.setText(isEventLevel
-            ? (eventId   > 0 ? "Event #"   + eventId   : "Event-level")
-            : (companyId > 0 ? "Company #" + companyId : "Company-level"));
+        if (isEventLevel) {
+            scopeContextLabel.setText(eventId > 0
+                ? "Event: " + currentEventName()
+                : "Event-level — choose an event");
+        } else {
+            scopeContextLabel.setText(companyId > 0
+                ? "Company: " + currentCompanyName()
+                : "No company selected");
+        }
+    }
+
+    private String currentCompanyName() {
+        ProductionCompanyDTO c = companySelect.getValue();
+        return c != null ? c.name() : ("#" + companyId);
+    }
+
+    private String currentEventName() {
+        EventDetailDTO ev = eventSelect.getValue();
+        return ev != null ? ev.name() : ("#" + eventId);
     }
 
     private void updateValidity() {
@@ -352,13 +498,27 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     }
 
     private void savePolicy() {
-        if (companyId <= 0) { Toasts.failure("No company selected."); return; }
-        if (isEventLevel && eventId <= 0) { Toasts.failure("No event selected."); return; }
+        if (companyId <= 0) { Toasts.failure("Choose a company first."); return; }
+        if (isEventLevel && eventId <= 0) { Toasts.failure("Choose an event, or switch to Company-level."); return; }
         switch (presenter.save(memberToken, companyId, eventId, isEventLevel, root)) {
-            case SaveOutcome.Success s        -> Toasts.success("Policy saved.");
-            case SaveOutcome.NotAuthenticated na -> Toasts.failure("Please sign in again to save.");
-            case SaveOutcome.Invalid inv      -> Toasts.warn(inv.reason());
-            case SaveOutcome.Failure f        -> Toasts.failure("Failed to save: " + f.reason());
+            case SaveOutcome.Success s           -> Toasts.success("Policy saved.");
+            case SaveOutcome.NotAuthenticated na  -> Toasts.failure("Please sign in again to save.");
+            case SaveOutcome.Invalid inv         -> Toasts.warn(inv.reason());
+            case SaveOutcome.Failure f           -> Toasts.failure("Failed to save: " + f.reason());
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static Integer parseOpt(String s) {
+        if (s == null) return null;
+        try { return Integer.parseInt(s); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static int parseId(String s) {
+        if (s == null) return -1;
+        try { return Integer.parseInt(s); } catch (NumberFormatException e) { return -1; }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -1,16 +1,14 @@
 package com.ticketing.system.Presentation.views.company;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Group;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.LoadOutcome;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Node;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Op;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Rule;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.RuleType;
 import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.SaveOutcome;
-import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.presenters.company.PurchasePolicyEditorPresenter.Validity;
 import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
@@ -21,7 +19,6 @@ import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -39,103 +36,45 @@ import com.vaadin.flow.router.RouteParameters;
 
 import jakarta.annotation.security.PermitAll;
 
-@Route(value = "owner/policies/:companyId?/:eventId?", layout = WorkspaceLayout.class)
-@PageTitle("Purchase Policies · TicketHub")
+@Route(value = "owner/policies/:companyId/:eventId", layout = WorkspaceLayout.class)
+@PageTitle("Purchase policies · TicketHub")
 @PermitAll
 @RequireCapability(Capability.EDIT_PURCHASE_POLICIES)
 public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObserver {
 
-    // ---------------------------------------------------------------------
-    // Rule types — one per Domain policy class
-    // ---------------------------------------------------------------------
-
-    private enum RuleType {
-        AgeAtLeast      ("years",   true),
-        QuantityAtLeast ("tickets", true),
-        QuantityAtMost  ("tickets", true);
-
-        final String unit;
-        final boolean hasValue;
-
-        RuleType(String unit, boolean hasValue) { this.unit = unit; this.hasValue = hasValue; }
-
-        String prettyEnglish(String value) {
-            return switch (this) {
-                case AgeAtLeast      -> "Age at least " + value + " years";
-                case QuantityAtLeast -> "Quantity at least " + value + " tickets";
-                case QuantityAtMost  -> "Quantity at most "  + value + " tickets";
-            };
-        }
-    }
-
-    // ---------------------------------------------------------------------
-    // Policy model
-    // ---------------------------------------------------------------------
-
-    private enum Op { AND, OR }
-
-    private sealed interface Node permits Composite, Rule {
-        String id();
-    }
-
-    private static final class Composite implements Node {
-        final String id = "n-" + UUID.randomUUID().toString().substring(0, 8);
-        Op op;
-        final List<Node> children = new ArrayList<>();
-        Composite(Op op) { this.op = op; }
-        public String id() { return id; }
-    }
-
-    private static final class Rule implements Node {
-        final String id = "n-" + UUID.randomUUID().toString().substring(0, 8);
-        RuleType type;
-        String value;
-        Rule(RuleType type, String value) { this.type = type; this.value = value; }
-        public String id() { return id; }
-    }
-
-    // ---------------------------------------------------------------------
-    // Services & state
-    // ---------------------------------------------------------------------
-
     private final PurchasePolicyEditorPresenter presenter;
 
-    private final Composite root = seedSamplePolicy();
-    private final Map<String, Node>      nodeMap   = new HashMap<>();
-    private final Map<String, Composite> parentMap = new HashMap<>();
-
-    private Span          plainEnglishText;
-    private PolicyTreeMap mapPanel;
-    private final Div     loadErrorSlot = new Div();
+    private Group   root;
     private int     companyId    = -1;
     private int     eventId      = -1;
     private boolean isEventLevel = true;
+    private String  memberToken;
 
-    // ---------------------------------------------------------------------
-    // Constructor
-    // ---------------------------------------------------------------------
+    private Span          plainEnglishText;
+    private PolicyTreeMap mapPanel;
+    private Span          validityBadge;
+    private Span          scopeContextLabel;
+    private final Div     loadErrorSlot = new Div();
 
     public PurchasePolicyEditorView(PurchasePolicyEditorPresenter presenter) {
         this.presenter = presenter;
+        this.root = presenter.emptyPolicy();
     }
 
-    // ---------------------------------------------------------------------
-    // BeforeEnterObserver
-    // ---------------------------------------------------------------------
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
         RouteParameters params = event.getRouteParameters();
         params.get("companyId").ifPresent(id -> {
-            try { this.companyId = Integer.parseInt(id); }
-            catch (NumberFormatException ignored) { }
+            try { this.companyId = Integer.parseInt(id); } catch (NumberFormatException ignored) { }
         });
         params.get("eventId").ifPresent(id -> {
-            try { this.eventId = Integer.parseInt(id); }
-            catch (NumberFormatException ignored) { }
+            try { this.eventId = Integer.parseInt(id); } catch (NumberFormatException ignored) { }
         });
 
-        title("Purchase Policies");
+        resolveIdentity();
+
+        title("Purchase policies");
         subtitle("Click a node to edit it · drag the canvas to pan · scroll to zoom.");
 
         add(buildScopeToolbar());
@@ -150,39 +89,16 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         rebuildTree();
     }
 
-    private static Composite seedSamplePolicy() {
-        Composite andRoot = new Composite(Op.AND);
-        andRoot.children.add(new Rule(RuleType.AgeAtLeast, "18"));
-        Composite or = new Composite(Op.OR);
-        or.children.add(new Rule(RuleType.QuantityAtLeast, "1"));
-        or.children.add(new Rule(RuleType.QuantityAtMost,  "4"));
-        andRoot.children.add(or);
-        return andRoot;
+    private void resolveIdentity() {
+        this.memberToken = presenter.resolveIdentity().memberToken();
     }
-
-    // ---------------------------------------------------------------------
-    // Load existing policy from backend
-    // ---------------------------------------------------------------------
 
     private void loadExistingPolicy() {
         loadErrorSlot.removeAll();
         if (companyId <= 0) return;
-        switch (presenter.load(AuthSession.token(), companyId, eventId, isEventLevel)) {
-            case LoadOutcome.Success s -> {
-                PurchasePolicyDTO dto = s.policy();
-                if (dto != null && !"NONE".equals(dto.type())) {
-                    Node loaded = dtoToNode(dto);
-                    root.children.clear();
-                    if (loaded instanceof Composite c) {
-                        root.op = c.op;
-                        root.children.addAll(c.children);
-                    } else {
-                        root.op = Op.AND;
-                        root.children.add(loaded);
-                    }
-                }
-            }
-            case LoadOutcome.NotAuthenticated na -> { }
+        switch (presenter.load(memberToken, companyId, eventId, isEventLevel)) {
+            case LoadOutcome.Success s -> this.root = s.root();
+            case LoadOutcome.NotAuthenticated na -> Toasts.warn("Please sign in again to edit policies.");
             case LoadOutcome.Failure f -> {
                 LkBanner err = new LkBanner(LkBanner.Tone.error,
                     new LkIcon("alert-circle", 16),
@@ -195,88 +111,62 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         }
     }
 
-    private Node dtoToNode(PurchasePolicyDTO dto) {
-        return switch (dto.type()) {
-            case "AGE"         -> new Rule(RuleType.AgeAtLeast,      String.valueOf(dto.minimumAge()));
-            case "MIN_TICKETS" -> new Rule(RuleType.QuantityAtLeast, String.valueOf(dto.minimumTickets()));
-            case "MAX_TICKETS" -> new Rule(RuleType.QuantityAtMost,  String.valueOf(dto.maximumTickets()));
-            case "AND", "OR"   -> {
-                Composite c = new Composite(Op.valueOf(dto.type()));
-                if (dto.children() != null) {
-                    for (PurchasePolicyDTO child : dto.children())
-                        c.children.add(dtoToNode(child));
-                }
-                yield c;
-            }
-            default -> new Rule(RuleType.AgeAtLeast, "0");
-        };
-    }
-
-    // ---------------------------------------------------------------------
-    // Scope toolbar
-    // ---------------------------------------------------------------------
 
     private Component buildScopeToolbar() {
-        Div bar = new Div();
-        bar.addClassName("pe-toolbar");
+        Div bar = new Div(); bar.addClassName("pe-toolbar");
 
-        Div scope = new Div();
-        scope.addClassName("pe-scope");
-        Span lbl = new Span("Scope");
-        lbl.addClassName("pe-scope-label");
+        Div scope = new Div(); scope.addClassName("pe-scope");
+        Span lbl = new Span("Scope"); lbl.addClassName("pe-scope-label");
         scope.add(lbl);
 
-        Div seg = new Div();
-        seg.addClassName("pe-seg");
-
-        NativeButton companyBtn = new NativeButton("Company-Level");
-        companyBtn.addClassName("pe-seg-opt");
-
-        NativeButton eventBtn = new NativeButton("Event-Level");
-        eventBtn.addClassName("pe-seg-opt");
-        eventBtn.addClassName("on");
+        Div seg = new Div(); seg.addClassName("pe-seg");
+        NativeButton companyBtn = new NativeButton("Company-level"); companyBtn.addClassName("pe-seg-opt");
+        NativeButton eventBtn   = new NativeButton("Event-level");   eventBtn.addClassName("pe-seg-opt");
+        if (isEventLevel) eventBtn.addClassName("on"); else companyBtn.addClassName("on");
 
         companyBtn.addClickListener(e -> {
             isEventLevel = false;
-            companyBtn.addClassName("on");
-            eventBtn.removeClassName("on");
-            loadExistingPolicy();
-            rebuildTree();
+            companyBtn.addClassName("on"); eventBtn.removeClassName("on");
+            loadExistingPolicy(); rebuildTree();
         });
         eventBtn.addClickListener(e -> {
             isEventLevel = true;
-            eventBtn.addClassName("on");
-            companyBtn.removeClassName("on");
-            loadExistingPolicy();
-            rebuildTree();
+            eventBtn.addClassName("on"); companyBtn.removeClassName("on");
+            loadExistingPolicy(); rebuildTree();
         });
-
         seg.add(companyBtn, eventBtn);
         scope.add(seg);
 
-        Span ctx = new Span();
-        ctx.addClassName("pe-scope-ctx");
+        Div ctx = new Div(); ctx.addClassName("pe-scope-ctx");
         ctx.add(new LkIcon("ticket", 16));
-        Span ctxLabel = new Span();
-        ctxLabel.getElement().setProperty("innerHTML", "<b>Coldplay · Music of the Spheres</b>");
-        ctx.add(ctxLabel);
-        ctx.add(new LkIcon("caret", 14));
+        scopeContextLabel = new Span();
+        ctx.add(scopeContextLabel);
         scope.add(ctx);
 
-        Div status = new Div();
-        status.addClassName("pe-status");
-        Span valid = new Span();
-        valid.addClassName("pe-valid");
-        valid.addClassName("ok");
-        Span dot = new Span("●");
-        dot.addClassName("dot");
-        valid.add(dot, new Span(" Valid"));
-        Span saved = new Span("Saved 2 min ago");
-        saved.addClassName("pe-saved");
-        status.add(valid, saved);
+        Div status = new Div(); status.addClassName("pe-status");
+        validityBadge = new Span(); validityBadge.addClassName("pe-valid");
+        status.add(validityBadge);
 
         bar.add(scope, status);
         return bar;
+    }
+
+    private void refreshScope() {
+        if (scopeContextLabel == null) return;
+        scopeContextLabel.setText(isEventLevel
+            ? (eventId   > 0 ? "Event #"   + eventId   : "Event-level")
+            : (companyId > 0 ? "Company #" + companyId : "Company-level"));
+    }
+
+    private void updateValidity() {
+        if (validityBadge == null) return;
+        Validity v = presenter.validate(root);
+        validityBadge.removeAll();
+        validityBadge.add(new Span("● "), new Span(v.valid() ? "Valid" : v.message()));
+        validityBadge.getStyle()
+            .set("color", v.valid() ? "#16a34a" : "#dc2626")
+            .set("font-size", "12.5px")
+            .set("font-weight", "600");
     }
 
     // ---------------------------------------------------------------------
@@ -284,54 +174,18 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     // ---------------------------------------------------------------------
 
     private Component buildPlainEnglishBanner() {
-        Div plain = new Div();
-        plain.addClassName("pe-plain");
-
-        Span emoji = new Span();
-        emoji.addClassName("pe-plain-emoji");
-        emoji.add(new LkIcon("comment", 22));
-
+        Div plain = new Div(); plain.addClassName("pe-plain");
+        Span emoji = new Span(); emoji.addClassName("pe-plain-emoji"); emoji.add(new LkIcon("comment", 22));
         Div text = new Div();
-        Span kicker = new Span("In plain English");
-        kicker.addClassName("pe-plain-k");
-        plainEnglishText = new Span();
-        plainEnglishText.addClassName("pe-plain-text");
+        Span kicker = new Span("In plain English"); kicker.addClassName("pe-plain-k");
+        plainEnglishText = new Span(); plainEnglishText.addClassName("pe-plain-text");
         text.add(kicker, plainEnglishText);
-
         plain.add(emoji, text);
         return plain;
     }
 
-    private String renderEnglish(Node node) {
-        if (node instanceof Rule r) {
-            return "<b>" + escape(r.type.prettyEnglish(r.value)) + "</b>";
-        }
-        Composite c = (Composite) node;
-        if (c.children.isEmpty()) {
-            return "<i>(empty " + c.op + " group)</i>";
-        }
-        String joiner = c.op == Op.AND ? "AND" : "OR";
-        return joinChildren(c.children, joiner);
-    }
-
-    private String joinChildren(List<Node> children, String joiner) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < children.size(); i++) {
-            if (i > 0) sb.append(" <span class='or'>").append(joiner).append("</span> ");
-            Node ch = children.get(i);
-            if (ch instanceof Composite) sb.append("(").append(renderEnglish(ch)).append(")");
-            else                          sb.append(renderEnglish(ch));
-        }
-        return sb.toString();
-    }
-
-    private void refreshPlainEnglish() {
-        plainEnglishText.getElement().setProperty("innerHTML",
-            "Buyer must satisfy " + renderEnglish(root) + ".");
-    }
-
     // ---------------------------------------------------------------------
-    // Canvas — D3 tree map
+    // Canvas
     // ---------------------------------------------------------------------
 
     private Component buildCanvas() {
@@ -340,60 +194,31 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         return mapPanel;
     }
 
+    /** Re-render every view surface from the current model (all data comes from the presenter). */
     private void rebuildTree() {
-        nodeMap.clear();
-        parentMap.clear();
-        walk(root, null);
-        mapPanel.render(treeToJson(root));
-        refreshPlainEnglish();
-    }
-
-    private void walk(Node node, Composite parent) {
-        nodeMap.put(node.id(), node);
-        if (parent != null) parentMap.put(node.id(), parent);
-        if (node instanceof Composite c) {
-            for (Node child : c.children) walk(child, c);
-        }
-    }
-
-    private String treeToJson(Node n) {
-        if (n instanceof Rule r) {
-            return "{\"id\":\"" + r.id() + "\",\"kind\":\"rule\",\"label\":\""
-                 + escapeJson(r.type.prettyEnglish(r.value == null ? "" : r.value)) + "\"}";
-        }
-        Composite c = (Composite) n;
-        StringBuilder children = new StringBuilder();
-        for (int i = 0; i < c.children.size(); i++) {
-            if (i > 0) children.append(",");
-            children.append(treeToJson(c.children.get(i)));
-        }
-        String desc = c.op == Op.AND ? "all of these" : "any of these";
-        return "{\"id\":\"" + c.id() + "\",\"kind\":\"comp\",\"op\":\""
-             + c.op + "\",\"label\":\"" + escapeJson(c.op + " · " + desc)
-             + "\",\"children\":[" + children + "]}";
+        mapPanel.render(presenter.toTreeJson(root));
+        plainEnglishText.getElement().setProperty("innerHTML", presenter.toPlainEnglishHtml(root));
+        refreshScope();
+        updateValidity();
     }
 
     private void handleNodeAction(String nodeId, String action) {
-        Node n = nodeMap.get(nodeId);
+        Node n = presenter.findNode(root, nodeId);
         if (n == null) return;
         switch (action) {
             case "click" -> {
                 if (n instanceof Rule r) openRuleDialog(r);
-                else if (n instanceof Composite c) openCompositeDialog(c);
+                else if (n instanceof Group g) openGroupDialog(g);
             }
             case "addRule" -> {
-                if (n instanceof Composite c) {
-                    c.children.add(new Rule(RuleType.AgeAtLeast, "18"));
-                    rebuildTree();
-                    Toasts.success("Rule added — click it to edit.");
-                }
+                presenter.addRule(root, nodeId);
+                rebuildTree();
+                Toasts.success("Rule added — click it to edit.");
             }
             case "addGroup" -> {
-                if (n instanceof Composite c) {
-                    c.children.add(new Composite(Op.AND));
-                    rebuildTree();
-                    Toasts.success("Group added — click it to add children.");
-                }
+                presenter.addGroup(root, nodeId);
+                rebuildTree();
+                Toasts.success("Group added — click it to add children.");
             }
         }
     }
@@ -411,26 +236,23 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         typeSelect.setLabel("Rule type");
         typeSelect.setItems(RuleType.values());
         typeSelect.setItemLabelGenerator(Enum::name);
-        typeSelect.setValue(r.type);
+        typeSelect.setValue(r.type());
         typeSelect.setWidthFull();
 
         TextField valueField = new TextField("Value");
-        valueField.setValue(r.value == null ? "" : r.value);
+        valueField.setValue(r.value() == null ? "" : r.value());
         valueField.setWidthFull();
-        applyValueFieldState(valueField, typeSelect.getValue());
-        typeSelect.addValueChangeListener(e -> applyValueFieldState(valueField, e.getValue()));
+        applyValueHelper(valueField, typeSelect.getValue());
+        typeSelect.addValueChangeListener(e -> applyValueHelper(valueField, e.getValue()));
 
         Div body = new Div(typeSelect, valueField);
         body.getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "12px");
         d.add(body);
 
-        Composite parent = parentMap.get(r.id());
-        if (parent != null) {
+        if (presenter.canDelete(root, r.id())) {
             Button delete = new Button("Delete rule", e -> {
-                parent.children.removeIf(child -> r.id().equals(child.id()));
-                d.close();
-                rebuildTree();
-                Toasts.warn("Rule removed.");
+                presenter.deleteNode(root, r.id());
+                d.close(); rebuildTree(); Toasts.warn("Rule removed.");
             });
             delete.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_TERTIARY);
             delete.getStyle().set("margin-right", "auto");
@@ -440,26 +262,23 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         Button cancel = new Button("Cancel", e -> d.close());
         cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         Button save = new Button("Save", e -> {
-            r.type  = typeSelect.getValue();
-            r.value = valueField.getValue().trim();
-            d.close();
-            rebuildTree();
-            Toasts.success("Rule updated.");
+            presenter.updateRule(root, r.id(), typeSelect.getValue(), valueField.getValue());
+            d.close(); rebuildTree(); Toasts.success("Rule updated.");
         });
         save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         d.getFooter().add(cancel, save);
         d.open();
     }
 
-    private void applyValueFieldState(TextField field, RuleType t) {
-        field.setHelperText("Numeric value · unit = " + t.unit);
+    private void applyValueHelper(TextField field, RuleType t) {
+        field.setHelperText("Numeric value · unit = " + t.unit());
     }
 
     // ---------------------------------------------------------------------
-    // Composite (group) editor dialog
+    // Group editor dialog
     // ---------------------------------------------------------------------
 
-    private void openCompositeDialog(Composite c) {
+    private void openGroupDialog(Group g) {
         Dialog d = new Dialog();
         d.setHeaderTitle("Edit group");
         d.setWidth("440px");
@@ -471,21 +290,17 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
             case AND -> "AND · all children must be true";
             case OR  -> "OR · any child can be true";
         });
-        opGroup.setValue(c.op);
+        opGroup.setValue(g.op());
 
         Button addRule = new Button("+ Add rule", e -> {
-            c.children.add(new Rule(RuleType.AgeAtLeast, "18"));
-            d.close();
-            rebuildTree();
-            Toasts.success("Rule added — click it to edit.");
+            presenter.addRule(root, g.id());
+            d.close(); rebuildTree(); Toasts.success("Rule added — click it to edit.");
         });
         addRule.addThemeVariants(ButtonVariant.LUMO_SUCCESS, ButtonVariant.LUMO_TERTIARY);
 
         Button addGroup = new Button("+ Add group", e -> {
-            c.children.add(new Composite(Op.AND));
-            d.close();
-            rebuildTree();
-            Toasts.success("Group added — click it to add children.");
+            presenter.addGroup(root, g.id());
+            d.close(); rebuildTree(); Toasts.success("Group added — click it to add children.");
         });
         addGroup.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
 
@@ -496,13 +311,10 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         body.getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "12px");
         d.add(body);
 
-        Composite parent = parentMap.get(c.id());
-        if (parent != null) {
+        if (presenter.canDelete(root, g.id())) {
             Button delete = new Button("Delete group", e -> {
-                parent.children.removeIf(child -> c.id().equals(child.id()));
-                d.close();
-                rebuildTree();
-                Toasts.warn("Group removed.");
+                presenter.deleteNode(root, g.id());
+                d.close(); rebuildTree(); Toasts.warn("Group removed.");
             });
             delete.addThemeVariants(ButtonVariant.LUMO_ERROR, ButtonVariant.LUMO_TERTIARY);
             delete.getStyle().set("margin-right", "auto");
@@ -512,10 +324,8 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         Button cancel = new Button("Cancel", e -> d.close());
         cancel.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
         Button save = new Button("Save", e -> {
-            c.op = opGroup.getValue();
-            d.close();
-            rebuildTree();
-            Toasts.success("Group updated.");
+            presenter.updateGroupOp(root, g.id(), opGroup.getValue());
+            d.close(); rebuildTree(); Toasts.success("Group updated.");
         });
         save.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         d.getFooter().add(cancel, save);
@@ -523,84 +333,32 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     }
 
     // ---------------------------------------------------------------------
-    // Action bar
+    // Action bar + save
     // ---------------------------------------------------------------------
 
     private Component buildActionBar() {
-        Div bar = new Div();
-        bar.addClassName("pe-actionbar");
+        Div bar = new Div(); bar.addClassName("pe-actionbar");
 
         Div left = new Div(); left.addClassName("l");
-        left.add(new LkBtn("Discard Changes").variant(LkBtn.Variant.tertiary)
-            .onClick(e -> {
-                Toasts.warn("Changes discarded.");
-                UI.getCurrent().navigate(CompanyEventListView.class);
-            }));
+        left.add(new LkBtn("Discard changes").variant(LkBtn.Variant.tertiary)
+            .onClick(e -> { loadExistingPolicy(); rebuildTree(); Toasts.warn("Changes discarded."); }));
 
         Div right = new Div(); right.addClassName("r");
-        right.add(
-            new LkBtn("Test Against a Buyer").variant(LkBtn.Variant.secondary)
-                .icon(new LkIcon("flask", 16))
-                .onClick(e -> Toasts.warn("Test-against-a-buyer dialog (V2-PEDIT-02).")),
-            new LkBtn("Save Policy").variant(LkBtn.Variant.primary)
-                .onClick(e -> savePolicy())
-        );
+        right.add(new LkBtn("Save policy").variant(LkBtn.Variant.primary)
+            .onClick(e -> savePolicy()));
 
         bar.add(left, right);
         return bar;
     }
 
-    // ---------------------------------------------------------------------
-    // Save
-    // ---------------------------------------------------------------------
-
     private void savePolicy() {
-        if (companyId <= 0) {
-            Toasts.failure("No company selected.");
-            return;
+        if (companyId <= 0) { Toasts.failure("No company selected."); return; }
+        if (isEventLevel && eventId <= 0) { Toasts.failure("No event selected."); return; }
+        switch (presenter.save(memberToken, companyId, eventId, isEventLevel, root)) {
+            case SaveOutcome.Success s        -> Toasts.success("Policy saved.");
+            case SaveOutcome.NotAuthenticated na -> Toasts.failure("Please sign in again to save.");
+            case SaveOutcome.Invalid inv      -> Toasts.warn(inv.reason());
+            case SaveOutcome.Failure f        -> Toasts.failure("Failed to save: " + f.reason());
         }
-        if (isEventLevel && eventId <= 0) {
-            Toasts.failure("No event selected.");
-            return;
-        }
-        switch (presenter.save(AuthSession.token(), companyId, eventId, isEventLevel, nodeToDTO(root))) {
-            case SaveOutcome.Success s -> Toasts.success("Policy saved.");
-            case SaveOutcome.NotAuthenticated na -> Toasts.failure("Not authenticated.");
-            case SaveOutcome.Failure f -> Toasts.failure("Failed to save: " + f.reason());
-        }
-    }
-
-    // ---------------------------------------------------------------------
-    // Node → PurchasePolicyDTO
-    // ---------------------------------------------------------------------
-
-    private PurchasePolicyDTO nodeToDTO(Node node) {
-        if (node instanceof Rule r) {
-            int val;
-            try {
-                val = Integer.parseInt(r.value);
-            } catch (NumberFormatException | NullPointerException e) {
-                return new PurchasePolicyDTO("NONE", null, null, null, null);
-            }
-            return switch (r.type) {
-                case AgeAtLeast      -> new PurchasePolicyDTO("AGE",         val,  null, null, null);
-                case QuantityAtLeast -> new PurchasePolicyDTO("MIN_TICKETS", null, val,  null, null);
-                case QuantityAtMost  -> new PurchasePolicyDTO("MAX_TICKETS", null, null, val,  null);
-            };
-        }
-        Composite c = (Composite) node;
-        List<PurchasePolicyDTO> children = c.children.stream()
-                .map(this::nodeToDTO)
-                .toList();
-        String type = c.op == Op.AND ? "AND" : "OR";
-        return new PurchasePolicyDTO(type, null, null, null, children);
-    }
-
-    private static String escape(String s) {
-        return s == null ? "" : s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
-    }
-
-    private static String escapeJson(String s) {
-        return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }


### PR DESCRIPTION
fix(policies): enforce EDIT_POLICIES permission + tidy editor MVP

Services: owners AND managers with EDIT_POLICIES can edit policies (was owner-only)
Presenter owns all logic (model, conversion, validation); View only renders + wires
Drop AuthSession from View, gate save on validation, remove mock data