### PR TITLE
docs(V3-DOC-02): README init/config/state-file formats + UC notes + requirements page (#374)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ src/main/frontend/generated/
 
 scripts/*
 docs/*
+# V3-DOC-02 (#374) deliverables are tracked; the rest of docs/ stays ignored.
+!docs/use-cases-v3.md
+!docs/version-3-requirements.html
 
 # Runtime log output (logs/event-ticket-system.log + rolled .gz archives)
 logs/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,200 @@
 # event-ticket-system
-An event management and ticketing platform that provides an infrastructure for trading event tickets between producers and buyers. Users can visit the platform to purchase tickets, as well as to create and manage events.
+
+An event management and ticketing platform that provides an infrastructure for trading event
+tickets between producers and buyers. Users can visit the platform to purchase tickets, as well as
+to create and manage events.
+
+## Architecture
+
+The codebase follows a clean, layered architecture:
+
+| Layer | Package | Responsibility |
+|---|---|---|
+| Domain | `Core/Domain` | Aggregates, entities, value objects, domain rules and the `IXxxRepository` ports |
+| Application | `Core/Application` | Use-case services, DTOs, application-level interfaces (ports) |
+| Infrastructure | `Infrastructure` | JPA/in-memory repository adapters, security (JWT), scheduling, external WSEP clients, dev seeding |
+| Presentation | `Presentation` | Vaadin views, presenters (MVP), UI components |
+
+**V3 — Persistence & Robustness.** The in-memory repositories are being replaced by JPA-backed
+adapters behind the unchanged `IXxxRepository` ports, every use-case runs inside a database
+transaction (`@Transactional` at the application layer, not the domain), external WSEP calls are
+kept outside the DB transaction, and the platform is deployable on PostgreSQL (Supabase). The same
+`jpa` profile runs against H2 locally and PostgreSQL on the deploy target — a config-only switch.
+
+## Build & run
+
+Prerequisites: JDK 21 and the bundled Maven wrapper (`./mvnw`).
+
+```bash
+# Production / staging path: jpa profile against PostgreSQL (see DB_* env vars below)
+./mvnw spring-boot:run
+
+# Local development: H2 in-memory DB, auto-opened market, and the demo scenario seed
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev
+```
+
+The app serves the Vaadin UI on `http://localhost:8080`. The Maven `production` profile
+(`./mvnw -Pproduction ...`) bundles the optimized Vaadin frontend for deployment.
+
+## How initialization works (UC-1 / UC-32)
+
+The platform comes up through a deterministic boot sequence, then waits for an admin to open the
+market before any money can move.
+
+1. **`PlatformInitializationRunner`** (`@Order(0)`, skipped under the `test` profile) calls
+   `SystemAdminService.initializePlatform()`.
+2. **`initializePlatform()`** (UC-1) runs the I.1 post-conditions in order:
+   - **I.1.2 / I.1.3** — external-service quorum: at least one payment gateway *and* one ticket
+     issuer must answer a WSEP `handshake` (`requireExternalServicesReachable()`), else
+     `ExternalServiceUnavailableException`.
+   - **I.1.4** — guarantee a System Admin: `createDefaultAdminIfMissing()` auto-creates the default
+     admin from `platform.admin.*` if none exists, else `MissingDefaultAdminException`.
+   - **I.1.1 gate** — re-assert the post-conditions (`verifyInitializationInvariants()`) and the
+     structural correctness scan (`SystemIntegrityVerifier.verify()`), else
+     `InitializationIntegrityException`. The platform transitions to **READY**.
+3. The market stays **CLOSED** until an admin calls **`openMarket()`** (UC-32), which re-verifies the
+   external services (I.2.2) and structural invariants (I.2.1) before flipping to **OPEN**. Sales
+   (`ReservationService` / `CheckoutService`) are gated on `isMarketOpen()`.
+4. Under the `dev` profile, **`DevMarketOpener`** (`@Order(1)`) opens the market automatically so the
+   seeded scenario can transact.
+
+The lifecycle is a small state machine: `UNINITIALIZED → READY → OPEN ↔ CLOSED`.
+
+> Initialization failures are logged but currently do not abort the JVM (the process boots, the
+> market just can't open). A hard boot-validity check that fails startup on invalid init is tracked
+> in **#367 (V3-INIT-02)** and not yet wired.
+
+## Config-file format
+
+Runtime configuration lives in `src/main/resources/application.yml` (all values are env-var
+overridable, shown as `${ENV:default}`). The `dev` profile overlay is
+`src/main/resources/application-dev.yml`.
+
+### `application.yml`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `spring.datasource.url` | `jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:ticketing}` | DB connection (env: `DB_HOST`/`DB_PORT`/`DB_NAME`) |
+| `spring.datasource.username` / `password` | `${DB_USER:postgres}` / `${DB_PASSWORD:postgres}` | DB credentials |
+| `spring.jpa.hibernate.ddl-auto` | `update` | Schema strategy (prod). Hibernate auto-detects the dialect per connection |
+| `spring.profiles.group.dev` | `jpa` | Activating `dev` also activates `jpa` |
+| `jwt.secret` | `${JWT_SECRET:…}` | JWT signing secret — **must** be supplied via env in production |
+| `session.member-ttl-minutes` | `1440` | Absolute member-session lifetime |
+| `session.guest-idle-timeout-minutes` | `30` | Idle timeout for guest sessions |
+| `auth.lockout.max-attempts` | `5` | Brute-force lockout threshold (`0` disables) |
+| `auth.lockout.lock-minutes` | `15` | Lockout duration |
+| `constants.ticket-reservation-duration` | `10` | Reservation hold window (minutes) |
+| `constants.order-expiration-duration` | `60` | Active-order expiration (minutes) |
+| `analytics.rate-window-minutes` | `5` | Trailing window for analytics rates |
+| `analytics.refresh-interval-ms` | `5000` | Dashboard auto-refresh (`0` disables) |
+| `management.endpoints.web.exposure.include` | `health,info` | Exposed Actuator endpoints |
+| `vaadin.launch-browser` | `false` | Don't auto-open a browser on run |
+| `vaadin.allowed-packages` | `com.ticketing.system.Presentation` | Restrict Vaadin component scan |
+| `platform.admin.username` | `${PLATFORM_ADMIN_USERNAME:admin}` | **UC-1 / I.1.4** default admin username |
+| `platform.admin.password` | `${PLATFORM_ADMIN_PASSWORD:admin}` | Default admin password — **override in production** |
+| `wsep.base-url` | `${WSEP_BASE_URL:https://…koyeb.app/}` | WSEP payment/issuance endpoint |
+
+### `application-dev.yml`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `spring.datasource.url` | `jdbc:h2:mem:devdb;…` | In-memory H2 (no Postgres/Docker needed locally) |
+| `spring.jpa.hibernate.ddl-auto` | `create-drop` | Drop + recreate schema each boot |
+| `seed.scenario` | `classpath:scenarios/demo.scenario` | Initial-state file to replay (see below) |
+| `seed.mode` | `idempotent` | `off` · `wipe` · anything else runs it |
+| `seed.fail-fast` | `false` | `true` stops at the first unexpected failure |
+
+> Per-environment `ddl-auto` (`validate`/migrations for the Supabase deploy, `create-drop` for
+> tests) and seeding/reset safety against a persisted DB are tracked in **#366 (V3-INIT-01)**.
+
+## Initial-state-file format
+
+The platform can be booted into a known state from an editable text file that **replays a sequence
+of use-case operations through the real application services** (one operation per line). This is the
+in-repo realization of the "initialize from a file" deliverable (#368). Two sample files ship under
+`src/main/resources/scenarios/`: `demo.scenario` (rich dataset) and `review.scenario` (minimal TA
+baseline). The runner (`Infrastructure/dev/seed/scenario/ScenarioRunner`) is `@Profile("dev")`, so
+it never runs in production.
+
+### Syntax
+
+- One operation per line; blank lines and lines starting with `#` are ignored.
+- Tokens are whitespace-separated; wrap values containing spaces in `"double quotes"`.
+- The first token is the operation; remaining bare tokens are **positional** args; tokens of the
+  form `key=value` are **named** args.
+- Refer to users/companies/events by short **aliases** (`u1`, `p1`, `e1`); the engine maps each
+  alias to the real id the service mints.
+
+### Operations
+
+Each operation dispatches to a real application-service method (`Infrastructure/dev/seed/scenario/ScenarioOps`):
+
+| Operation | Application service call |
+|---|---|
+| `register <alias> <password> <email> <age>` | `AuthenticationService.register` |
+| `login <alias>` | `AuthenticationService.login` |
+| `login-admin <alias> <username> <password>` | `AuthenticationService.signInAsAdmin` |
+| `logout <alias>` / `logout-all` | `AuthenticationService.logout` |
+| `guest <alias>` | `AuthenticationService.startGuestSession` |
+| `open-company <owner> <companyAlias> "<name>" ["<desc>"]` | `CompanyManagementService.registerCompany` |
+| `appoint-owner <by> <company> <target>` | `CompanyManagementService.appointOwner` |
+| `appoint-manager <by> <company> <target> perms=A,B,C` | `CompanyManagementService.appointManager` |
+| `confirm <alias> <company>` | `CompanyManagementService.respondToAppointment` |
+| `add-event <by> <company> <eventAlias> <zone>… [name= category= city= days= publish=]` | `EventManagementService.addEvent` + `configureVenueMap` (+ `publishEvent` if `publish=true`) |
+| `publish <by> <company> <event>` | `EventManagementService.publishEvent` |
+| `reserve <buyer> <event> <zoneRef> qty=<n> \| seats=A1,A2` | `ReservationService.reserveForMember` / `reserveForGuest` |
+| `checkout <buyer> [email= age=]` | `CheckoutService.checkoutMember` / `checkoutGuest` |
+| `cancel-event <by> <event>` | `EventManagementService.cancelEventAndRefund` |
+| `contact-company <from> <company> subject= body=` | `MessagingService.startConversation` |
+| `submit-complaint <from> subject= body=` | `MessagingService.submitComplaint` |
+| `announce <admin> title= body= [audience=BROADCAST_MEMBERS\|BROADCAST_PRODUCERS]` | `MessagingService.sendOutreach` |
+| `assert-status <event> <STATUS> by=<owner>` | read-only assertion via `EventManagementService.getEventDetail` |
+| `expect-error <op> <args…>` | negative test — passes only if the wrapped op throws |
+| `add-coupon …` | recognized but `SKIPPED` (no coupon feature) |
+
+Permissions for `appoint-manager perms=` are any of: `CONFIGURE_VENUE`, `MANAGE_INVENTORY`,
+`EDIT_POLICIES`, `VIEW_SALES`, `RESPOND_TO_INQUIRIES`. Zone specs for `add-event` are
+`standing:<capacity>@<price>` or `seated:<rows>x<cols>@<price>` (e.g. `standing:30@50`,
+`seated:10x10@100`).
+
+### Example (`review.scenario`)
+
+```text
+register u1 password123 u1@demo.test 30
+login u1
+open-company u1 p1 "Production Company p1"
+appoint-owner u1 p1 u2
+login u2
+confirm u2 p1
+appoint-manager u2 p1 u3 perms=CONFIGURE_VENUE
+login u3
+confirm u3 p1
+add-event u2 p1 e1 standing:30@50 seated:10x10@100 name="e1"
+logout-all
+```
+
+### Running a state file
+
+```bash
+# Use a specific file, wiping the in-memory repos first
+./mvnw spring-boot:run -Dspring-boot.run.profiles=dev \
+    -Dspring-boot.run.arguments="--seed.scenario=file:/abs/path/to/your.scenario --seed.mode=wipe"
+```
+
+Each line is classified `PASS` / `SKIPPED` / `FAIL` / `BLOCKED` and a summary report is logged at the
+end. With `seed.fail-fast=true` the run aborts (and reports) on the first unexpected failure, which
+satisfies the "init fails if any step fails" requirement.
+
+## Persistent cart (UC-13)
+
+A member's Active Order (cart) persists by `userId` across logout and is restored on re-authentication
+within the reservation window: `AuthenticationService.handleCartOnPromotion` re-attaches the persisted
+cart (or promotes a guest cart) on login, and `ReservationService.restoreActiveOrder` rehydrates it
+with the remaining timer (II.3.0.2 / UC-13). Expired carts are released back to inventory by the
+scheduled `SessionAndOrderSweeper` (II.3.0.3) and are not restored.
+
+## Further docs
+
+- `docs/use-cases-v3.md` — V3 use-case notes (UC-1, UC-32, UC-13).
+- `docs/version-3-requirements.html` — V3 requirements page (SLR.5/6/7, I.2.x, II.3.0.x).
+- `SEED.md` — the `dev` demo dataset (users, companies, events) and `seed.mode` behavior.

--- a/docs/use-cases-v3.md
+++ b/docs/use-cases-v3.md
@@ -1,0 +1,127 @@
+# Use cases — V3 updates
+
+This document records the V3 (Persistence & Robustness) changes to the use cases most affected by
+the move to a persisted database and the cart-lifecycle work: **UC-1 Initialize Platform**,
+**UC-32 Open Trading Market**, and **UC-13 Restore Active Order**.
+
+> The canonical, graded use-case book is maintained externally (LaTeX/Overleaf). This Markdown is
+> the in-repo record of the V3 deltas so the code and the docs stay in sync; mirror any change here
+> into the LaTeX book before submitting.
+
+---
+
+## UC-1 — Initialize Platform
+
+**Primary actor:** System (boot) / System Admin
+**Goal:** Bring the platform to a healthy, market-openable state on startup, validated against the
+**persisted** database.
+
+**Preconditions**
+- The configured datasource is reachable (`jpa` profile → PostgreSQL on deploy, H2 in dev).
+- Init parameters are available from the config file (`platform.admin.*`, `wsep.base-url`, …).
+
+**Main flow**
+1. On boot, `PlatformInitializationRunner` (`@Order(0)`) invokes
+   `SystemAdminService.initializePlatform()`.
+2. **Persistence load (V3).** Under the `jpa` profile the repositories are JPA-backed, so the
+   platform initializes against state already persisted in the database (admins, companies, events,
+   orders, …) rather than an empty in-memory store.
+3. **I.1.2 / I.1.3 — external-service quorum.** At least one payment gateway and one ticket issuer
+   must answer a WSEP `handshake` (`requireExternalServicesReachable()`).
+4. **I.1.4 — default admin.** `createDefaultAdminIfMissing()` creates the default System Admin from
+   `platform.admin.username` / `platform.admin.password` if none exists, and confirms the write
+   persisted.
+5. **I.1.1 — integrity re-validation (V3).** `verifyInitializationInvariants()` re-asserts the
+   post-conditions and `SystemIntegrityVerifier.verify()` runs the structural correctness scans
+   against the **loaded DB state** (e.g. every active company has an owner; every producer resolves
+   to a registered user). See #372 for extending these scans across the full constraint set at boot.
+6. The platform transitions **UNINITIALIZED → READY**; the market remains **CLOSED** until UC-32.
+
+**Alternate / exception flows**
+- No reachable payment **or** issuance service → `ExternalServiceUnavailableException`; platform
+  stays UNINITIALIZED.
+- Default admin cannot be created/persisted → `MissingDefaultAdminException`.
+- A post-condition or invariant fails at the gate (incl. a violation in loaded DB state) →
+  `InitializationIntegrityException`; the platform does not reach READY and the market cannot open.
+- Re-invocation on an already-initialized platform is a graceful no-op (idempotent).
+
+**Postconditions**
+- On success: status = READY, a System Admin exists, external services verified, invariants hold.
+- `isMarketOpen()` is still `false` — opening the market is the separate UC-32.
+
+---
+
+## UC-32 — Open Trading Market
+
+**Primary actor:** System Admin
+**Goal:** Open the market so reservations and purchases are accepted.
+
+**Preconditions**
+- The platform is initialized (status = READY) or was previously OPEN then CLOSED.
+- The caller presents a valid admin token.
+
+**Main flow**
+1. Admin calls `SystemAdminService.openMarket(request)`; `requireSystemAdmin()` enforces the admin
+   role.
+2. **I.2.2** — re-verify the external-service quorum (`requireExternalServicesReachable()`).
+3. **I.2.1** — re-assert structural invariants: at least one admin present and
+   `SystemIntegrityVerifier.verify()` passes against current DB state.
+4. Status transitions **READY → OPEN** (or **CLOSED → OPEN**); `lastOpenedAt` is recorded.
+5. Sales paths (`ReservationService`, `CheckoutService`) now pass the `isMarketOpen()` gate.
+
+**Alternate / exception flows**
+- Caller is not a valid admin → `UnauthorizedActionException`.
+- Platform not initialized → `MarketNotOpenException("platform not initialized")`.
+- External service down at open time → `ExternalServiceUnavailableException`.
+- No admin present / invariant violated → `InitializationIntegrityException`.
+- Already OPEN → idempotent no-op returning the current state.
+
+**Postconditions**
+- On success: status = OPEN; transactions are accepted.
+- `closeMarket()` returns the market to CLOSED (idempotent; rejects if it was never opened).
+
+---
+
+## UC-13 — Restore Active Order
+
+**Primary actor:** Member
+**Goal:** Restore a member's reserved Active Order (cart) on re-authentication, before the
+reservation timer expires (II.3.0.2).
+
+**Preconditions**
+- The member had an Active Order with at least one reserved line.
+- Re-authentication happens within the reservation window (`constants.ticket-reservation-duration`).
+
+**Main flow**
+1. The cart persists by `userId` across logout — the Session row is deleted but the Active Order
+   survives (II.3.0.1 / D9a). In the domain, logout orphans the cart from its session
+   (`ActiveOrder.clearSession()`) while keeping `userId`.
+2. On login, `AuthenticationService.handleCartOnPromotion(session, user)` runs:
+   - If a **guest cart** exists for the just-used guest session, it is promoted to the member
+     (`attachToUser`).
+   - Otherwise, if a **persisted member cart** exists from a previous session, it is re-attached to
+     the new session (`attachToSession`).
+3. `ReservationService.restoreActiveOrder(userId)` rehydrates the cart, enriches lines with event
+   names, and returns the remaining seconds so the UI can resume the countdown. The result is
+   carried back in the `LoginDTO`.
+
+**Alternate / exception flows**
+- **Expired cart.** If the reservation window elapsed while the member was logged out, the
+  scheduled `SessionAndOrderSweeper` has already released the tickets to inventory and deleted the
+  cart (II.3.0.3); restore finds nothing and the member sees an empty cart (no stale hold).
+- **Both carts present** (a fresh guest cart and a prior member cart): the guest cart wins, because
+  the repository collapses identity by `userId` on save.
+
+**Postconditions**
+- On success: the member's reserved items and remaining hold time are restored to the session.
+- Inventory is never double-held: a restored cart re-attaches the *same* reservation; an expired one
+  was already returned to stock.
+
+---
+
+## Related V3 work
+
+- #366–#368 — seeding/reset safety, config-file-driven init params + boot validity check, and the
+  initial-state replay file (documented in the README).
+- #369–#371 — cart persist-on-exit, restore-on-re-auth (this UC-13), and offline expiration sweep.
+- #372 — re-validate invariants on startup against loaded DB state (extends UC-1 step 5).

--- a/docs/version-3-requirements.html
+++ b/docs/version-3-requirements.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Version 3 Requirements · event-ticket-system</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1f2430; --muted: #5b6577; --line: #e3e7ef;
+    --head: #0f172a; --accent: #2563eb;
+    --done-bg: #e7f6ec; --done-fg: #1a7f37;
+    --partial-bg: #fff4e0; --partial-fg: #9a6700;
+    --pending-bg: #fde7ea; --pending-fg: #b42318;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2.5rem 1.25rem; background: var(--bg); color: var(--fg);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  main { max-width: 1040px; margin: 0 auto; }
+  h1 { font-size: 1.9rem; margin: 0 0 .25rem; color: var(--head); }
+  h2 { font-size: 1.25rem; margin: 2.25rem 0 .5rem; color: var(--head); border-bottom: 2px solid var(--line); padding-bottom: .35rem; }
+  p.lede { color: var(--muted); margin: 0 0 1.5rem; }
+  .legend { display: flex; gap: .75rem; flex-wrap: wrap; margin: 1rem 0 0; }
+  table { width: 100%; border-collapse: collapse; margin-top: .5rem; }
+  th, td { text-align: left; padding: .6rem .7rem; border-bottom: 1px solid var(--line); vertical-align: top; }
+  th { font-size: .78rem; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); }
+  td.id { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; white-space: nowrap; font-weight: 600; }
+  td.where { font-size: .9rem; color: var(--muted); }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #f4f6fa; padding: .05rem .3rem; border-radius: 4px; font-size: .88em; }
+  .badge { display: inline-block; font-size: .72rem; font-weight: 700; padding: .15rem .5rem; border-radius: 999px; white-space: nowrap; }
+  .done { background: var(--done-bg); color: var(--done-fg); }
+  .partial { background: var(--partial-bg); color: var(--partial-fg); }
+  .pending { background: var(--pending-bg); color: var(--pending-fg); }
+  footer { margin-top: 2.5rem; padding-top: 1rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .85rem; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Version 3 — Requirements</h1>
+  <p class="lede">
+    V3 = Persistence &amp; Robustness (tracking epic
+    <a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/347">#347</a>).
+    This page tracks the robustness requirements (SLR.5/6/7), the initialization &amp; market
+    requirements (I.1.x / I.2.x), and the Active-Order persistence requirements (II.3.0.x), with
+    where each is realized in the code and its current status. Status reflects the code on the
+    development branch; requirement text is summarized from the course spec and the linked issues.
+  </p>
+  <div class="legend">
+    <span class="badge done">Done</span>
+    <span class="badge partial">Partial</span>
+    <span class="badge pending">Pending</span>
+  </div>
+
+  <h2>Robustness &amp; fault tolerance — SLR.5 / SLR.6 / SLR.7</h2>
+  <table>
+    <thead><tr><th>ID</th><th>Requirement</th><th>Status</th><th>Realized in</th></tr></thead>
+    <tbody>
+      <tr>
+        <td class="id">SLR.7</td>
+        <td>Durable persistence: all aggregates persist to a relational DB behind the unchanged
+            <code>IXxxRepository</code> ports; every use-case runs inside a DB transaction
+            (<code>@Transactional</code> at the application layer, not the domain).</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where">JPA adapters under <code>Infrastructure/persistence</code>;
+            <a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/359">#359</a></td>
+      </tr>
+      <tr>
+        <td class="id">SLR.5</td>
+        <td>External-system (WSEP) fault tolerance: payment/issuance calls are kept outside the DB
+            transaction; transport-level retry/backoff for transient WSEP failures.</td>
+        <td><span class="badge partial">Partial</span></td>
+        <td class="where">WSEP-outside-tx done
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/360">#360</a>);
+            retry/backoff pending
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/365">#365</a>, tier-exempt)</td>
+      </tr>
+      <tr>
+        <td class="id">SLR.6</td>
+        <td>Recovery: the system survives a transient database outage — no crash, a friendly error
+            to the user, and automatic recovery once the DB reconnects.</td>
+        <td><span class="badge pending">Pending</span></td>
+        <td class="where"><a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/362">#362</a></td>
+      </tr>
+      <tr>
+        <td class="id">SLR.8.2</td>
+        <td>Real-time error logging/telemetry for operational visibility.</td>
+        <td><span class="badge partial">Partial</span></td>
+        <td class="where">Actuator <code>health,info</code> + <code>LoggingAspect</code> exist;
+            real-time error logging pending
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/364">#364</a>)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Initialization &amp; market — I.1.x / I.2.x</h2>
+  <table>
+    <thead><tr><th>ID</th><th>Requirement</th><th>Status</th><th>Realized in</th></tr></thead>
+    <tbody>
+      <tr>
+        <td class="id">I.1.2 / I.1.3</td>
+        <td>At initialization, verify at least one external payment service and one ticket-issuance
+            service are reachable.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>SystemAdminService.initializePlatform</code> · UC-1</td>
+      </tr>
+      <tr>
+        <td class="id">I.1.4</td>
+        <td>Guarantee a System Admin exists; auto-create the default admin from the config file when
+            none is present.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>createDefaultAdminIfMissing</code>; <code>platform.admin.*</code> · UC-1</td>
+      </tr>
+      <tr>
+        <td class="id">I.1.1</td>
+        <td>Re-validate structural invariants at the init gate against the loaded DB state; a
+            violation blocks the platform from going live.</td>
+        <td><span class="badge partial">Partial</span></td>
+        <td class="where"><code>SystemIntegrityVerifier.verify</code>; full constraint scan vs loaded
+            state pending
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/372">#372</a>)</td>
+      </tr>
+      <tr>
+        <td class="id">I.1.i</td>
+        <td>Initialize from a config file with a boot validity check — the system does not come up if
+            the init configuration is invalid.</td>
+        <td><span class="badge partial">Partial</span></td>
+        <td class="where"><code>application.yml</code> externalizes config; hard boot-fail on invalid
+            init pending
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/367">#367</a>)</td>
+      </tr>
+      <tr>
+        <td class="id">I.1.ii</td>
+        <td>Initialize from an external initial-state file that replays a use-case sequence through
+            the application services; the whole init fails if any step fails.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where">Scenario DSL via <code>ScenarioRunner</code> / <code>ScenarioOps</code>
+            (dev profile); format documented in the README
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/368">#368</a>)</td>
+      </tr>
+      <tr>
+        <td class="id">I.2.1</td>
+        <td>Before opening the market, re-assert structural invariants (≥1 admin, integrity scan).</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>SystemAdminService.openMarket</code> · UC-32</td>
+      </tr>
+      <tr>
+        <td class="id">I.2.2</td>
+        <td>Before opening the market, re-verify the external-service quorum; sales are gated on the
+            market being OPEN.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>openMarket</code> → <code>isMarketOpen()</code> gate in
+            <code>ReservationService</code> / <code>CheckoutService</code> · UC-32</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Active Order persistence — II.3.0.x</h2>
+  <table>
+    <thead><tr><th>ID</th><th>Requirement</th><th>Status</th><th>Realized in</th></tr></thead>
+    <tbody>
+      <tr>
+        <td class="id">II.3.0.1</td>
+        <td>A member's Active Order (cart) persists on exit/logout — the session ends but the cart
+            survives by <code>userId</code>.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>ActiveOrder.clearSession</code>; cart row keyed by userId
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/369">#369</a>)</td>
+      </tr>
+      <tr>
+        <td class="id">II.3.0.2</td>
+        <td>On re-authentication within the reservation window, the persisted cart is restored and
+            the timer resumed (UC-13); a guest cart is merged via the promotion path.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>handleCartOnPromotion</code> + <code>restoreActiveOrder</code> · UC-13
+            (one acceptance test currently <code>@Disabled</code>;
+            <a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/370">#370</a>)</td>
+      </tr>
+      <tr>
+        <td class="id">II.3.0.3</td>
+        <td>Offline/expired carts are swept: reserved tickets are released back to inventory when the
+            hold window elapses, and expired carts are not restored.</td>
+        <td><span class="badge done">Done</span></td>
+        <td class="where"><code>SessionAndOrderSweeper</code>
+            (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/371">#371</a>)</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <footer>
+    Generated for V3-DOC-02
+    (<a href="https://github.com/AdamSimkinbgu/event-ticket-system/issues/374">#374</a>).
+    Status is a point-in-time view of the development branch — see the linked issues for the live
+    state. See also <code>README.md</code> (init + file formats) and <code>docs/use-cases-v3.md</code>.
+  </footer>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Closes #374.

## Summary
Documentation deliverables for **V3-DOC-02**. Docs-only — no source changed.

- **README.md** (was a 2-line stub) — full rewrite:
  - Architecture + V3 stance (JPA behind `IXxxRepository` ports; every use-case a DB transaction; WSEP outside the tx).
  - Build & run (prod `jpa`/Postgres and `dev`/H2).
  - **How initialization works** — the UC-1/UC-32 boot sequence (`PlatformInitializationRunner` → `SystemAdminService.initializePlatform` → `openMarket`), lifecycle `UNINITIALIZED→READY→OPEN↔CLOSED`.
  - **Config-file format** — full `application.yml` / `application-dev.yml` key tables with env overrides.
  - **Initial-state-file format** — the `.scenario` DSL (syntax + every operation → application-service mapping + a `review.scenario` example + how to run), i.e. the in-repo realization of #368.
  - Persistent-cart (UC-13) notes.
- **docs/use-cases-v3.md** — UC-1 (adds persistence-load + integrity re-validation), UC-32 (open market), UC-13 (restore active order), with failure modes.
- **docs/version-3-requirements.html** — self-contained styled page: SLR.5/6/7 + I.1.x/I.2.x + II.3.0.x, each with an honest status and where it's realized.
- **.gitignore** — un-ignore exactly these two `docs/` deliverables (the rest of `docs/` stays ignored).

## Notes
- Decisions (confirmed): UC docs delivered as Markdown (no LaTeX toolchain available; the graded LaTeX/Overleaf UC book is maintained externally — mirror these deltas there); requirements page authored directly; file-format docs describe what exists today, flagging the #367/#368 gaps.
- Out of scope: #373 (architecture.puml + class diagram).
- Content verified against the code: config keys exist in the YAMLs, every documented scenario op exists in `ScenarioOps`, and the boot sequence matches `PlatformInitializationRunner` + `SystemAdminService`.