### PR TITLE
417 v2 my events event status edit functionality

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -752,8 +752,7 @@ public class EventManagementService {
             // permanently delete one that still has purchase history, which would orphan its
             // OrderReceipt/Ticket records (referenced by eventId, no cascade).
             if (!orderReceiptRepository.findByEventId(eventId).isEmpty()) {
-                throw new BusinessRuleViolationException(
-                        "Cannot delete event " + eventId + " — it has purchase history and is retained for reporting.");
+                throw new BusinessRuleViolationException("Can't delete event with purchase history");
             }
             eventRepository.delete(eventId);
             log.info("Event {} deleted by user {}", eventId, userId);

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -735,6 +735,24 @@ public class EventManagementService {
         }
     }
 
+    // Permanently removes a CANCELED event. Only callable by a user with CONFIGURE_VENUE.
+    public void deleteEvent(String token, int eventId) {
+        int userId = validateTokenAndGetUserId(token);
+        eventRepository.lockForUpdate(eventId);
+        try {
+            Event event = eventRepository.findById(eventId);
+            User user = userRepository.getUserById(userId);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            if (event.getStatus() != EventStatus.CANCELED) {
+                throw new IllegalStateException("Only CANCELED events can be deleted");
+            }
+            eventRepository.delete(eventId);
+            log.info("Event {} deleted by user {}", eventId, userId);
+        } finally {
+            eventRepository.unlock(eventId);
+        }
+    }
+
     // Owner/Manager changes an event's status to a target state (non-cancel transitions only).
     // Cancel with refund pipeline uses cancelEventAndRefund.
     public void changeEventStatus(String token, int eventId, EventStatus targetStatus) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -745,6 +745,7 @@ public class EventManagementService {
             User user = userRepository.getUserById(userId);
             user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
             switch (targetStatus) {
+                case SCHEDULED -> event.transitionToScheduled();
                 case ON_SALE -> event.transitionToOnSale();
                 default -> throw new IllegalArgumentException("Cannot manually set status to " + targetStatus);
             }

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -11,8 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
 import com.ticketing.system.Core.Domain.exceptions.CompanyNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
@@ -744,7 +746,14 @@ public class EventManagementService {
             User user = userRepository.getUserById(userId);
             user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
             if (event.getStatus() != EventStatus.CANCELED) {
-                throw new IllegalStateException("Only CANCELED events can be deleted");
+                throw new InvalidStateTransitionException("Only CANCELED events can be deleted");
+            }
+            // Soft-cancel keeps events "for historical and reporting purposes": refuse to
+            // permanently delete one that still has purchase history, which would orphan its
+            // OrderReceipt/Ticket records (referenced by eventId, no cascade).
+            if (!orderReceiptRepository.findByEventId(eventId).isEmpty()) {
+                throw new BusinessRuleViolationException(
+                        "Cannot delete event " + eventId + " — it has purchase history and is retained for reporting.");
             }
             eventRepository.delete(eventId);
             log.info("Event {} deleted by user {}", eventId, userId);
@@ -765,7 +774,7 @@ public class EventManagementService {
             switch (targetStatus) {
                 case SCHEDULED -> event.transitionToScheduled();
                 case ON_SALE -> event.transitionToOnSale();
-                default -> throw new IllegalArgumentException("Cannot manually set status to " + targetStatus);
+                default -> throw new InvalidStateTransitionException("Cannot manually set status to " + targetStatus);
             }
             eventRepository.save(event);
             log.info("Event {} status changed to {} by user {}", eventId, targetStatus, userId);

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -735,6 +735,26 @@ public class EventManagementService {
         }
     }
 
+    // Owner/Manager changes an event's status to a target state (non-cancel transitions only).
+    // Cancel with refund pipeline uses cancelEventAndRefund.
+    public void changeEventStatus(String token, int eventId, EventStatus targetStatus) {
+        int userId = validateTokenAndGetUserId(token);
+        eventRepository.lockForUpdate(eventId);
+        try {
+            Event event = eventRepository.findById(eventId);
+            User user = userRepository.getUserById(userId);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            switch (targetStatus) {
+                case ON_SALE -> event.transitionToOnSale();
+                default -> throw new IllegalArgumentException("Cannot manually set status to " + targetStatus);
+            }
+            eventRepository.save(event);
+            log.info("Event {} status changed to {} by user {}", eventId, targetStatus, userId);
+        } finally {
+            eventRepository.unlock(eventId);
+        }
+    }
+
     // UC-19 — soft cancel; fires EventCancelled domain event for UC-4 refund
     // pipeline.
     public void cancelEventAndRefund(String token, int eventId) {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
@@ -46,6 +46,9 @@ public interface IEventRepository extends IRepository<Event, Integer> {
     List<Event> searchONSALE(CatalogSearchFiltersDTO filters);
     
 
+    // Permanently removes a CANCELED event from the store.
+    void delete(int eventId);
+
     int nextId();
 
     int nextVenueMapId();

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
@@ -93,6 +93,12 @@ public class JpaEventRepository implements IEventRepository {
     }
 
     @Override
+    @Transactional
+    public void delete(int eventId) {
+        data.deleteById(eventId);
+    }
+
+    @Override
     public List<Event> findByCompanyId(int companyId) {
         return data.findByCompanyId(companyId);
     }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -65,6 +65,11 @@ public class MemoryEventRepository implements IEventRepository {
     }
 
     @Override
+    public void delete(int eventId) {
+        events.remove(eventId);
+    }
+
+    @Override
     public boolean save(Event event) {
         // New events (not yet in the map) may be saved without a lock — no other
         // thread can know the ID before the first save completes.

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -66,6 +66,13 @@ public class MemoryEventRepository implements IEventRepository {
 
     @Override
     public void delete(int eventId) {
+        // Delete is a structural/lifecycle change: an existing event must be write-locked
+        // by the calling thread, mirroring save(), so it can't race with buyer read locks
+        // (lockForBuyerOperation) or other lifecycle writes.
+        if (events.containsKey(eventId)
+                && !locks.isWriteHeldByCurrentThread(eventId)) {
+            throw new IllegalStateException("Event " + eventId + " must be locked before deleting");
+        }
         events.remove(eventId);
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -9,6 +9,7 @@ import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 
 @Component
@@ -39,10 +40,40 @@ public class CompanyEventListPresenter {
         }
     }
 
+    public ActionOutcome cancelEvent(String token, int eventId) {
+        if (token == null) return new ActionOutcome.NotAuthenticated();
+        try {
+            eventService.cancelEventAndRefund(token, eventId);
+            return new ActionOutcome.Success();
+        } catch (InvalidTokenException e) {
+            return new ActionOutcome.NotAuthenticated();
+        } catch (RuntimeException e) {
+            return new ActionOutcome.Failure(e.getMessage());
+        }
+    }
+
+    public ActionOutcome changeEventStatus(String token, int eventId, EventStatus targetStatus) {
+        if (token == null) return new ActionOutcome.NotAuthenticated();
+        try {
+            eventService.changeEventStatus(token, eventId, targetStatus);
+            return new ActionOutcome.Success();
+        } catch (InvalidTokenException e) {
+            return new ActionOutcome.NotAuthenticated();
+        } catch (RuntimeException e) {
+            return new ActionOutcome.Failure(e.getMessage());
+        }
+    }
+
     public sealed interface Outcome {
         record Success(List<EventDetailDTO> events) implements Outcome {}
         record NotAuthenticated() implements Outcome {}
         record NoCompany() implements Outcome {}
         record Failure(String reason) implements Outcome {}
+    }
+
+    public sealed interface ActionOutcome {
+        record Success() implements ActionOutcome {}
+        record NotAuthenticated() implements ActionOutcome {}
+        record Failure(String reason) implements ActionOutcome {}
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -52,6 +52,18 @@ public class CompanyEventListPresenter {
         }
     }
 
+    public ActionOutcome deleteEvent(String token, int eventId) {
+        if (token == null) return new ActionOutcome.NotAuthenticated();
+        try {
+            eventService.deleteEvent(token, eventId);
+            return new ActionOutcome.Success();
+        } catch (InvalidTokenException e) {
+            return new ActionOutcome.NotAuthenticated();
+        } catch (RuntimeException e) {
+            return new ActionOutcome.Failure(e.getMessage());
+        }
+    }
+
     public ActionOutcome changeEventStatus(String token, int eventId, EventStatus targetStatus) {
         if (token == null) return new ActionOutcome.NotAuthenticated();
         try {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -122,12 +122,15 @@ public class CompanyEventListView extends LkPage {
             iconBtn("edit",    "Edit metadata", () -> UI.getCurrent().navigate("owner/events/" + ev.eventId())),
             iconBtn("map",     "Venue map",     () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())),
             iconBtn("policy",  "Policies",      () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)),
-            iconBtn("chart",   "Sales",         () -> UI.getCurrent().navigate(CompanySalesView.class)),
-            iconBtn("gear",    "Change status", () -> openStatusDialog(ev)),
-            iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev))
+            iconBtn("chart",   "Sales",         () -> UI.getCurrent().navigate(CompanySalesView.class))
         );
         if (ev.status() == EventStatus.CANCELED) {
+            // A canceled event has no further transitions and can't be canceled again —
+            // the only action is to permanently remove it.
             actions.add(iconBtn("trash", "Remove event", () -> openDeleteDialog(ev)));
+        } else {
+            actions.add(iconBtn("gear",    "Change status", () -> openStatusDialog(ev)));
+            actions.add(iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev)));
         }
         row.put("act", actions);
         grid.row(row);
@@ -135,7 +138,7 @@ public class CompanyEventListView extends LkPage {
 
     private void openCancelDialog(EventDetailDTO ev) {
         ConfirmDialog dialog = new ConfirmDialog();
-        dialog.setHeader("Cancel \"" + escape(ev.name()) + "\"?");
+        dialog.setHeader("Cancel \"" + ev.name() + "\"?");
         dialog.setText("This will refund all ticket holders and permanently cancel the event. This cannot be undone.");
         dialog.setCancelable(true);
         dialog.setCancelText("Keep event");
@@ -159,7 +162,7 @@ public class CompanyEventListView extends LkPage {
 
     private void openDeleteDialog(EventDetailDTO ev) {
         ConfirmDialog dialog = new ConfirmDialog();
-        dialog.setHeader("Remove \"" + escape(ev.name()) + "\"?");
+        dialog.setHeader("Remove \"" + ev.name() + "\"?");
         dialog.setText("The event record will be permanently deleted. This cannot be undone.");
         dialog.setCancelable(true);
         dialog.setCancelText("Keep");
@@ -197,14 +200,17 @@ public class CompanyEventListView extends LkPage {
         select.setPlaceholder("Select new status…");
 
         ConfirmDialog dialog = new ConfirmDialog();
-        dialog.setHeader("Change status — " + escape(ev.name()));
+        dialog.setHeader("Change status — " + ev.name());
         dialog.add(select);
         dialog.setCancelable(true);
         dialog.setCancelText("Cancel");
         dialog.setConfirmText("Apply");
         dialog.addConfirmListener(ignored -> {
             EventStatus target = select.getValue();
-            if (target == null) return;
+            if (target == null) {
+                Toasts.warn("Please select a status.");
+                return;
+            }
             switch (presenter.changeEventStatus(AuthSession.token(), Integer.parseInt(ev.eventId()), target)) {
                 case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
                     Toasts.success("Event status changed to " + target.name() + ".");

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -123,7 +123,7 @@ public class CompanyEventListView extends LkPage {
             iconBtn("map",     "Venue map",     () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())),
             iconBtn("policy",  "Policies",      () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)),
             iconBtn("chart",   "Sales",         () -> UI.getCurrent().navigate(CompanySalesView.class)),
-            iconBtn("status",  "Change status", () -> openStatusDialog(ev)),
+            iconBtn("gear",    "Change status", () -> openStatusDialog(ev)),
             iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev))
         );
         row.put("act", actions);
@@ -164,6 +164,7 @@ public class CompanyEventListView extends LkPage {
         Select<EventStatus> select = new Select<>();
         select.setItems(allowed);
         select.setItemLabelGenerator(s -> switch (s) {
+            case SCHEDULED -> "Mark as Scheduled";
             case ON_SALE -> "Publish (On Sale)";
             default -> s.name();
         });
@@ -194,6 +195,7 @@ public class CompanyEventListView extends LkPage {
 
     private static List<EventStatus> allowedTransitions(EventStatus current) {
         return switch (current) {
+            case DRAFT -> List.of(EventStatus.SCHEDULED);
             case SCHEDULED -> List.of(EventStatus.ON_SALE);
             default -> List.of();
         };

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -177,7 +177,7 @@ public class CompanyEventListView extends LkPage {
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
                     Toasts.warn("Session expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure("Remove failed: " + fail.reason());
+                    Toasts.failure(fail.reason() == null ? "Remove failed." : fail.reason());
             }
         });
         dialog.open();

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -21,7 +21,9 @@ import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.views.admin.CompanySalesView;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
@@ -35,7 +37,7 @@ import java.util.Map;
 @PermitAll
 @RequireCapability(Capability.VIEW_COMPANY_EVENTS)
 public class CompanyEventListView extends LkPage {
-    
+
     private final CompanyEventListPresenter presenter;
     private final LkCard eventsCard = new LkCard().pad(0);
 
@@ -53,7 +55,7 @@ public class CompanyEventListView extends LkPage {
         );
         add(buildFilters());
         add(eventsCard);
-        Span hint = Lk.muted("Row actions → Edit metadata · Venue map · Policies · Sales · Cancel.");
+        Span hint = Lk.muted("Row actions → Edit metadata · Venue map · Policies · Sales · Status · Cancel.");
         hint.getStyle().set("font-size", "12.5px");
         add(hint);
         reload();
@@ -121,10 +123,80 @@ public class CompanyEventListView extends LkPage {
             iconBtn("map",     "Venue map",     () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())),
             iconBtn("policy",  "Policies",      () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)),
             iconBtn("chart",   "Sales",         () -> UI.getCurrent().navigate(CompanySalesView.class)),
-            iconBtn("warning", "Cancel event",  () -> Toasts.warn("Cancel-event dialog — V2-CADMIN-EVT-CANCEL."))
+            iconBtn("status",  "Change status", () -> openStatusDialog(ev)),
+            iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev))
         );
         row.put("act", actions);
         grid.row(row);
+    }
+
+    private void openCancelDialog(EventDetailDTO ev) {
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Cancel \"" + escape(ev.name()) + "\"?");
+        dialog.setText("This will refund all ticket holders and permanently cancel the event. This cannot be undone.");
+        dialog.setCancelable(true);
+        dialog.setCancelText("Keep event");
+        dialog.setConfirmText("Cancel event");
+        dialog.setConfirmButtonTheme("error primary");
+        dialog.addConfirmListener(ignored -> {
+            int eventId = ev.eventId();
+            switch (presenter.cancelEvent(AuthSession.token(), eventId)) {
+                case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
+                    Toasts.success("Event canceled and refunds issued.");
+                    reload();
+                }
+                case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
+                    Toasts.warn("Session expired — please sign in again.");
+                case CompanyEventListPresenter.ActionOutcome.Failure fail ->
+                    Toasts.error("Cancel failed: " + fail.reason());
+            }
+        });
+        dialog.open();
+    }
+
+    private void openStatusDialog(EventDetailDTO ev) {
+        List<EventStatus> allowed = allowedTransitions(ev.status());
+        if (allowed.isEmpty()) {
+            Toasts.warn("No status transitions available for a " + ev.status().name() + " event.");
+            return;
+        }
+
+        Select<EventStatus> select = new Select<>();
+        select.setItems(allowed);
+        select.setItemLabelGenerator(s -> switch (s) {
+            case ON_SALE -> "Publish (On Sale)";
+            default -> s.name();
+        });
+        select.setPlaceholder("Select new status…");
+
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Change status — " + escape(ev.name()));
+        dialog.add(select);
+        dialog.setCancelable(true);
+        dialog.setCancelText("Cancel");
+        dialog.setConfirmText("Apply");
+        dialog.addConfirmListener(ignored -> {
+            EventStatus target = select.getValue();
+            if (target == null) return;
+            switch (presenter.changeEventStatus(AuthSession.token(), ev.eventId(), target)) {
+                case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
+                    Toasts.success("Event status changed to " + target.name() + ".");
+                    reload();
+                }
+                case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
+                    Toasts.warn("Session expired — please sign in again.");
+                case CompanyEventListPresenter.ActionOutcome.Failure fail ->
+                    Toasts.error("Status change failed: " + fail.reason());
+            }
+        });
+        dialog.open();
+    }
+
+    private static List<EventStatus> allowedTransitions(EventStatus current) {
+        return switch (current) {
+            case SCHEDULED -> List.of(EventStatus.ON_SALE);
+            default -> List.of();
+        };
     }
 
     private static LkIconBtn iconBtn(String iconName, String tooltip, Runnable r) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -126,6 +126,9 @@ public class CompanyEventListView extends LkPage {
             iconBtn("gear",    "Change status", () -> openStatusDialog(ev)),
             iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev))
         );
