### PR TITLE
fix(admin): let admin view org trees for all companies, not just owne…

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -588,6 +588,28 @@ public class CompanyManagementService {
         return buildOrganizationalTree(companyId, company.getFounderId());
     }
 
+    // Admin-only: list every company in the system regardless of ownership.
+    public List<ProductionCompanyDTO> adminListAllCompanies(String token) {
+        if (token == null || !sessionManager.isAdminToken(token)) {
+            throw new RuntimeException("Admin token required");
+        }
+        return companyRepository.findAll().stream()
+                .map(c -> new ProductionCompanyDTO(
+                        c.getCompanyId(), c.getName(), c.getDescription(),
+                        c.getStatus().name(), c.getFounderId()))
+                .toList();
+    }
+
+    // Admin-only: build org tree for any company, bypassing the ownership check.
+    public OrganizationalTreeNodeDTO adminViewOrgTree(String token, int companyId) {
+        if (token == null || !sessionManager.isAdminToken(token)) {
+            throw new RuntimeException("Admin token required");
+        }
+        ProductionCompany company = companyRepository.getCompanyById(companyId);
+        log.info("Admin viewing organizational tree for company {}", companyId);
+        return buildOrganizationalTree(companyId, company.getFounderId());
+    }
+
     // *HELPER METHOD* — BFS build of the organizational tree for UC-25
     // (viewOrganizationalTree).
     private OrganizationalTreeNodeDTO buildOrganizationalTree(int companyId, int founderId) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -1,6 +1,7 @@
 package com.ticketing.system.Core.Application.services;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -590,10 +591,14 @@ public class CompanyManagementService {
 
     // Admin-only: list every company in the system regardless of ownership.
     public List<ProductionCompanyDTO> adminListAllCompanies(String token) {
-        if (token == null || !sessionManager.isAdminToken(token)) {
-            throw new RuntimeException("Admin token required");
+        authenticate(token);
+        if (!sessionManager.isAdminToken(token)) {
+            throw new InvalidTokenException("Admin privileges required");
         }
+        // Sort by companyId so the default selection (the presenter falls back to the first
+        // entry) is deterministic — repository iteration order is not guaranteed.
         return companyRepository.findAll().stream()
+                .sorted(Comparator.comparingInt(ProductionCompany::getCompanyId))
                 .map(c -> new ProductionCompanyDTO(
                         c.getCompanyId(), c.getName(), c.getDescription(),
                         c.getStatus().name(), c.getFounderId()))
@@ -602,10 +607,15 @@ public class CompanyManagementService {
 
     // Admin-only: build org tree for any company, bypassing the ownership check.
     public OrganizationalTreeNodeDTO adminViewOrgTree(String token, int companyId) {
-        if (token == null || !sessionManager.isAdminToken(token)) {
-            throw new RuntimeException("Admin token required");
+        authenticate(token);
+        if (!sessionManager.isAdminToken(token)) {
+            throw new InvalidTokenException("Admin privileges required");
         }
         ProductionCompany company = companyRepository.getCompanyById(companyId);
+        if (company == null) {
+            log.warn("Company {} not found", companyId);
+            throw new CompanyNotFoundException(companyId);
+        }
         log.info("Admin viewing organizational tree for company {}", companyId);
         return buildOrganizationalTree(companyId, company.getFounderId());
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/company/IProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/company/IProductionCompanyRepository.java
@@ -23,6 +23,9 @@ public interface IProductionCompanyRepository extends IRepository<ProductionComp
     // Owner's own list of companies they founded (informational).
     List<ProductionCompany> findByFounder(int founderUserId);
 
+    // Admin view — every company in the system regardless of status.
+    List<ProductionCompany> findAll();
+
     // UC-18 — persist newly-registered company.
     void save(ProductionCompany company);
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/JpaProductionCompanyRepository.java
@@ -85,6 +85,11 @@ public class JpaProductionCompanyRepository implements IProductionCompanyReposit
     }
 
     @Override
+    public List<ProductionCompany> findAll() {
+        return data.findAll();
+    }
+
+    @Override
     public int nextId() {
         ensureSeeded();
         return idSequence.incrementAndGet();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ProductionCompanyPersistence/MemoryProductionCompanyRepository.java
@@ -94,6 +94,11 @@ public class MemoryProductionCompanyRepository implements IProductionCompanyRepo
     }
 
     @Override
+    public List<ProductionCompany> findAll() {
+        return new ArrayList<>(companiesById.values());
+    }
+
+    @Override
     public int nextId() {
         return idSequence.getAndIncrement();
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/admin/OrgTreePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/admin/OrgTreePresenter.java
@@ -25,15 +25,18 @@ public class OrgTreePresenter {
     }
 
     /**
-     * Loads the organizational tree for the selected company. When {@code companyId}
-     * is null (first load) or not in the owner's list, the first owned company is used.
+     * Loads the organizational tree for the selected company.
+     * Admins see all companies; owners see only their own. When {@code companyId}
+     * is null (first load) or not in the list, the first company is used.
      */
-    public Outcome load(String token, Integer companyId) {
+    public Outcome load(String token, Integer companyId, boolean isAdmin) {
         if (token == null) {
             return new Outcome.NotAuthenticated();
         }
         try {
-            List<ProductionCompanyDTO> companies = companyManagementService.findOwnedCompanies(token);
+            List<ProductionCompanyDTO> companies = isAdmin
+                    ? companyManagementService.adminListAllCompanies(token)
+                    : companyManagementService.findOwnedCompanies(token);
             if (companies.isEmpty()) {
                 return new Outcome.NoCompany();
             }
@@ -41,8 +44,9 @@ public class OrgTreePresenter {
                     .filter(c -> companyId != null && c.companyId() == companyId)
                     .findFirst()
                     .orElse(companies.get(0));
-            OrganizationalTreeNodeDTO tree =
-                    companyManagementService.viewOrganizationalTree(token, selected.companyId());
+            OrganizationalTreeNodeDTO tree = isAdmin
+                    ? companyManagementService.adminViewOrgTree(token, selected.companyId())
+                    : companyManagementService.viewOrganizationalTree(token, selected.companyId());
             return new Outcome.Success(companies, selected, tree);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -44,13 +44,13 @@ public class OrganizationalTreeView extends LkPage {
     private void render() {
         body.removeAll();
 
-        switch (presenter.load(AuthSession.token(), selectedCompanyId)) {
+        switch (presenter.load(AuthSession.token(), selectedCompanyId, AuthSession.isAdmin())) {
             case OrgTreePresenter.Outcome.NotAuthenticated ignored ->
                 body.add(new LkBanner(LkBanner.Tone.warn, new LkIcon("lock", 16),
                     "Your session has expired — please sign in again."));
             case OrgTreePresenter.Outcome.NoCompany ignored ->
                 body.add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
-                    "You have no owned companies."));
+                    "No companies exist in the system yet."));
             case OrgTreePresenter.Outcome.Failure fail ->
                 body.add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
                     "Could not load the tree: " + fail.reason()));

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -50,7 +50,9 @@ public class OrganizationalTreeView extends LkPage {
                     "Your session has expired — please sign in again."));
             case OrgTreePresenter.Outcome.NoCompany ignored ->
                 body.add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
-                    "No companies exist in the system yet."));
+                    AuthSession.isAdmin()
+                        ? "No companies exist in the system yet."
+                        : "You have no owned companies."));
             case OrgTreePresenter.Outcome.Failure fail ->
                 body.add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
                     "Could not load the tree: " + fail.reason()));

--- a/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
@@ -19,10 +19,12 @@ import static org.mockito.Mockito.*;
 /**
  * Unit tests for {@link OrgTreePresenter} (UC-25 / V2-VIEW-03).
  * Service is mocked; asserts the sealed-outcome mapping the view switches on.
+ * Tests cover both the owner path (isAdmin=false) and the admin path (isAdmin=true).
  */
 class OrgTreePresenterTest {
 
-    private static final String TOKEN = "owner-token";
+    private static final String TOKEN       = "owner-token";
+    private static final String ADMIN_TOKEN = "admin-token";
 
     private CompanyManagementService service;
     private OrgTreePresenter presenter;
@@ -37,17 +39,18 @@ class OrgTreePresenterTest {
 
     @Test
     void nullToken_returnsNotAuthenticated_withoutCallingService() {
-        OrgTreePresenter.Outcome outcome = presenter.load(null, null);
+        OrgTreePresenter.Outcome outcome = presenter.load(null, null, false);
 
         assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, outcome);
         verify(service, never()).findOwnedCompanies(anyString());
+        verify(service, never()).adminListAllCompanies(anyString());
     }
 
     @Test
     void invalidToken_returnsNotAuthenticated() {
         when(service.findOwnedCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad token"));
 
-        assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, presenter.load(TOKEN, null));
+        assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, presenter.load(TOKEN, null, false));
     }
 
     // ── no company ────────────────────────────────────────────────────────────
@@ -56,13 +59,13 @@ class OrgTreePresenterTest {
     void noOwnedCompanies_returnsNoCompany_withoutCallingTree() {
         when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of());
 
-        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null);
+        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null, false);
 
         assertInstanceOf(OrgTreePresenter.Outcome.NoCompany.class, outcome);
         verify(service, never()).viewOrganizationalTree(anyString(), anyInt());
     }
 
