### PR TITLE
[V3-TX-01] Per-use-case @Transactional + optimistic-lock conflict translation

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
@@ -115,11 +116,13 @@ public class AuthenticationService {
     }
 
     /** Delegates to {@link ISessionManager#extractUserId}. */
+    @Transactional(readOnly = true)
     public int extractUserId(String token) {
         return sessionManager.extractUserId(token);
     }
 
     /** Delegates to {@link ISessionManager#validateToken}. */
+    @Transactional(readOnly = true)
     public boolean validateToken(String token) {
         return sessionManager.validateToken(token);
     }
@@ -132,6 +135,7 @@ public class AuthenticationService {
      * Mints a new Guest session. Entry point for any visitor before
      * register/login.
      */
+    @Transactional
     public GuestSessionDTO startGuestSession() {
         Instant now = clock.instant();
         Instant expiry = now.plus(guestIdleMinutes, ChronoUnit.MINUTES);
@@ -147,6 +151,7 @@ public class AuthenticationService {
      * input is a no-op. Attached cart cleanup is the sweeper's
      * responsibility (Phase 5).
      */
+    @Transactional
     public void endGuestSession(String sessionId) {
         if (sessionId == null || sessionId.isBlank())
             return;
@@ -184,6 +189,7 @@ public class AuthenticationService {
      *                                     </ul>
      *                                     >>>>>>> dev
      */
+    @Transactional
     public void register(RegisterRequestDTO request) {
         // 1. Cheap format validation first — bots / garbage fail before any IO.
         validateEmail(request.email());
@@ -260,6 +266,7 @@ public class AuthenticationService {
      *                                       sessionId
      * @throws AuthenticationFailedException invalid credentials
      */
+    @Transactional
     public LoginDTO login(LoginRequestDTO request) {
         // 1. Guest session must exist.
         Session session = requireActiveGuestSession(request.guestSessionId());
@@ -314,6 +321,7 @@ public class AuthenticationService {
      * — disjoint-pool rule), applies the shared lock-after-N policy, audit-logs every failure, and
      * issues an ADMIN-role JWT so the backend admin gate can authorize it.
      */
+    @Transactional(readOnly = true)
     public AuthTokenDTO signInAsAdmin(String username, String rawPassword) {
         String lockKey = lockoutKey("a", username);
 
@@ -453,6 +461,7 @@ public class AuthenticationService {
      * token is a no-op.
      * >>>>>>> dev
      */
+    @Transactional
     public void logout(LogoutRequestDTO request) {
         Optional<Integer> userIdOpt = sessionManager.tryExtractUserId(request.token());
         sessionManager.invalidate(request.token());

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -34,9 +34,11 @@ import com.ticketing.system.Core.Domain.events.IEventRepository;
 // Separated from EventManagementService (which is owner-side / write-heavy) so the two audiences
 // don't share an API surface — see design_walkthrough_summary.md §6.
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class CatalogService {
 
     private final ISessionManager sessionManager;

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyAnalyticsService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -34,6 +35,7 @@ import com.ticketing.system.Core.Domain.users.IUserRepository;
  */
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class CompanyAnalyticsService {
 
     private static final int WINDOW_DAYS = 30;

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -57,6 +57,7 @@ import com.ticketing.system.Core.Domain.policies.purchase.MinTicketsPurchasePoli
 import com.ticketing.system.Core.Domain.policies.purchase.MaxTicketsPurchasePolicy;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -83,6 +84,7 @@ public class CompanyManagementService {
     }
 
     // UC-23 — Owner appoints another Member as co-Owner (PENDING).
+    @Transactional
     public void appointOwner(String token, OwnerAppointmentRequestDTO request) {
         if (request.companyId() <= 0 || request.targetUserId() <= 0) {
             log.warn("Invalid appointment request: companyId and targetUserId must be positive integers");
@@ -121,6 +123,7 @@ public class CompanyManagementService {
     }
 
     // UC-24 — Owner appoints a Manager with explicit granular permissions.
+    @Transactional
     public void appointManager(String token, ManagerAppointmentRequestDTO request) {
         if (request.companyId() <= 0 || request.targetUserId() <= 0) {
             log.warn("Invalid manager appointment request: companyId and targetUserId must be positive integers");
@@ -149,6 +152,7 @@ public class CompanyManagementService {
 
     // UC-23 / UC-24 — target accepts or rejects a pending owner/manager
     // appointment.
+    @Transactional
     public void respondToAppointment(String token, AppointmentResponseDTO response) {
         if (response.companyId() <= 0) {
             log.warn("Invalid appointment response: companyId must be a positive integer");
@@ -188,6 +192,7 @@ public class CompanyManagementService {
     }
 
     // UC-24 — edit a Manager's permission set (only by the original appointer).
+    @Transactional
     public void editManagerPermissions(String token, PermissionEditDTO edit) {
         int ownerId = authenticate(token);
 
@@ -221,6 +226,7 @@ public class CompanyManagementService {
                 edit.companyId());
     }
 
+    @Transactional
     public void RevokeAppointment(String token, AppointmentRevokeDTO revokeRequest) {
         int ownerId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(revokeRequest.companyId());
@@ -250,6 +256,7 @@ public class CompanyManagementService {
     }
 
     // Resolves a username-or-email string to a userId — used by the invite flow.
+    @Transactional(readOnly = true)
     public int resolveUserId(String identifier) {
         if (identifier == null || identifier.isBlank())
             throw new IllegalArgumentException("Identifier must not be blank");
@@ -270,6 +277,7 @@ public class CompanyManagementService {
     // ---------------------------------------------------------------------------
 
     // II.4.7.1 — active managers of a company (owner-only view).
+    @Transactional(readOnly = true)
     public List<AppointmentInfoDTO> listManagers(String token, int companyId) {
         int requesterId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
@@ -296,6 +304,7 @@ public class CompanyManagementService {
     }
 
     // II.4.7.1 — pending invitations (manager + owner offers) awaiting acceptance.
+    @Transactional(readOnly = true)
     public List<AppointmentInfoDTO> listPendingInvitations(String token, int companyId) {
         int requesterId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
@@ -324,6 +333,7 @@ public class CompanyManagementService {
     // Bridges token -> companyId for the owner workspace until a real
     // current-company
     // selector lands (V2-CADMIN-05).
+    @Transactional(readOnly = true)
     public List<ProductionCompanyDTO> findOwnedCompanies(String token) {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
@@ -357,6 +367,7 @@ public class CompanyManagementService {
     // (V2-WIRE-OWNER-DASH);
     // unlike findOwnedCompanies it keeps managers, since /owner is reachable by
     // them too.
+    @Transactional(readOnly = true)
     public List<MyCompanyDTO> findMyCompanies(String token) {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
@@ -392,6 +403,7 @@ public class CompanyManagementService {
     // resolved ACTIVE/REJECTED/REVOKED rows (history). Names are resolved per row,
     // mirroring
     // listPendingInvitations.
+    @Transactional(readOnly = true)
     public List<InvitationDTO> listMyInvitations(String token) {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
@@ -433,6 +445,7 @@ public class CompanyManagementService {
 
     // UC-18 — register a new Production Company; appoints Founder/Owner in same
     // transaction.
+    @Transactional
     public ProductionCompanyDTO registerCompany(String token, CompanyRegistrationDTO request) {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
@@ -483,6 +496,7 @@ public class CompanyManagementService {
         }
     }
 
+    @Transactional
     public void setCompanyPolicies(String token, CompanyPolicyConfigDTO config) {
         if (config == null) {
             throw new IllegalArgumentException("Company policy config cannot be null");
@@ -507,6 +521,7 @@ public class CompanyManagementService {
     // for events of this company (the rest are filtered out). This way we return
     // the full receipt details for each relevant purchase, but only
     // include the tickets that are relevant to this company's sales history.
+    @Transactional(readOnly = true)
     public List<PurchaseHistoryDTO> viewSalesHistory(String token, int companyId) {
         log.info("Attempting to view sales history for company {}", companyId);
 
@@ -560,6 +575,7 @@ public class CompanyManagementService {
     }
 
     // UC-25 — recursive organizational tree (Owners only per II.4.15).
+    @Transactional(readOnly = true)
     public OrganizationalTreeNodeDTO viewOrganizationalTree(String token, int companyId) {
         log.info("Attempting to view organizational tree for company {}", companyId);
 
@@ -634,6 +650,7 @@ public class CompanyManagementService {
         return userIdToNodeMap.get(founderId);
     }
 
+    @Transactional(readOnly = true)
     public List<UserCompanyDTO> listForUser(int userId) {
         User user = userRepository.getUserById(userId);
         if (user == null) {
@@ -656,6 +673,7 @@ public class CompanyManagementService {
         return memberships;
     }
 
+    @Transactional(readOnly = true)
     public boolean isOwnerOf(int userId, int companyId) {
         User user = userRepository.getUserById(userId);
         if (user == null) {
@@ -748,6 +766,7 @@ public class CompanyManagementService {
         }
     }
 
+    @Transactional(readOnly = true)
     public PurchasePolicyDTO getCompanyPurchasePolicy(String token, int companyId) {
         int userId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 // Owner / Manager-side write service for the Event aggregate and its lifecycle.
 // UC-19 (Manage Event Catalog), UC-20 (Configure Venue Map & Inventory), UC-21 (Configure Policies).
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Domain.exceptions.CompanyNotFoundException;
@@ -114,6 +115,7 @@ public class EventManagementService {
     // a second step.
 
     // UC-19 — Owner adds an Event in DRAFT state.
+    @Transactional
     public EventDetailDTO addEvent(String token, EventCreationDTO request) {
         int ownerId = validateTokenAndGetUserId(token);
 
@@ -168,6 +170,7 @@ public class EventManagementService {
     }
 
     // II.4.1.1 — Owner lists all events under their company.
+    @Transactional(readOnly = true)
     public List<EventDetailDTO> listEventsForCompany(String token, int companyId) {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
@@ -189,6 +192,7 @@ public class EventManagementService {
             .toList();
     }
 
+    @Transactional(readOnly = true)
     public EventDetailDTO getEvent(String token, int eventId) {
         int userId = validateTokenAndGetUserId(token);
         Event event = eventRepository.findById(eventId);
@@ -226,6 +230,7 @@ public class EventManagementService {
 
     // II.4.2.3 — Read back the current zone states from the domain so the
     // editor reflects real-time inventory (capacity consumed by sales, etc.).
+    @Transactional(readOnly = true)
     public VenueLayoutDTO getEventZones(String token, int eventId) {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
@@ -283,6 +288,7 @@ public class EventManagementService {
     // It also allows for a more iterative setup process where the owner/manager can
     // first create the event with basic details and then configure the venue map in
     // a second step.
+    @Transactional
     public void configureVenueMap(String token, int companyId, VenueMapConfigDTO config) {
         int eventId = Integer.parseInt(config.eventId());
 
@@ -360,6 +366,7 @@ public class EventManagementService {
 
     // UC-19 — partial update; immutability rules enforced inside
     // Event.editDetails().
+    @Transactional
     public void editEventDetails(String token, EventUpdateDTO update) {
         int userId = validateTokenAndGetUserId(token);
 
@@ -405,6 +412,7 @@ public class EventManagementService {
         }
     }
 
+    @Transactional
     public int addInventoryZone(String token, int companyId, int eventId, VenueMapConfigDTO.ZoneConfigDTO zoneConfig) {
 
         eventRepository.lockForUpdate(eventId);
@@ -453,6 +461,7 @@ public class EventManagementService {
         }
     }
 
+    @Transactional
     public void removeInventoryZone(String token, int companyId, int eventId, int zoneId) {
 
         eventRepository.lockForUpdate(eventId);
@@ -474,6 +483,7 @@ public class EventManagementService {
 
     // addPlacesToStandingZone is a helper function that allows the owner/manager to
     // add more places to a standing zone.
+    @Transactional
     public void addPlacesToStandingZone(String token, int companyId, int eventId, int zoneId, int placesToAdd) {
         eventRepository.lockForUpdate(eventId);
 
@@ -490,6 +500,7 @@ public class EventManagementService {
 
     // removePlacesFromStandingZone is a helper function that allows the
     // owner/manager to remove a specified number of places from a standing zone.
+    @Transactional
     public void removePlacesFromStandingZone(String token, int companyId, int eventId, int zoneId, int placesToRemove) {
         eventRepository.lockForUpdate(eventId);
 
@@ -506,6 +517,7 @@ public class EventManagementService {
 
     // addSeatsToSeatedZone is a helper function that allows the owner/manager to
     // add specific seats to a seated zone.
+    @Transactional
     public void addSeatsToSeatedZone(
             String token,
             int companyId,
@@ -528,6 +540,7 @@ public class EventManagementService {
 
     // removeSeatsFromSeatedZone is a helper function that allows the owner/manager
     // to remove specific seats from a seated zone.
+    @Transactional
     public void removeSeatsFromSeatedZone(
             String token,
             int companyId,
@@ -550,6 +563,7 @@ public class EventManagementService {
 
     // addSeatRowToSeatedZone is a helper function that allows the owner/manager to
     // add an entire row of seats to a seated zone.
+    @Transactional
     public void addSeatRowToSeatedZone(
             String token,
             int companyId,
@@ -591,6 +605,7 @@ public class EventManagementService {
     // based on the existing seat layout in the zone.
     // * This ensures that all seats in the specified row are removed consistently.
     // */
+    @Transactional
     public void removeSeatRowFromSeatedZone(
             String token,
             int companyId,
@@ -695,6 +710,7 @@ public class EventManagementService {
     }
 
     // Detail view for owner-side editing pages.
+    @Transactional(readOnly = true)
     public EventDetailDTO getEventDetail(String token, int eventId) {
         int userId = validateTokenAndGetUserId(token);
 
@@ -712,6 +728,7 @@ public class EventManagementService {
     // The actual transition (and its venue-map/show-date/invariant guards) lives in
     // Event.transitionToOnSale(); this method enforces auth, ownership, and
     // locking.
+    @Transactional
     public void publishEvent(String token, int companyId, int eventId) {
         int userId = validateTokenAndGetUserId(token);
 
@@ -737,6 +754,8 @@ public class EventManagementService {
 
     // UC-19 — soft cancel; fires EventCancelled domain event for UC-4 refund
     // pipeline.
+    // Intentionally NOT @Transactional: this calls the external payment gateway (refund) mid-flow,
+    // so its transaction boundary is restructured separately (externals outside the tx) in V3-TX-02.
     public void cancelEventAndRefund(String token, int eventId) {
         int ownerId = validateTokenAndGetUserId(token);
         // We lock the event for update to prevent concurrent modifications during the
@@ -902,6 +921,7 @@ public class EventManagementService {
     // to the event's purchase policy while we're updating it. This ensures that we
     // have a consistent view of the event's state and that we don't accidentally
     // overwrite changes made by another user at the same time.
+    @Transactional
     public void setEventPolicies(String token, EventPolicyConfigDTO config) {
         if (!sessionManager.validateToken(token)) {
             throw new RuntimeException("Invalid token");
@@ -1037,6 +1057,7 @@ public class EventManagementService {
         return sessionManager.extractUserId(token);
     }
 
+    @Transactional(readOnly = true)
     public PurchasePolicyDTO getEventPurchasePolicy(String token, int companyId, int eventId) {
         if (!sessionManager.validateToken(token))
             throw new RuntimeException("Invalid token");

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberAccountService.java
@@ -23,9 +23,11 @@ import lombok.extern.slf4j.Slf4j;
 // Separated from AuthenticationService (which is auth-flow only) so personal-data reads don't
 // stretch the auth boundary — see design_walkthrough_summary.md §6.
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class MemberAccountService {
 
     private final AuthenticationService authenticationService; // For user identity verification, if needed for future methods.

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberQueryService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberQueryService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.ticketing.system.Core.Application.dto.MemberSearchResultDTO;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Read-only queries on the User aggregate that the presentation layer
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
  * surface stays focused.
  */
 @Service
+@Transactional(readOnly = true)
 public class MemberQueryService {
 
     private final IUserRepository userRepository;

--- a/src/main/java/com/ticketing/system/Core/Application/services/MessagingService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MessagingService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.dto.ComplaintFilterDTO;
 import com.ticketing.system.Core.Application.dto.ConversationDTO;
@@ -86,6 +87,7 @@ public class MessagingService {
     // ---------------------------------------------------------------------------
 
     // II.3.10 — Member starts an INQUIRY conversation (two-way chat) with a Company.
+    @Transactional
     public ConversationDTO startConversation(String token, StartConversationRequestDTO request) {
         int memberId = authenticate(token);
         int companyId = request.counterpartyId();
@@ -108,6 +110,7 @@ public class MessagingService {
 
 
     // Append a reply to an existing conversation. Sender must be a participant.
+    @Transactional
     public void sendMessage(String token, SendMessageRequestDTO request) {
         Caller caller = authenticateCaller(token);
         String conversationId = request.conversationId();
@@ -138,6 +141,7 @@ public class MessagingService {
 
 
     // II.3.3 — Member submits a COMPLAINT (counterparty = ADMIN_GROUP).
+    @Transactional
     public ConversationDTO submitComplaint(String token, SubmitComplaintRequestDTO request) {
         int memberId = authenticate(token);
         String body = request.body();
@@ -160,6 +164,7 @@ public class MessagingService {
 
 
     // II.6.3.1 — admin sends the single response to a complaint, which resolves it (one-shot).
+    @Transactional
     public void respondToComplaint(String token, RespondToComplaintRequestDTO request) {
         int adminId = requireSystemAdmin(token);
         String conversationId = request.conversationId();
@@ -190,6 +195,7 @@ public class MessagingService {
     // II.6.3.2 — admin proactive messaging. Resolves the recipient set (explicit members, and/or
     // all members, and/or all producers' owner accounts), then opens one two-way DIRECT
     // conversation per recipient so each lands in that member's Support Inbox as a chat.
+    @Transactional
     public OutreachResultDTO sendOutreach(String token, OutreachRequestDTO request) {
         int adminId = requireSystemAdmin(token);
 
@@ -236,6 +242,7 @@ public class MessagingService {
 
 
     // UI action — mark a single message as read by the viewer.
+    @Transactional
     public void markMessageAsRead(String token, String conversationId, String messageId) {
         Caller caller = authenticateCaller(token);
         conversationRepository.lockForUpdate(conversationId);
@@ -252,6 +259,7 @@ public class MessagingService {
 
 
     // Terminal action — close a conversation (no further messages allowed).
+    @Transactional
     public void closeConversation(String token, String conversationId) {
         Caller caller = authenticateCaller(token);
         conversationRepository.lockForUpdate(conversationId);
@@ -270,6 +278,7 @@ public class MessagingService {
     // ---------------------------------------------------------------------------
 
     // Member-facing Support Inbox: inquiries + complaints the member opened, plus admin outreach.
+    @Transactional(readOnly = true)
     public List<ConversationDTO> viewMyConversations(String token) {
         int memberId = authenticate(token);
         return conversationRepository.findMemberInbox(memberId).stream()
@@ -279,6 +288,7 @@ public class MessagingService {
     }
 
     // Open a single thread. Caller must be a participant.
+    @Transactional(readOnly = true)
     public ConversationDTO viewConversation(String token, String conversationId) {
         Caller caller = authenticateCaller(token);
         Conversation conversation = loadConversation(conversationId);
@@ -287,6 +297,7 @@ public class MessagingService {
     }
 
     // II.4.4 — company support inbox: all conversations where this company is counterparty.
+    @Transactional(readOnly = true)
     public List<ConversationDTO> viewCompanyInbox(String token, int companyId) {
         int callerId = authenticate(token);
         if (!callerActsForCompany(callerId, companyId)) {
@@ -300,6 +311,7 @@ public class MessagingService {
     }
 
     // II.6.3.1 — admin queue of complaints with filters.
+    @Transactional(readOnly = true)
     public List<ConversationDTO> viewAllComplaints(String token, ComplaintFilterDTO filters) {
         int adminId = requireSystemAdmin(token);
         ConversationStatus status = parseStatusOrNull(filters == null ? null : filters.status());
@@ -316,6 +328,7 @@ public class MessagingService {
 
     // II.6.3.2 — admin "sent history": every DIRECT conversation the admin initiated.
     // The fan-out creates one conversation per recipient; callers group them into broadcasts.
+    @Transactional(readOnly = true)
     public List<ConversationDTO> viewSentOutreach(String token) {
         int adminId = requireSystemAdmin(token);
         return conversationRepository.findByTypeAndInitiatorType(ConversationType.DIRECT, ParticipantType.ADMIN).stream()
@@ -327,6 +340,7 @@ public class MessagingService {
     // Admin Inbox — the calling admin's own DIRECT conversations (outreach they started), newest
     // first, so they can chat and close each one. Scoped to this admin (findByParticipant is an
     // exact id/type match), so it never includes another admin's outreach or complaints.
+    @Transactional(readOnly = true)
     public List<ConversationDTO> viewAdminInbox(String token) {
         int adminId = requireSystemAdmin(token);
         return conversationRepository.findByParticipant(adminId, ParticipantType.ADMIN).stream()

--- a/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/ReservationService.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
 import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
@@ -70,21 +71,25 @@ public class ReservationService {
     // Public API - use these methods from new code/controllers/tests
     // ---------------------------------------------------------------------
 
+    @Transactional
     public ReservationResultDTO reserveForMember(String token, int eventId, int zoneId,
             InventorySelectionDTO selectionDto) {
         return reserve(authenticateMember(token), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
+    @Transactional
     public ReservationResultDTO reserveForGuest(String sessionId, int eventId, int zoneId,
             InventorySelectionDTO selectionDto) {
         return reserve(authenticateGuest(sessionId), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
+    @Transactional
     public ReservationResultDTO removeForMember(String token, int eventId, int zoneId,
             InventorySelectionDTO selectionDto) {
         return remove(authenticateMember(token), eventId, zoneId, toDomainSelection(selectionDto));
     }
 
+    @Transactional
     public ReservationResultDTO removeForGuest(String sessionId, int eventId, int zoneId,
             InventorySelectionDTO selectionDto) {
         return remove(authenticateGuest(sessionId), eventId, zoneId, toDomainSelection(selectionDto));
@@ -676,6 +681,7 @@ public class ReservationService {
     }
 
     // method to restore an active order for a user (member) - this is used by the frontend when a user logs in or returns to the site after navigating away, to restore their active order and show them their current reservations in the cart. For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we convert it to an ActiveOrderDTO and return it. If no active order is found, we return null. We also enrich the DTO with event names for better UX in the frontend, so that the frontend can show the event names directly in the cart without needing to make extra calls to get event details for each line item.
+    @Transactional(readOnly = true)
     public ActiveOrderDTO restoreActiveOrder(int userId) {
         ActiveOrder activeOrder = activeOrderRepository.getByUserId(userId);
         if (activeOrder == null) {
@@ -707,6 +713,7 @@ public class ReservationService {
                 enrichedLines);
     }
 
+    @Transactional(readOnly = true)
     public ActiveOrderDTO restoreActiveOrderForGuest(String sessionId) {
         return activeOrderRepository.getBySessionId(sessionId)
                 .map(order -> {
@@ -736,6 +743,7 @@ public class ReservationService {
     // leave it untouched so the existing expiry/sweeper path can reject the stale cart. The
     // reset runs under the per-order lock (the same lock the expiry sweeper acquires first),
     // so it cannot race the sweeper. The enriched DTO is built by reusing restoreActiveOrder.
+    @Transactional
     public ActiveOrderDTO renewReservationsForMemberCheckout(int userId) {
         String orderLockKey = "user:" + userId;
         activeOrderRepository.lockForUpdate(orderLockKey);
@@ -753,6 +761,7 @@ public class ReservationService {
         return restoreActiveOrder(userId);
     }
 
+    @Transactional
     public ActiveOrderDTO renewReservationsForGuestCheckout(String sessionId) {
         String orderLockKey = "sess:" + sessionId;
         activeOrderRepository.lockForUpdate(orderLockKey);
@@ -771,6 +780,7 @@ public class ReservationService {
     }
 
     // Helper method to abandon the active order for a user (member or guest) - this is used by the frontend when a user explicitly clicks "Abandon Cart" or when they log out, to clear their active order and release any reserved inventory back to the events. For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we release any reserved inventory back to the events and then delete the active order. If no active order is found, we simply return without doing anything. This ensures that we do not leave any reserved inventory hanging around for abandoned carts, which keeps our inventory accurate and allows other users to purchase those tickets if they are still available.
+    @Transactional
     public void abandonActiveOrder(BuyerContextDTO buyer) {
         if (buyer == null) {
             throw new IllegalArgumentException("Buyer context is required");
@@ -874,6 +884,7 @@ public class ReservationService {
     * Removes a line from the cart, automatically determining whether the user is a Member or Guest.
     * The UI just calls this method, no need to handle InventorySelectionDTO or user type.
     */
+    @Transactional
     public ReservationResultDTO removeLine(String userTokenOrSessionId, int eventId, int zoneId,
             InventorySelectionDTO selection) {
 
@@ -910,6 +921,7 @@ public class ReservationService {
     }
 
     // Helper method to view the current active order for a user (member or guest). For members, we look up the active order by their user ID. For guests, we look up the active order by their session ID. If an active order is found, we convert it to an ActiveOrderDTO and return it. If no active order is found, we return null. This allows the frontend to show the user their current reservations in the cart when they navigate to the cart page, etc.
+    @Transactional(readOnly = true)
     public ActiveOrderDTO viewMyActiveOrder(String userOrSessionId) {
         if (userOrSessionId == null || userOrSessionId.isBlank()) {
             return null;

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 // UC-1 (Initialize), UC-31 (Global History), UC-32 (Open/Close Market).
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -301,6 +302,7 @@ public class SystemAdminService {
 
     // UC-31 — global purchase history with filters (admin-only RBAC enforced inside).
     // this function filters by buyer, production company, or specific event, and by date range. All filters are optional and can be combined.
+    @Transactional(readOnly = true)
     public List<PurchaseHistoryDTO> viewGlobalHistory(String token, GlobalHistoryFiltersDTO filters) {
         log.info("Admin request to view global purchase history with filters: {}", filters);
         requireSystemAdmin(token);

--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAnalyticsService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.dto.AdminOverviewDTO;
 import com.ticketing.system.Core.Application.dto.GlobalHistoryFiltersDTO;
@@ -35,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Service
 @Slf4j
+@Transactional(readOnly = true)
 public class SystemAnalyticsService {
 
     private static final int THROUGHPUT_WINDOW_MINUTES = 60;

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OptimisticLockTranslationAspect.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OptimisticLockTranslationAspect.java
@@ -1,0 +1,59 @@
+package com.ticketing.system.Infrastructure.persistence;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Domain.exceptions.ConcurrentReservationException;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Translates a JPA optimistic-lock conflict into the domain's {@link ConcurrentReservationException}.
+ *
+ * <p>Under the {@code jpa} profile, concurrency is enforced by {@code @Version} optimistic locking:
+ * when two transactions write the same aggregate, the loser's commit fails and Spring raises an
+ * {@link OptimisticLockingFailureException}. That is an infrastructure exception; left unhandled it
+ * would leak past the application layer to the UI. This aspect re-types it into the domain's
+ * designated concurrency exception so the conflict surfaces as a typed "please retry" failure that
+ * presenters already map to a clean outcome (their {@code catch (RuntimeException)} boundary).
+ *
+ * <p>Ordered {@link Ordered#HIGHEST_PRECEDENCE} so it wraps the {@code @Transactional} advice
+ * (whose interceptor sits at {@link Ordered#LOWEST_PRECEDENCE}). The {@code @Version} conflict is
+ * thrown at <em>commit</em> — as the transaction interceptor unwinds, after the service method body
+ * has already returned — so only an outer aspect can observe and translate it.
+ *
+ * <p>This aspect <strong>only re-types</strong> the exception; it never re-invokes the method, so it
+ * is safe for operations with non-DB side effects (e.g. notification dispatch). Bounded auto-retry of
+ * the safe pure-DB paths, and the concurrency proof that exercises it, are tracked separately
+ * (V3-TX-03).
+ */
+@Aspect
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@Slf4j
+public class OptimisticLockTranslationAspect {
+
+    /** Every public application-service method — the same surface {@code LoggingAspect} traces. */
+    @Pointcut("execution(public * com.ticketing.system.Core.Application.services..*(..))")
+    public void applicationService() {
+    }
+
+    @Around("applicationService()")
+    public Object translateOptimisticLock(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            return joinPoint.proceed();
+        } catch (OptimisticLockingFailureException conflict) {
+            String signature = joinPoint.getSignature().toShortString();
+            log.warn("Concurrent modification on {} — translating to a retryable conflict", signature);
+            throw new ConcurrentReservationException(
+                    "Concurrent modification detected while running " + signature + " — please retry",
+                    conflict);
+        }
+    }
+}

--- a/src/test/java/com/ticketing/system/Core/Application/services/OptimisticLockTranslationAspectTest.java
+++ b/src/test/java/com/ticketing/system/Core/Application/services/OptimisticLockTranslationAspectTest.java
@@ -1,0 +1,76 @@
+package com.ticketing.system.Core.Application.services;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.annotation.AspectJProxyFactory;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import com.ticketing.system.Core.Domain.exceptions.ConcurrentReservationException;
+import com.ticketing.system.Infrastructure.persistence.OptimisticLockTranslationAspect;
+
+/**
+ * Unit test for {@link OptimisticLockTranslationAspect}.
+ *
+ * <p>The aspect advises {@code execution(... Core.Application.services..*(..))}, so the stand-in
+ * service it wraps must live in that package — which is why this test sits here rather than under the
+ * usual {@code unit/} tree. {@link AspectJProxyFactory} weaves the aspect around a plain target with
+ * no Spring context, keeping the test fast and focused purely on the advice's behaviour.
+ */
+class OptimisticLockTranslationAspectTest {
+
+    /** Minimal stand-in for a real application service — same package, so the pointcut advises it. */
+    static class FakeService {
+        Object result = "ok";
+        RuntimeException toThrow;
+
+        public Object run() {
+            if (toThrow != null) {
+                throw toThrow;
+            }
+            return result;
+        }
+    }
+
+    private static FakeService advised(FakeService target) {
+        AspectJProxyFactory factory = new AspectJProxyFactory(target);
+        factory.addAspect(new OptimisticLockTranslationAspect());
+        return factory.getProxy();
+    }
+
+    @Test
+    void translatesOptimisticLockFailureIntoConcurrentReservationException() {
+        FakeService target = new FakeService();
+        OptimisticLockingFailureException conflict = new OptimisticLockingFailureException("version mismatch");
+        target.toThrow = conflict;
+
+        FakeService proxy = advised(target);
+
+        ConcurrentReservationException thrown =
+                assertThrows(ConcurrentReservationException.class, proxy::run);
+        assertSame(conflict, thrown.getCause(), "the original failure must be preserved as the cause");
+    }
+
+    @Test
+    void passesSuccessfulResultsThroughUnchanged() {
+        FakeService target = new FakeService();
+        target.result = "done";
+
+        FakeService proxy = advised(target);
+
+        assertEquals("done", proxy.run());
+    }
+
+    @Test
+    void leavesNonConflictExceptionsUntouched() {
+        FakeService target = new FakeService();
+        IllegalStateException unrelated = new IllegalStateException("not a conflict");
+        target.toThrow = unrelated;
+
+        FakeService proxy = advised(target);
+
+        assertSame(unrelated, assertThrows(IllegalStateException.class, proxy::run));
+    }
+}


### PR DESCRIPTION
Closes #359 (V3-TX-01) — its **core**. Adds the per-use-case transaction layer and an optimistic-lock conflict translator. The external-call boundary and the lock-retirement/auto-retry are deliberately split to #360 / #361 (the V3 plan's C1/C2/C3 split) and tracked there — see **Deferred** below.

## What this does
- `@Transactional` on every pure-DB use-case **write** method and `@Transactional(readOnly = true)` on **read** methods across the application services — **40 write + 46 read** (all 113 public service methods were audited and classified).
  - Class-level `readOnly` on the pure-query services (Catalog, MemberQuery, System/Company analytics, MemberAccount); method-level on the mixed services.
- `OptimisticLockTranslationAspect` — an outermost aspect that re-types Spring's `OptimisticLockingFailureException` (raised at commit when a `@Version` check fails) into the domain's `ConcurrentReservationException`, so a concurrent-write conflict surfaces as a clean retryable failure rather than leaking an infrastructure exception to the UI. Unit-tested with `AspectJProxyFactory`.

## Runtime / profiles
- The run-profile flip was already in place from Lane B: `dev`→`jpa`, deploy→`jpa`, `test`→Memory. Under `jpa` the repo `lockForUpdate`/`unlock` are already **no-ops**, so the running app is already on `@Version` optimistic locking; this PR makes each use-case a single DB transaction on top of that.

## Verification
- Full suite green: **1360 tests, 0 failures, 0 errors** (`./mvnw -o -Pno-vaadin test`).
- Audit of every public service method: 40 write / 46 read / 27 deliberately unannotated (each with a documented reason).

## Deferred (tracked, not lost)
- **→ #360 (V3-TX-02):** `@Transactional` for the external-call write paths — `CheckoutService.checkout*`, `RefundService.requestRefund`, `EventManagementService.cancelEventAndRefund` — to be done there with the WSEP call **outside** the transaction. Also: once every writer is service-wrapped, remove the now-redundant repo-level `@Transactional` on `Jpa*Repository.save/update/delete` (a stopgap from before the service layer had transactions).
- **→ #361 (V3-TX-03):** delete the (already-inert-under-`jpa`) `lockForUpdate`/`unlock` call-sites, add bounded auto-retry on `OptimisticLockException`, and the no-double-sell concurrency test that proves it.
- `SystemAdminService.initializePlatform` is intentionally **not** wrapped (boot-time `verifyConnection` probe + self-invoked single admin write, already atomic at the repo level).

Part of #347.