+        if (ev.status() == EventStatus.CANCELED) {
+            actions.add(iconBtn("trash", "Remove event", () -> openDeleteDialog(ev)));
+        }
         row.put("act", actions);
         grid.row(row);
     }
@@ -149,6 +152,29 @@ public class CompanyEventListView extends LkPage {
                     Toasts.warn("Session expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
                     Toasts.failure("Cancel failed: " + fail.reason());
+            }
+        });
+        dialog.open();
+    }
+
+    private void openDeleteDialog(EventDetailDTO ev) {
+        ConfirmDialog dialog = new ConfirmDialog();
+        dialog.setHeader("Remove \"" + escape(ev.name()) + "\"?");
+        dialog.setText("The event record will be permanently deleted. This cannot be undone.");
+        dialog.setCancelable(true);
+        dialog.setCancelText("Keep");
+        dialog.setConfirmText("Remove");
+        dialog.setConfirmButtonTheme("error primary");
+        dialog.addConfirmListener(ignored -> {
+            switch (presenter.deleteEvent(AuthSession.token(), Integer.parseInt(ev.eventId()))) {
+                case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
+                    Toasts.success("Event removed.");
+                    reload();
+                }
+                case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
+                    Toasts.warn("Session expired — please sign in again.");
+                case CompanyEventListPresenter.ActionOutcome.Failure fail ->
+                    Toasts.failure("Remove failed: " + fail.reason());
             }
         });
         dialog.open();

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -139,7 +139,7 @@ public class CompanyEventListView extends LkPage {
         dialog.setConfirmText("Cancel event");
         dialog.setConfirmButtonTheme("error primary");
         dialog.addConfirmListener(ignored -> {
-            int eventId = ev.eventId();
+            int eventId = Integer.parseInt(ev.eventId());
             switch (presenter.cancelEvent(AuthSession.token(), eventId)) {
                 case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
                     Toasts.success("Event canceled and refunds issued.");
@@ -148,7 +148,7 @@ public class CompanyEventListView extends LkPage {
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
                     Toasts.warn("Session expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.error("Cancel failed: " + fail.reason());
+                    Toasts.failure("Cancel failed: " + fail.reason());
             }
         });
         dialog.open();
@@ -178,7 +178,7 @@ public class CompanyEventListView extends LkPage {
         dialog.addConfirmListener(ignored -> {
             EventStatus target = select.getValue();
             if (target == null) return;
-            switch (presenter.changeEventStatus(AuthSession.token(), ev.eventId(), target)) {
+            switch (presenter.changeEventStatus(AuthSession.token(), Integer.parseInt(ev.eventId()), target)) {
                 case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
                     Toasts.success("Event status changed to " + target.name() + ".");
                     reload();
@@ -186,7 +186,7 @@ public class CompanyEventListView extends LkPage {
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
                     Toasts.warn("Session expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.error("Status change failed: " + fail.reason());
+                    Toasts.failure("Status change failed: " + fail.reason());
             }
         });
         dialog.open();

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
@@ -44,7 +44,7 @@ public abstract class IEventRepositoryContractTest {
 
     // Builds a minimal valid Event with specified category and one zone priced at
     // 50.
-    private Event buildEvent(int id, String name, Double rating, int companyId, EventStatus status,
+    protected Event buildEvent(int id, String name, Double rating, int companyId, EventStatus status,
             EventCategory category) {
         VenueMap venueMap = new VenueMap(id, LOCATION, List.of(new StandingZone(1, "Floor", 100, 50)));
         ShowDate showDate = new ShowDate(FUTURE_START, FUTURE_END);

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/MemoryEventRepositoryTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/MemoryEventRepositoryTest.java
@@ -1,6 +1,13 @@
 package com.ticketing.system.unit.infrastructure.persistence.EventPersistence;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Infrastructure.persistence.EventPersistence.MemoryEventRepository;
 
 public class MemoryEventRepositoryTest extends IEventRepositoryContractTest {
@@ -10,4 +17,30 @@ public class MemoryEventRepositoryTest extends IEventRepositoryContractTest {
         return new MemoryEventRepository();
     }
 
+    // === delete — write-lock enforcement (Memory-specific concurrency contract) ===
+    // delete() is a structural change; like save(), it must reject an unlocked caller so it
+    // can't race with buyer read locks or other lifecycle writes.
+
+    @Test
+    void givenExistingEvent_whenDeletedWithoutHoldingWriteLock_thenThrows() {
+        IEventRepository repo = newRepository();
+        repo.save(buildEvent(1, "Rock Night", 4.5, 10, EventStatus.CANCELED, EventCategory.CONCERT));
+
+        assertThrows(IllegalStateException.class, () -> repo.delete(1));
+    }
+
+    @Test
+    void givenExistingEvent_whenDeletedHoldingWriteLock_thenEventIsRemoved() {
+        IEventRepository repo = newRepository();
+        repo.save(buildEvent(1, "Rock Night", 4.5, 10, EventStatus.CANCELED, EventCategory.CONCERT));
+
+        repo.lockForUpdate(1);
+        try {
+            repo.delete(1);
+        } finally {
+            repo.unlock(1);
+        }
+
+        assertThrows(EventNotFoundException.class, () -> repo.findById(1));
+    }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Presentation.presenters.company.CompanyEventListPresenter;
 import org.junit.jupiter.api.BeforeEach;
@@ -154,7 +155,7 @@ class CompanyEventListPresenterTest {
 
     @Test
     void deleteEvent_notCanceled_returnsFailureWithMessage() {
-        doThrow(new IllegalStateException("Only CANCELED events can be deleted"))
+        doThrow(new InvalidStateTransitionException("Only CANCELED events can be deleted"))
                 .when(eventService).deleteEvent(TOKEN, EVENT_ID);
 
         CompanyEventListPresenter.ActionOutcome.Failure fail =

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -154,6 +154,16 @@ class CompanyEventListPresenterTest {
     }
 
     @Test
+    void changeEventStatus_toScheduled_callsServiceAndReturnsSuccess() {
+        doNothing().when(eventService).changeEventStatus(TOKEN, EVENT_ID, EventStatus.SCHEDULED);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Success.class,
+                presenter.changeEventStatus(TOKEN, EVENT_ID, EventStatus.SCHEDULED));
+
+        verify(eventService).changeEventStatus(eq(TOKEN), eq(EVENT_ID), eq(EventStatus.SCHEDULED));
+    }
+
+    @Test
     void changeEventStatus_serviceThrowsRuntime_returnsFailureWithMessage() {
         doThrow(new RuntimeException("invalid transition"))
                 .when(eventService).changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE);

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -125,6 +125,45 @@ class CompanyEventListPresenterTest {
         assertEquals("refund failed", fail.reason());
     }
 
+    // ── deleteEvent ───────────────────────────────────────────────────────────
+
+    @Test
+    void deleteEvent_nullToken_returnsNotAuthenticated() {
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.deleteEvent(null, EVENT_ID));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void deleteEvent_invalidToken_returnsNotAuthenticated() {
+        doThrow(new InvalidTokenException("bad")).when(eventService).deleteEvent(TOKEN, EVENT_ID);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.deleteEvent(TOKEN, EVENT_ID));
+    }
+
+    @Test
+    void deleteEvent_success_callsServiceAndReturnsSuccess() {
+        doNothing().when(eventService).deleteEvent(TOKEN, EVENT_ID);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Success.class,
+                presenter.deleteEvent(TOKEN, EVENT_ID));
+
+        verify(eventService).deleteEvent(TOKEN, EVENT_ID);
+    }
+
+    @Test
+    void deleteEvent_notCanceled_returnsFailureWithMessage() {
+        doThrow(new IllegalStateException("Only CANCELED events can be deleted"))
+                .when(eventService).deleteEvent(TOKEN, EVENT_ID);
+
+        CompanyEventListPresenter.ActionOutcome.Failure fail =
+                assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Failure.class,
+                        presenter.deleteEvent(TOKEN, EVENT_ID));
+
+        assertEquals("Only CANCELED events can be deleted", fail.reason());
+    }
+
     // ── changeEventStatus ─────────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 import com.ticketing.system.Presentation.presenters.company.CompanyEventListPresenter;
@@ -163,6 +164,18 @@ class CompanyEventListPresenterTest {
                         presenter.deleteEvent(TOKEN, EVENT_ID));
 
         assertEquals("Only CANCELED events can be deleted", fail.reason());
+    }
+
+    @Test
+    void deleteEvent_withPurchaseHistory_returnsFailureWithMessage() {
+        doThrow(new BusinessRuleViolationException("Can't delete event with purchase history"))
+                .when(eventService).deleteEvent(TOKEN, EVENT_ID);
+
+        CompanyEventListPresenter.ActionOutcome.Failure fail =
+                assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Failure.class,
+                        presenter.deleteEvent(TOKEN, EVENT_ID));
+
+        assertEquals("Can't delete event with purchase history", fail.reason());
     }
 
     // ── changeEventStatus ─────────────────────────────────────────────────────

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -1,0 +1,179 @@
+package com.ticketing.system.unit.presentation;
+
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.presenters.company.CompanyEventListPresenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class CompanyEventListPresenterTest {
+
+    private static final String TOKEN = "owner-token";
+    private static final int COMPANY_ID = 42;
+    private static final int EVENT_ID = 7;
+
+    private EventManagementService eventService;
+    private CompanyManagementService companyService;
+    private CompanyEventListPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        eventService = mock(EventManagementService.class);
+        companyService = mock(CompanyManagementService.class);
+        presenter = new CompanyEventListPresenter(eventService, companyService);
+    }
+
+    // ── load ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void load_nullToken_returnsNotAuthenticated() {
+        assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
+                presenter.load(null));
+        verifyNoInteractions(eventService, companyService);
+    }
+
+    @Test
+    void load_invalidToken_returnsNotAuthenticated() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad"));
+
+        assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
+                presenter.load(TOKEN));
+    }
+
+    @Test
+    void load_noOwnedCompanies_returnsNoCompany() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+
+        assertInstanceOf(CompanyEventListPresenter.Outcome.NoCompany.class,
+                presenter.load(TOKEN));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void load_success_returnsEventsForFirstOwnedCompany() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        List<EventDetailDTO> events = List.of(event(EVENT_ID, "Gala Night"));
+        when(eventService.listEventsForCompany(TOKEN, COMPANY_ID)).thenReturn(events);
+
+        CompanyEventListPresenter.Outcome.Success ok =
+                assertInstanceOf(CompanyEventListPresenter.Outcome.Success.class, presenter.load(TOKEN));
+
+        assertEquals(1, ok.events().size());
+        assertEquals("Gala Night", ok.events().get(0).name());
+    }
+
+    @Test
+    void load_serviceThrowsRuntime_returnsFailure() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(eventService.listEventsForCompany(anyString(), anyInt()))
+                .thenThrow(new RuntimeException("db error"));
+
+        CompanyEventListPresenter.Outcome.Failure fail =
+                assertInstanceOf(CompanyEventListPresenter.Outcome.Failure.class, presenter.load(TOKEN));
+
+        assertEquals("db error", fail.reason());
+    }
+
+    // ── cancelEvent ───────────────────────────────────────────────────────────
+
+    @Test
+    void cancelEvent_nullToken_returnsNotAuthenticated() {
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.cancelEvent(null, EVENT_ID));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void cancelEvent_invalidToken_returnsNotAuthenticated() {
+        doThrow(new InvalidTokenException("bad")).when(eventService).cancelEventAndRefund(TOKEN, EVENT_ID);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.cancelEvent(TOKEN, EVENT_ID));
+    }
+
+    @Test
+    void cancelEvent_success_callsServiceAndReturnsSuccess() {
+        doNothing().when(eventService).cancelEventAndRefund(TOKEN, EVENT_ID);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Success.class,
+                presenter.cancelEvent(TOKEN, EVENT_ID));
+
+        verify(eventService).cancelEventAndRefund(TOKEN, EVENT_ID);
+    }
+
+    @Test
+    void cancelEvent_serviceThrowsRuntime_returnsFailureWithMessage() {
+        doThrow(new RuntimeException("refund failed")).when(eventService).cancelEventAndRefund(TOKEN, EVENT_ID);
+
+        CompanyEventListPresenter.ActionOutcome.Failure fail =
+                assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Failure.class,
+                        presenter.cancelEvent(TOKEN, EVENT_ID));
+
+        assertEquals("refund failed", fail.reason());
+    }
+
+    // ── changeEventStatus ─────────────────────────────────────────────────────
+
+    @Test
+    void changeEventStatus_nullToken_returnsNotAuthenticated() {
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.changeEventStatus(null, EVENT_ID, EventStatus.ON_SALE));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void changeEventStatus_invalidToken_returnsNotAuthenticated() {
+        doThrow(new InvalidTokenException("bad"))
+                .when(eventService).changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.NotAuthenticated.class,
+                presenter.changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE));
+    }
+
+    @Test
+    void changeEventStatus_toOnSale_callsServiceAndReturnsSuccess() {
+        doNothing().when(eventService).changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE);
+
+        assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Success.class,
+                presenter.changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE));
+
+        verify(eventService).changeEventStatus(eq(TOKEN), eq(EVENT_ID), eq(EventStatus.ON_SALE));
+    }
+
+    @Test
+    void changeEventStatus_serviceThrowsRuntime_returnsFailureWithMessage() {
+        doThrow(new RuntimeException("invalid transition"))
+                .when(eventService).changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE);
+
+        CompanyEventListPresenter.ActionOutcome.Failure fail =
+                assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Failure.class,
+                        presenter.changeEventStatus(TOKEN, EVENT_ID, EventStatus.ON_SALE));
+
+        assertEquals("invalid transition", fail.reason());
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private static ProductionCompanyDTO company(int id) {
+        return new ProductionCompanyDTO(id, "Company " + id, "desc", "ACTIVE", 1);
+    }
+
+    private static EventDetailDTO event(int id, String name) {
+        return new EventDetailDTO(String.valueOf(id), name, null, null, null, null,
+                String.valueOf(COMPANY_ID), "Company " + COMPANY_ID, EventStatus.SCHEDULED,
+                new ArrayList<>(), new ArrayList<>());
+    }
+}