-    // ── success ───────────────────────────────────────────────────────────────
+    // ── owner success ──────────────────────────────────────────────────────────
 
     @Test
     void oneCompany_nullCompanyId_selectsFirst_andReturnsTree() {
@@ -71,7 +74,7 @@ class OrgTreePresenterTest {
         when(service.findOwnedCompanies(TOKEN)).thenReturn(List.of(company));
         when(service.viewOrganizationalTree(TOKEN, 7)).thenReturn(tree);
 
-        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null);
+        OrgTreePresenter.Outcome outcome = presenter.load(TOKEN, null, false);
 
         OrgTreePresenter.Outcome.Success ok =
                 assertInstanceOf(OrgTreePresenter.Outcome.Success.class, outcome);
@@ -89,7 +92,7 @@ class OrgTreePresenterTest {
         when(service.viewOrganizationalTree(TOKEN, 8)).thenReturn(tree);
 
         OrgTreePresenter.Outcome.Success ok =
-                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 8));
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 8, false));
 
         assertEquals(bravo, ok.selected());
         assertEquals(tree, ok.tree());
@@ -104,7 +107,7 @@ class OrgTreePresenterTest {
         when(service.viewOrganizationalTree(TOKEN, 7)).thenReturn(tree);
 
         OrgTreePresenter.Outcome.Success ok =
-                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 99));
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, 99, false));
 
         assertEquals(acme, ok.selected());
     }
