### PR TITLE
[#410] Serialize refunds with a pessimistic row-lock (no double-refund under jpa)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/RefundService.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
@@ -49,18 +51,24 @@ public class RefundService {
     private final ITicketRepository ticketRepository;
     private final IPaymentGateway paymentGateway;
     private final IEventRepository eventRepository;
+    // Programmatic transaction for the refund critical section: it must hold a real row lock on the
+    // receipt (SELECT … FOR UPDATE) across the eligibility check + gateway refund + receipt flip so a
+    // double-click can't refund twice (#410). The gateway-first call runs inside it by design.
+    private final TransactionTemplate transactionTemplate;
 
     public RefundService(
             AuthenticationService authenticationService,
             IOrderReceiptRepository orderReceiptRepository,
             ITicketRepository ticketRepository,
             IPaymentGateway paymentGateway,
-            IEventRepository eventRepository) {
+            IEventRepository eventRepository,
+            PlatformTransactionManager transactionManager) {
         this.authenticationService = authenticationService;
         this.orderReceiptRepository = orderReceiptRepository;
         this.ticketRepository = ticketRepository;
         this.paymentGateway = paymentGateway;
         this.eventRepository = eventRepository;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
     /**
@@ -81,44 +89,48 @@ public class RefundService {
         }
         int userId = authenticationService.extractUserId(token);
 
-        RefundResultDTO refundResult;
-        // Serialize the eligibility check + gateway refund + receipt flip per receipt under the receipt
-        // lock. Without it, two concurrent requests (double-click / retry) could both pass wasRefunded()
-        // and both call paymentGateway.refund() — refunding the buyer twice. Fetching inside the lock
-        // means the loser sees isRefunded=true (happens-before via the same lock) and bails.
-        orderReceiptRepository.lockForUpdate(orderId);
-        try {
-            OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(orderId)
-                    .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", orderId));
+        // Serialize the eligibility check + gateway refund + receipt flip in ONE transaction holding a
+        // row lock on the receipt. orderReceiptRepository.lockForUpdate takes a real SELECT … FOR UPDATE
+        // under jpa (and a real lock under the in-memory repo), held until this transaction commits.
+        // Without it, two concurrent requests (double-click / retry) could both pass wasRefunded() and
+        // both call paymentGateway.refund() — refunding the buyer twice (#410). The loser blocks on the
+        // lock, then sees isRefunded=true and bails before any second gateway call. The slow WSEP refund
+        // runs inside this section by design (gateway-first: never mark refunded while the gateway
+        // disagrees); refunds are low-frequency, so holding the row lock across it is acceptable.
+        RefundResultDTO refundResult = transactionTemplate.execute(status -> {
+            orderReceiptRepository.lockForUpdate(orderId);
+            try {
+                OrderReceipt receipt = orderReceiptRepository.findByOrderReceiptId(orderId)
+                        .orElseThrow(() -> new EntityNotFoundException("OrderReceipt", orderId));
 
-            Integer holderUserId = receipt.getHolderUserId();
-            if (holderUserId == null || holderUserId != userId) {
-                throw new UnauthorizedActionException("refund order " + orderId, userId);
+                Integer holderUserId = receipt.getHolderUserId();
+                if (holderUserId == null || holderUserId != userId) {
+                    throw new UnauthorizedActionException("refund order " + orderId, userId);
+                }
+
+                if (receipt.wasRefunded()) {
+                    throw new BusinessRuleViolationException("Order " + orderId + " has already been refunded");
+                }
+
+                double refundAmount = receipt.getTotalAmount();
+                int paymentTransactionId = receipt.getPaymentTransactionId()
+                        .orElseThrow(() -> new RefundFailedException(orderId, "receipt does not contain a payment transaction"));
+
+                RefundResultDTO result = paymentGateway.refund(paymentTransactionId, refundAmount);
+                validateRefundResult(orderId, refundAmount, result);
+
+                receipt.markRefunded(TransactionRecord.refund(
+                        result.refundTransactionId(),
+                        paymentGateway.getId(),
+                        result.totalRefunded(),
+                        receipt.getPaymentCurrency(),
+                        result.refundedAt()));
+                orderReceiptRepository.save(receipt);
+                return result;
+            } finally {
+                orderReceiptRepository.unlock(orderId);
             }
-
-            if (receipt.wasRefunded()) {
-                throw new BusinessRuleViolationException("Order " + orderId + " has already been refunded");
-            }
-
-            double refundAmount = receipt.getTotalAmount();
-            // Charge the gateway BEFORE touching domain state — we never want a receipt marked refunded
-            // while the gateway disagrees.
-            int paymentTransactionId = receipt.getPaymentTransactionId()
-                    .orElseThrow(() -> new RefundFailedException(orderId, "receipt does not contain a payment transaction"));
-
-            refundResult = paymentGateway.refund(paymentTransactionId, refundAmount);
-            validateRefundResult(orderId, refundAmount, refundResult);
-
-            receipt.markRefunded(TransactionRecord.refund(
-                    refundResult.refundTransactionId(),
-                    paymentGateway.getId(),
-                    refundResult.totalRefunded(),
-                    receipt.getPaymentCurrency(),
-                    refundResult.refundedAt()));
-            orderReceiptRepository.save(receipt);
-        } finally {
-            orderReceiptRepository.unlock(orderId);
-        }
+        });
 
         // The money refund + receipt flip have committed under the lock; the remaining ticket flips and
         // inventory return run outside it (best-effort, idempotent-by-state). A second concurrent request

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/JpaOrderReceiptRepository.java
@@ -22,7 +22,8 @@ import jakarta.persistence.criteria.Predicate;
  * layer depends only on {@code IOrderReceiptRepository}, never on Spring Data. Owned receipt-line and
  * transaction value lists ({@code @ElementCollection}) persist by cascade with the receipt.
  *
- * <p>{@code lockForUpdate}/{@code unlock} are no-ops (concurrency via {@code @Version}). {@code save}
+ * <p>{@code lockForUpdate} issues a real {@code SELECT … FOR UPDATE} (the refund critical section's row
+ * lock, #410); {@code unlock} is a no-op because the lock releases at transaction commit. {@code save}
  * delegates to {@code data.save} under {@code @Version} and is {@code @Transactional}. {@link #nextId()}
  * keeps the assigned-id design but seeds an in-memory counter from {@code max(receiptId)} on first use
  * so ids survive a restart. {@link #findGlobal} assembles the optional admin filters into a dynamic
@@ -42,10 +43,18 @@ public class JpaOrderReceiptRepository implements IOrderReceiptRepository {
     }
 
     @Override
-    public void lockForUpdate(Integer id) { /* no-op — @Version optimistic locking */ }
+    public void lockForUpdate(Integer id) {
+        // Real pessimistic row-lock (SELECT … FOR UPDATE) on the receipt — serialises the refund
+        // critical section (#410). Requires an active transaction (RefundService wraps it in one); the
+        // lock is held until that transaction commits, so a concurrent refund of the same receipt blocks
+        // here, then sees is_refunded=true and bails before a second gateway.refund(). Other writes use
+        // optimistic @Version, but @Version can't prevent the double gateway call (it fails only at
+        // commit, after the gateway was already hit), so this one path is pessimistic.
+        data.findByIdForUpdate(id);
+    }
 
     @Override
-    public void unlock(Integer id) { /* no-op */ }
+    public void unlock(Integer id) { /* no-op — the pessimistic lock releases at transaction commit */ }
 
     @Override
     public int nextId() {

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/SpringDataOrderReceiptRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/OrderReceiptPersistence/SpringDataOrderReceiptRepository.java
@@ -1,13 +1,17 @@
 package com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+
+import jakarta.persistence.LockModeType;
 
 /**
  * Spring Data JPA repository for {@link OrderReceipt} — the auto-implemented SQL backing
@@ -23,6 +27,15 @@ public interface SpringDataOrderReceiptRepository
 
     /** Member receipts for a buyer (guest receipts have a null userid, so they are excluded). */
     List<OrderReceipt> findByUserid(int userid);
+
+    /**
+     * Pessimistic-write fetch (SELECT … FOR UPDATE) of a receipt by id — backs the refund critical
+     * section's row lock (#410). The lock is held until the surrounding transaction commits, so
+     * concurrent refunds of the same receipt serialise and only one reaches {@code paymentGateway.refund()}.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select r from OrderReceipt r where r.receiptId = :id")
+    Optional<OrderReceipt> findByIdForUpdate(@Param("id") int id);
 
     @Query("select distinct r from OrderReceipt r join r.receiptLines l where l.eventid = :eventId")
     List<OrderReceipt> findByEventId(@Param("eventId") int eventId);

--- a/src/test/java/com/ticketing/system/concurrency/RefundConcurrencyTest.java
+++ b/src/test/java/com/ticketing/system/concurrency/RefundConcurrencyTest.java
@@ -1,0 +1,142 @@
+package com.ticketing.system.concurrency;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.ticketing.system.Core.Application.dto.RefundResultDTO;
+import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
+import com.ticketing.system.Core.Application.services.RefundService;
+import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+import com.ticketing.system.Core.Domain.orders.ReceiptLine;
+import com.ticketing.system.Core.Domain.orders.TransactionRecord;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.SpringDataOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.security.JwtSessionManager;
+
+/**
+ * No-double-refund concurrency proof (#410), run on the real JPA stack.
+ *
+ * <p>Under jpa the receipt's {@code lockForUpdate} used to be a no-op, so two concurrent refund
+ * requests for the same receipt could both pass {@code wasRefunded()} and both call
+ * {@code paymentGateway.refund()} — refunding the buyer twice ({@code @Version} only fails the second
+ * SAVE, <em>after</em> the gateway was already hit). This test fires N refunds at the same receipt
+ * simultaneously and asserts the gateway is called <strong>exactly once</strong>, proving the real
+ * {@code SELECT … FOR UPDATE} row lock serialises the critical section so every loser sees
+ * {@code is_refunded=true} and bails before any second gateway call.
+ *
+ * <p>Profiles {@code jpa,test}: JPA repositories + H2. The gateway is mocked so {@code refund()} calls
+ * can be counted; the platform-init runner that would probe it is {@code @Profile("!test")}, so it
+ * stays off and the unstubbed mock is harmless at startup.
+ */
+@SpringBootTest
+@ActiveProfiles({"jpa", "test"})
+class RefundConcurrencyTest {
+
+    private static final int CONCURRENT_REQUESTS = 6;
+    private static final int RECEIPT_ID = 7;
+    private static final int BUYER_ID = 42;
+    private static final int PAYMENT_TX = 5000;
+    private static final double TOTAL = 100.0;
+    private static final LocalDateTime WHEN = LocalDateTime.of(2026, 6, 1, 12, 0);
+
+    @Autowired
+    private RefundService refundService;
+    @Autowired
+    private IOrderReceiptRepository orderReceiptRepository;
+    @Autowired
+    private JwtSessionManager jwtSessionManager;
+    @Autowired
+    private SpringDataOrderReceiptRepository receiptData;
+
+    @MockitoBean
+    private IPaymentGateway paymentGateway;
+
+    private String buyerToken;
+
+    @BeforeEach
+    void setUp() {
+        receiptData.deleteAll();
+
+        // Mocked gateway: refund returns a valid result (totalRefunded == requested amount) so
+        // validateRefundResult passes; getId is non-null for the refund TransactionRecord.
+        when(paymentGateway.getId()).thenReturn("test-gateway");
+        when(paymentGateway.refund(anyInt(), anyDouble())).thenAnswer(invocation -> {
+            int txId = invocation.getArgument(0);
+            double amount = invocation.getArgument(1);
+            return new RefundResultDTO("refund-" + txId, String.valueOf(txId), amount, LocalDateTime.now(),
+                    List.of(), List.of());
+        });
+
+        // A refundable member receipt: holder == BUYER_ID, with an original charge so
+        // getPaymentTransactionId() is present and getTotalAmount() == TOTAL.
+        ReceiptLine line = new ReceiptLine(101, TOTAL, 2, 1, "15", WHEN);
+        TransactionRecord charge = TransactionRecord.paymentCharge(PAYMENT_TX, "stub", TOTAL, "ILS", WHEN);
+        orderReceiptRepository.save(OrderReceipt.forMember(RECEIPT_ID, BUYER_ID, TOTAL, List.of(line), List.of(charge)));
+
+        buyerToken = jwtSessionManager.generateToken(BUYER_ID, "buyer");
+    }
+
+    @Test
+    void givenManyConcurrentRefundsForSameReceipt_thenGatewayIsCalledExactlyOnce() throws InterruptedException {
+        ExecutorService pool = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+        CountDownLatch armed = new CountDownLatch(CONCURRENT_REQUESTS);
+        CountDownLatch fire = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(CONCURRENT_REQUESTS);
+        AtomicInteger refunded = new AtomicInteger();
+        AtomicInteger alreadyRefunded = new AtomicInteger();
+        ConcurrentLinkedQueue<Throwable> unexpected = new ConcurrentLinkedQueue<>();
+
+        for (int i = 0; i < CONCURRENT_REQUESTS; i++) {
+            pool.submit(() -> {
+                try {
+                    armed.countDown();
+                    fire.await(); // release all requests at once to maximise the race
+                    refundService.requestRefund(buyerToken, RECEIPT_ID, "double-click");
+                    refunded.incrementAndGet();
+                } catch (BusinessRuleViolationException alreadyDone) {
+                    alreadyRefunded.incrementAndGet(); // the loser saw is_refunded=true and bailed
+                } catch (Throwable t) {
+                    unexpected.add(t);
+                } finally {
+                    finished.countDown();
+                }
+            });
+        }
+
+        assertTrue(armed.await(5, TimeUnit.SECONDS), "workers did not arm in time");
+        fire.countDown();
+        assertTrue(finished.await(20, TimeUnit.SECONDS), "refunds did not finish in time");
+        pool.shutdownNow();
+
+        assertTrue(unexpected.isEmpty(), "only clean already-refunded failures expected, got: " + unexpected);
+        assertEquals(1, refunded.get(), "exactly one refund should succeed");
+        assertEquals(CONCURRENT_REQUESTS - 1, alreadyRefunded.get(),
+                "every other request must bail as already-refunded");
+        // The crux of #410: the gateway is hit exactly once despite the concurrent double-clicks.
+        verify(paymentGateway, times(1)).refund(anyInt(), anyDouble());
+        assertTrue(orderReceiptRepository.findByOrderReceiptId(RECEIPT_ID).orElseThrow().wasRefunded(),
+                "the receipt is recorded as refunded");
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/RefundServiceTest.java
@@ -40,6 +40,7 @@ import com.ticketing.system.Core.Domain.orders.OrderReceipt;
 import com.ticketing.system.Core.Domain.orders.ReceiptLine;
 import com.ticketing.system.Core.Domain.orders.TransactionRecord;
 import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.MemoryOrderReceiptRepository;
+import com.ticketing.system.testutil.TestTransactions;
 
 @ExtendWith(MockitoExtension.class)
 class RefundServiceTest {
@@ -68,7 +69,7 @@ class RefundServiceTest {
     @BeforeEach
     void setUp() {
         service = new RefundService(authenticationService, orderReceiptRepository, ticketRepository,
-                paymentGateway, eventRepository);
+                paymentGateway, eventRepository, TestTransactions.noOpManager());
     }
 
     private static OrderReceipt memberReceiptWithCharge(int userId) {
@@ -253,7 +254,7 @@ class RefundServiceTest {
         Mockito.when(ticketRepo.findByOrderReceiptId(ORDER_ID)).thenReturn(List.of());
         IEventRepository eventRepo = Mockito.mock(IEventRepository.class);
 
-        RefundService concurrentService = new RefundService(auth, realReceiptRepo, ticketRepo, countingGateway, eventRepo);
+        RefundService concurrentService = new RefundService(auth, realReceiptRepo, ticketRepo, countingGateway, eventRepo, TestTransactions.noOpManager());
 
         int threads = 2;
         CyclicBarrier barrier = new CyclicBarrier(threads);


### PR DESCRIPTION
Closes #410. Closes the production double-refund hole on the `jpa` profile.

## The bug
Under `jpa`, `JpaOrderReceiptRepository.lockForUpdate` was a no-op (concurrency via `@Version`), so two concurrent refund requests for the same receipt could both pass `wasRefunded()` and both call `paymentGateway.refund()` — refunding the buyer twice. `@Version` only fails the *second save*, **after** the gateway was already hit, so it can't prevent the double gateway call.

## The fix — pessimistic row-lock (Option 1, the issue's preferred)
- `lockForUpdate` now issues a real **`SELECT … FOR UPDATE`** on the receipt row (a SpringData `@Lock(PESSIMISTIC_WRITE)` query).
- `RefundService.requestRefund`'s critical section (eligibility check → gateway refund → mark + save) is wrapped in a **`TransactionTemplate`**, so the lock is held across it until commit. The loser **blocks** on the lock, then sees `is_refunded=true` and **bails before any second gateway call**.
- Keeps the safe **gateway-first** ordering (never mark refunded while the gateway disagrees) — so no "marked-but-not-refunded" window. The slow WSEP refund runs inside the locked section by design; refunds are low-frequency, so holding the row lock across it is acceptable (a narrow, deliberate exception to #360's "WSEP outside the tx", required for the exactly-once guarantee).
- Why not the alternatives: WSEP has **no idempotency-key field** (option 2 infeasible); a CAS flip-first (option 3) would invert to mark-first and reintroduce the window + need compensation.

## Acceptance
- ✅ Under `jpa`, concurrent refunds for the same receipt → **exactly one** `paymentGateway.refund()` call.
- ✅ New **`RefundConcurrencyTest`** (`@SpringBootTest`, jpa profile): 6 concurrent refunds → one succeeds, five bail as already-refunded, gateway hit once, receipt recorded refunded. **Deterministic** across reruns.
- ✅ The existing in-memory regression test (`givenConcurrentRefundRequests…`) stays.
- Full suite green: **1388 tests, 0 failures**.

## Side effect
`RefundService` now runs its critical section in a transaction — it was the **last application service without one**, so this also finishes the "transactions in every service" thread (#426). (Note: the refund WSEP call is deliberately *inside* this locked transaction, the one documented exception to the WSEP-outside-the-tx rule, for the reason above.)

Discovered in review of #409. Part of #347.