### PR DESCRIPTION
feat(#417): My Events — cancel, status change, and delete event actions

## Summary
- **Wire cancel button**: the existing "Cancel event" icon now opens a confirmation dialog before calling `cancelEventAndRefund` (full refund pipeline + notifications); reloads the grid on success.
- **Status change action**: a new gear icon per row opens a dialog with a `Select` showing only domain-valid transitions for the event's current state — `DRAFT → Scheduled`, `SCHEDULED → On Sale`. Backed by a new `changeEventStatus(token, eventId, target)` service method that delegates to the appropriate domain transition and enforces `CONFIGURE_VENUE` permission.
- **Delete canceled events**: a trash icon appears exclusively on `CANCELED` rows. Clicking opens a confirm dialog that calls a new `deleteEvent(token, eventId)` service method, which validates permission and enforces the CANCELED-only guard before calling the new `IEventRepository.delete(int)` port (implemented in both Memory and JPA adapters).
- **`CompanyEventListPresenter`**: extended with `cancelEvent`, `changeEventStatus`, and `deleteEvent` — each returns a sealed `ActionOutcome` (Success / NotAuthenticated / Failure) the view switches on.

Closes #417

## Test plan
- [ ] Create an event → status shows `DRAFT` → gear icon → "Mark as Scheduled" option appears → confirm → status updates
- [ ] SCHEDULED event → gear icon → "Publish (On Sale)" → confirm → status updates
- [ ] ON_SALE event → gear icon → toast says no transitions available
- [ ] Cancel an event → confirm dialog appears → event transitions to `CANCELED`, refunds issued
- [ ] CANCELED event → trash icon appears → confirm → event removed from list
- [ ] Non-CANCELED event has no trash icon
- [ ] All 18 `CompanyEventListPresenterTest` tests pass
- [ ] Full suite: 1375 tests, 0 failures