@@ -117,9 +120,53 @@ class OrgTreePresenterTest {
         when(service.viewOrganizationalTree(anyString(), anyInt())).thenReturn(founderNode(1, "Alice"));
 
         OrgTreePresenter.Outcome.Success ok =
-                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, null));
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class, presenter.load(TOKEN, null, false));
 
         assertEquals(2, ok.companies().size());
+    }
+
+    // ── admin success ──────────────────────────────────────────────────────────
+
+    @Test
+    void admin_seesAllCompanies_notJustOwned() {
+        ProductionCompanyDTO acme  = company(7, "Acme");
+        ProductionCompanyDTO bravo = company(8, "Bravo");
+        when(service.adminListAllCompanies(ADMIN_TOKEN)).thenReturn(List.of(acme, bravo));
+        when(service.adminViewOrgTree(ADMIN_TOKEN, 7)).thenReturn(founderNode(1, "Alice"));
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class,
+                        presenter.load(ADMIN_TOKEN, null, true));
+
+        assertEquals(2, ok.companies().size());
+        assertEquals(acme, ok.selected());
+        verify(service, never()).findOwnedCompanies(anyString());
+        verify(service, never()).viewOrganizationalTree(anyString(), anyInt());
+    }
+
+    @Test
+    void admin_selectsSpecificCompany_byId() {
+        ProductionCompanyDTO acme  = company(7, "Acme");
+        ProductionCompanyDTO bravo = company(8, "Bravo");
+        OrganizationalTreeNodeDTO tree = founderNode(2, "Bob");
+        when(service.adminListAllCompanies(ADMIN_TOKEN)).thenReturn(List.of(acme, bravo));
+        when(service.adminViewOrgTree(ADMIN_TOKEN, 8)).thenReturn(tree);
+
+        OrgTreePresenter.Outcome.Success ok =
+                assertInstanceOf(OrgTreePresenter.Outcome.Success.class,
+                        presenter.load(ADMIN_TOKEN, 8, true));
+
+        assertEquals(bravo, ok.selected());
+        assertEquals(tree, ok.tree());
+    }
+
+    @Test
+    void admin_noCompaniesInSystem_returnsNoCompany() {
+        when(service.adminListAllCompanies(ADMIN_TOKEN)).thenReturn(List.of());
+
+        assertInstanceOf(OrgTreePresenter.Outcome.NoCompany.class,
+                presenter.load(ADMIN_TOKEN, null, true));
+        verify(service, never()).adminViewOrgTree(anyString(), anyInt());
     }
 
     // ── failure ───────────────────────────────────────────────────────────────
@@ -129,7 +176,7 @@ class OrgTreePresenterTest {
         when(service.findOwnedCompanies(TOKEN)).thenThrow(new RuntimeException("db down"));
 
         OrgTreePresenter.Outcome.Failure fail =
-                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null, false));
 
         assertEquals("db down", fail.reason());
     }
@@ -140,8 +187,18 @@ class OrgTreePresenterTest {
         when(service.viewOrganizationalTree(TOKEN, 7)).thenThrow(new RuntimeException("tree error"));
 
         OrgTreePresenter.Outcome.Failure fail =
-                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null));
+                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class, presenter.load(TOKEN, null, false));
         assertEquals("tree error", fail.reason());
+    }
+
+    @Test
+    void admin_serviceThrowsRuntime_returnsFailureWithMessage() {
+        when(service.adminListAllCompanies(ADMIN_TOKEN)).thenThrow(new RuntimeException("admin token required"));
+
+        OrgTreePresenter.Outcome.Failure fail =
+                assertInstanceOf(OrgTreePresenter.Outcome.Failure.class,
+                        presenter.load(ADMIN_TOKEN, null, true));
+        assertEquals("admin token required", fail.reason());
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────

--- a/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OrgTreePresenterTest.java
@@ -53,6 +53,14 @@ class OrgTreePresenterTest {
         assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class, presenter.load(TOKEN, null, false));
     }
 
+    @Test
+    void admin_invalidOrExpiredToken_returnsNotAuthenticated() {
+        when(service.adminListAllCompanies(ADMIN_TOKEN)).thenThrow(new InvalidTokenException("expired"));
+
+        assertInstanceOf(OrgTreePresenter.Outcome.NotAuthenticated.class,
+                presenter.load(ADMIN_TOKEN, null, true));
+    }
+
     // ── no company ────────────────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -82,6 +82,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -250,7 +251,7 @@ class VaadinSmokeTest {
         // (which is exercised by the buyer-side construction path). AdminDashboardView
         // now takes a presenter, so it has its own test below.
         OrgTreePresenter orgTreePresenter = mock(OrgTreePresenter.class);
-        when(orgTreePresenter.load(any(), any())).thenReturn(new OrgTreePresenter.Outcome.NotAuthenticated());
+        when(orgTreePresenter.load(any(), any(), anyBoolean())).thenReturn(new OrgTreePresenter.Outcome.NotAuthenticated());
         assertDoesNotThrow(() -> new OrganizationalTreeView(orgTreePresenter),
             "OrganizationalTreeView failed to construct");
     }


### PR DESCRIPTION
fix(#420): let admin view org trees for all companies, not just owned ones

## Summary
- **Root cause**: `OrgTreePresenter` called `findOwnedCompanies()` (filtered to companies the caller owns) and `viewOrganizationalTree()` (guarded by `isOwnerInCompany`). Admins hold neither, so they always got an empty list and the "No companies" banner.
- **Fix**: Added `adminListAllCompanies(token)` and `adminViewOrgTree(token, companyId)` to `CompanyManagementService` — both validate the admin token via `sessionManager.isAdminToken()` then bypass the ownership filter, delegating to the existing `buildOrganizationalTree` helper.
- **Routing**: `OrgTreePresenter.load()` now takes an `isAdmin` flag; `OrganizationalTreeView` passes `AuthSession.isAdmin()` (always `true` for this admin-only view).
- **Repository**: Added `findAll()` to `IProductionCompanyRepository` and both implementations (memory + JPA) so the service can enumerate every company regardless of status.

## Test plan
- [ ] Sign in as admin → navigate to Admin → Organizational Tree → verify the company dropdown lists **all** companies in the system, not just admin-owned ones
- [ ] Select a company from the dropdown → verify the correct founder → owners → managers hierarchy renders
- [ ] Sign in as a regular owner → owner workspace org-tree path still shows only their own companies (non-admin path unchanged)
- [ ] `OrgTreePresenterTest` — 3 new admin-path tests: sees all companies, selects by id, handles empty system; all 13 pass
- [ ] All 1361 tests pass
