### PR TITLE
UI fixes: admin session persistence, org-tree views, event ratings & notifications

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/dto/CompanyDashboardDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/CompanyDashboardDTO.java
@@ -3,10 +3,12 @@ package com.ticketing.system.Core.Application.dto;
 // Owner-workspace dashboard counters for a single company (V2-WIRE-OWNER-DASH).
 // revenue30d / ticketsSold30d are the company's share of non-refunded receipts in the
 // trailing 30 days; activeEvents counts ON_SALE events; openInquiries counts unresolved
-// INQUIRY conversations where the company is the counterparty.
+// INQUIRY conversations where the company is the counterparty. rating is DERIVED — the mean
+// of the company's events' ratings (null when none of its events are rated).
 public record CompanyDashboardDTO(
     int activeEvents,
     int ticketsSold30d,
     double revenue30d,
-    int openInquiries
+    int openInquiries,
+    Double rating
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/dto/EventSummaryDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/EventSummaryDTO.java
@@ -15,5 +15,6 @@ public record EventSummaryDTO(
     List<ShowDateDTO> showDates,
     double minPrice,
     double maxPrice,
-    boolean soldOut
+    boolean soldOut,
+    List<String> artistsNames
 ) {}

--- a/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
@@ -30,7 +30,8 @@ public class EventMapper {
                 event.getShowDates().stream().map(sd -> new ShowDateDTO(sd.getStartTime(), sd.getEndTime())).toList(),
                 minPrice,
                 maxPrice,
-                event.getStatus() == EventStatus.SOLD_OUT);
+                event.getStatus() == EventStatus.SOLD_OUT,
+                event.getArtistsNames());
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -321,7 +321,11 @@ public class AuthenticationService {
      * — disjoint-pool rule), applies the shared lock-after-N policy, audit-logs every failure, and
      * issues an ADMIN-role JWT so the backend admin gate can authorize it.
      */
-    @Transactional(readOnly = true)
+    // Read-WRITE: generateAdminToken persists a brand-new Session row. A read-only transaction
+    // would leave Hibernate in MANUAL flush mode, so the assigned-id INSERT would never flush
+    // under the jpa profile and every admin token would fail validation as "session not found"
+    // (member login is unaffected — it promotes an already-persisted guest session).
+    @Transactional
     public AuthTokenDTO signInAsAdmin(String username, String rawPassword) {
         String lockKey = lockoutKey("a", username);
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -321,13 +321,10 @@ public class AuthenticationService {
      * — disjoint-pool rule), applies the shared lock-after-N policy, audit-logs every failure, and
      * issues an ADMIN-role JWT so the backend admin gate can authorize it.
      */
-<<<<<<< UI_General_Fixes
     // Read-WRITE: generateAdminToken persists a brand-new Session row. A read-only transaction
     // would leave Hibernate in MANUAL flush mode, so the assigned-id INSERT would never flush
     // under the jpa profile and every admin token would fail validation as "session not found"
     // (member login is unaffected — it promotes an already-persisted guest session).
-=======
->>>>>>> dev
     @Transactional
     public AuthTokenDTO signInAsAdmin(String username, String rawPassword) {
         String lockKey = lockoutKey("a", username);

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -3,8 +3,10 @@ package com.ticketing.system.Core.Application.services;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
@@ -133,18 +135,28 @@ public class CatalogService {
 
         List<EventSummaryDTO> results = new ArrayList<>();
 
+        // Company rating is DERIVED from a company's events (see CompanyRatings) — compute it only
+        // when an Organizer-rating filter is active, cached per company for this search.
+        boolean filterByCompanyRating =
+                effectiveFilters.minCompanyRating() != null || effectiveFilters.maxCompanyRating() != null;
+        Map<Integer, Double> companyRatingCache = new HashMap<>();
+
         // Iterate over all events returned by the eventRepository.searchONSALE() method, applying the effective filters.
         for (Event event : eventRepository.searchONSALE(effectiveFilters)) {
             // Check if the event is associated with an active company and is publicly visible (ON_SALE).
-            
             ProductionCompany company = activeCompanyOrNull(event.getCompanyId());
 
             // If the event is not publicly visible or the company does not match the company rating filters, skip to the next event.
             if (!isCompanyPubliclyVisible(company)) {
                 continue;
             }
-            if (!matchesCompanyRating(company, effectiveFilters)) {
-                continue;
+            if (filterByCompanyRating) {
+                Double companyRating = companyRatingCache.computeIfAbsent(
+                        event.getCompanyId(),
+                        id -> CompanyRatings.fromEvents(eventRepository.findByCompanyId(id)));
+                if (!matchesCompanyRating(companyRating, effectiveFilters)) {
+                    continue;
+                }
             }
 
             results.add(mapper.convertEventToEventSummaryDTO(event, productionCompanyRepository));
@@ -278,7 +290,8 @@ public class CatalogService {
                 .filter(c -> needle.isEmpty()
                         || (c.getName() != null && c.getName().toLowerCase().contains(needle)))
                 .sorted(Comparator.comparing(ProductionCompany::getName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
-                .map(c -> new CompanySummaryDTO(c.getCompanyId(), c.getName(), c.getRating()))
+                .map(c -> new CompanySummaryDTO(c.getCompanyId(), c.getName(),
+                        CompanyRatings.fromEvents(eventRepository.findByCompanyId(c.getCompanyId()))))
                 .toList();
     }
 
@@ -363,18 +376,15 @@ public class CatalogService {
         return company != null && company.getStatus() == CompanyStatus.ACTIVE;
     }
 
-    // *HELPER METHOD* to check if a ProductionCompany's rating matches the min/max company rating filters, returning true if it does, false otherwise.
-    private boolean matchesCompanyRating(ProductionCompany company, CatalogSearchFiltersDTO filters) {
-        Double rating = company.getRating();
-
+    // *HELPER METHOD* — does the company's DERIVED rating (mean of its events' ratings) satisfy the
+    // min/max company-rating filters? A null rating (no rated events) fails any active bound.
+    private boolean matchesCompanyRating(Double rating, CatalogSearchFiltersDTO filters) {
         if (filters.minCompanyRating() != null && (rating == null || rating < filters.minCompanyRating())) {
             return false;
         }
-
         if (filters.maxCompanyRating() != null && (rating == null || rating > filters.maxCompanyRating())) {
             return false;
         }
-
         return true;
     }
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -295,6 +295,12 @@ public class CatalogService {
                 .toList();
     }
 
+    //* A company's DERIVED rating — the mean of its events' ratings (CompanyRatings), or null when
+    //* it has no rated events. Backs the organizer line on the event-details page.
+    public Double companyRating(int companyId) {
+        return CompanyRatings.fromEvents(eventRepository.findByCompanyId(companyId));
+    }
+
     // *HELPER METHOD* — "city, country" label for an event's venue, or null if it has no location.
     private String venueLabel(Event event) {
         if (event.getVenueMap() == null || event.getVenueMap().getLocation() == null) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -151,9 +151,18 @@ public class CatalogService {
                 continue;
             }
             if (filterByCompanyRating) {
-                Double companyRating = companyRatingCache.computeIfAbsent(
-                        event.getCompanyId(),
-                        id -> CompanyRatings.fromEvents(eventRepository.findByCompanyId(id)));
+                // NOTE: don't use computeIfAbsent — a derived company rating is null when none of
+                // the company's events are rated, and computeIfAbsent does NOT store a null result,
+                // so it would re-query findByCompanyId for every event of an unrated company. Cache
+                // the null explicitly via containsKey/put so each company is looked up at most once.
+                Integer companyId = event.getCompanyId();
+                Double companyRating;
+                if (companyRatingCache.containsKey(companyId)) {
+                    companyRating = companyRatingCache.get(companyId);
+                } else {
+                    companyRating = CompanyRatings.fromEvents(eventRepository.findByCompanyId(companyId));
+                    companyRatingCache.put(companyId, companyRating);
+                }
                 if (!matchesCompanyRating(companyRating, effectiveFilters)) {
                     continue;
                 }

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyAnalyticsService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyAnalyticsService.java
@@ -93,9 +93,12 @@ public class CompanyAnalyticsService {
                 .filter(c -> c.getType() == ConversationType.INQUIRY && !c.isClosed())
                 .count();
 
-        log.debug("Dashboard for company {}: {} active events, {} tickets/30d, {} revenue/30d, {} open inquiries",
-                companyId, activeEvents, ticketsSold, revenue, openInquiries);
-        return new CompanyDashboardDTO(activeEvents, ticketsSold, revenue, openInquiries);
+        // Company rating is derived: the mean of this company's events' ratings (null if none rated).
+        Double rating = CompanyRatings.fromEvents(eventRepository.findByCompanyId(companyId));
+
+        log.debug("Dashboard for company {}: {} active events, {} tickets/30d, {} revenue/30d, {} open inquiries, rating {}",
+                companyId, activeEvents, ticketsSold, revenue, openInquiries, rating);
+        return new CompanyDashboardDTO(activeEvents, ticketsSold, revenue, openInquiries, rating);
     }
 
     public PurchaseHistoryDTO salesHistory(int companyId) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -474,7 +474,7 @@ public class CompanyManagementService {
                     request.getName().trim(),
                     CompanyStatus.ACTIVE,
                     request.getDescription().trim(),
-                    null);
+                    0.0);
 
             // IProductionCompanyRepository.save returns void; the new instance IS the saved
             // one.

--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyRatings.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyRatings.java
@@ -1,0 +1,38 @@
+package com.ticketing.system.Core.Application.services;
+
+import java.util.Collection;
+
+import com.ticketing.system.Core.Domain.events.Event;
+
+/**
+ * A production company's rating is <b>derived, not stored</b>: it is the mean of its events'
+ * ratings — events without a rating are ignored — or {@code null} when none of its events are
+ * rated. The result is rounded to one decimal place.
+ *
+ * <p>Single source of truth for the company rating surfaced by the catalogue Organizer-rating
+ * filter ({@code CatalogService}) and the owner workspace dashboard ({@code CompanyAnalyticsService}).
+ */
+public final class CompanyRatings {
+
+    private CompanyRatings() { }
+
+    /** Mean of the non-null event ratings (1-decimal), or {@code null} if no event is rated. */
+    public static Double fromEvents(Collection<Event> events) {
+        if (events == null) {
+            return null;
+        }
+        double sum = 0;
+        int count = 0;
+        for (Event event : events) {
+            Double rating = event.getRating();
+            if (rating != null) {
+                sum += rating;
+                count++;
+            }
+        }
+        if (count == 0) {
+            return null;
+        }
+        return Math.round((sum / count) * 10.0) / 10.0;
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -21,6 +21,7 @@ import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 import com.ticketing.system.Core.Domain.orders.TransactionRecord;
 import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
@@ -174,6 +175,13 @@ public class EventManagementService {
     // II.4.1.1 — Owner lists all events under their company.
     @Transactional(readOnly = true)
     public List<EventDetailDTO> listEventsForCompany(String token, int companyId) {
+        return listEventsForCompany(token, companyId, CatalogSearchFiltersDTO.empty());
+    }
+
+    // II.4.1.1 — Owner lists their company's events narrowed by the catalogue filters (company-rating
+    // filters don't apply to a single company, so they're stripped).
+    @Transactional(readOnly = true)
+    public List<EventDetailDTO> listEventsForCompany(String token, int companyId, CatalogSearchFiltersDTO filters) {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
@@ -186,10 +194,9 @@ public class EventManagementService {
         }
 
         user.requirePermissionInCompany(companyId, Permission.MANAGE_INVENTORY);
-        
 
         EventMapper mapper = new EventMapper();
-        return eventRepository.findByCompanyId(companyId).stream()
+        return eventRepository.searchByCompanyAll(companyId, filters.withoutCompanyRating()).stream()
             .map(e -> mapper.toEventDetailDTO(e, company.getName()))
             .toList();
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
@@ -279,8 +279,16 @@ public class ProductionCompany implements InvariantChecked {
     }
 
     public void setRating(Double rating) {
+        // Validate-before-commit: roll back if the new rating is out of range, so a rejected
+        // call never leaves the company with a corrupted rating.
+        Double previous = this.rating;
         this.rating = rating;
-        checkInvariants();
+        try {
+            checkInvariants();
+        } catch (RuntimeException ex) {
+            this.rating = previous;
+            throw ex;
+        }
     }
 
     // UC-18 — Founder is the original creator, immutable for the lifetime of the
@@ -318,6 +326,10 @@ public class ProductionCompany implements InvariantChecked {
         }
         if (name == null || name.isBlank()) {
             throw new IllegalStateException("ProductionCompany invariant violated: name must be non-blank");
+        }
+        if (rating != null && (rating < 0 || rating > 5)) {
+            throw new IllegalStateException(
+                    "ProductionCompany invariant violated: rating must be between 0 and 5 (was " + rating + ")");
         }
         if (companyStatus == null) {
             throw new IllegalStateException("ProductionCompany invariant violated: status must not be null");

--- a/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/company/ProductionCompany.java
@@ -327,9 +327,9 @@ public class ProductionCompany implements InvariantChecked {
         if (name == null || name.isBlank()) {
             throw new IllegalStateException("ProductionCompany invariant violated: name must be non-blank");
         }
-        if (rating != null && (rating < 0 || rating > 5)) {
+        if (rating != null && (!Double.isFinite(rating) || rating < 0 || rating > 5)) {
             throw new IllegalStateException(
-                    "ProductionCompany invariant violated: rating must be between 0 and 5 (was " + rating + ")");
+                    "ProductionCompany invariant violated: rating must be a finite value between 0 and 5 (was " + rating + ")");
         }
         if (companyStatus == null) {
             throw new IllegalStateException("ProductionCompany invariant violated: status must not be null");

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -676,9 +676,9 @@ public class Event implements InvariantChecked {
         if (name == null || name.isBlank()) {
             throw new IllegalStateException("Event invariant violated: name must be non-blank");
         }
-        if (rating != null && (rating < 0 || rating > 5)) {
+        if (rating != null && (!Double.isFinite(rating) || rating < 0 || rating > 5)) {
             throw new IllegalStateException(
-                    "Event invariant violated: rating must be between 0 and 5 (was " + rating + ")");
+                    "Event invariant violated: rating must be a finite value between 0 and 5 (was " + rating + ")");
         }
         if (comapnyid <= 0) {
             throw new IllegalStateException(

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -3,6 +3,7 @@ package com.ticketing.system.Core.Domain.events;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
@@ -452,14 +453,14 @@ public class Event implements InvariantChecked {
 
 
 
-    // ON_SALE -> COMPLETED after the last show date.
+    // ON_SALE / SOLD_OUT -> COMPLETED after the last show date.
     public void transitionToCompleted() {
         if (status == EventStatus.COMPLETED) {
             return;
         }
 
-        if (status != EventStatus.ON_SALE) {
-            throw new IllegalStateException("Only on-sale events can be marked as completed");
+        if (status != EventStatus.ON_SALE && status != EventStatus.SOLD_OUT) {
+            throw new IllegalStateException("Only on-sale or sold-out events can be marked as completed");
         }
 
         this.status = EventStatus.COMPLETED;
@@ -577,6 +578,19 @@ public class Event implements InvariantChecked {
 
     public List<ShowDate> getShowDates() {
         return List.copyOf(showDates);
+    }
+
+    // True once the event's last show has ended as of `now` — drives auto-completion
+    // (ON_SALE / SOLD_OUT -> COMPLETED). A multi-leg event finishes only after its latest leg.
+    public boolean hasFinishedAsOf(LocalDateTime now) {
+        if (showDates == null || showDates.isEmpty()) {
+            return false;
+        }
+        LocalDateTime lastEnd = showDates.stream()
+                .map(ShowDate::getEndTime)
+                .max(Comparator.naturalOrder())
+                .orElse(null);
+        return lastEnd != null && now.isAfter(lastEnd);
     }
 
     public VenueMap getVenueMap() {

--- a/src/main/java/com/ticketing/system/Core/Domain/events/EventStatus.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/EventStatus.java
@@ -6,7 +6,7 @@ package com.ticketing.system.Core.Domain.events;
 //   SCHEDULED  → ON_SALE    (UC-32: market opened or per-event publish)
 //   ON_SALE    → SOLD_OUT   (no AVAILABLE tickets remain)
 //   *          → CANCELED   (UC-4 trigger for refunds)
-//   ON_SALE    → COMPLETED  (event date passed)
+//   ON_SALE / SOLD_OUT → COMPLETED  (last show date passed)
 public enum EventStatus {
     DRAFT,
     SCHEDULED,

--- a/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
@@ -44,6 +44,8 @@ public interface IEventRepository extends IRepository<Event, Integer> {
     List<Event> searchAll(CatalogSearchFiltersDTO filters);
     // UC-7 — search across all events that are ON_SALE (filters from DTO).
     List<Event> searchONSALE(CatalogSearchFiltersDTO filters);
+    // Owner event list — a single company's events (all statuses), narrowed by the DTO filters.
+    List<Event> searchByCompanyAll(int companyId, CatalogSearchFiltersDTO filters);
     
 
     // Permanently removes a CANCELED event from the store.

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioCommand.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioCommand.java
@@ -90,7 +90,14 @@ public final class ScenarioCommand {
             return null;
         }
         try {
-            return Double.parseDouble(v.trim());
+            double parsed = Double.parseDouble(v.trim());
+            // Double.parseDouble accepts "NaN"/"Infinity"; reject them so seeded data can't bypass
+            // range checks that rely on < / > (both false for NaN) and corrupt ratings downstream.
+            if (!Double.isFinite(parsed)) {
+                throw new IllegalArgumentException(
+                        "line " + line + " (" + op + "): " + key + " must be a finite number, got '" + v + "'");
+            }
+            return parsed;
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("line " + line + " (" + op + "): " + key + " must be a number, got '" + v + "'");
         }

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioCommand.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioCommand.java
@@ -82,4 +82,17 @@ public final class ScenarioCommand {
         String v = named.get(key);
         return v == null ? fallback : Boolean.parseBoolean(v.trim());
     }
+
+    /** Named arg parsed as a {@code Double}, or {@code null} if absent. Located error on bad numbers. */
+    public Double doubleNamed(String key) {
+        String v = named.get(key);
+        if (v == null) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(v.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("line " + line + " (" + op + "): " + key + " must be a number, got '" + v + "'");
+        }
+    }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioOps.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioOps.java
@@ -275,7 +275,7 @@ public final class ScenarioOps {
 
         EventDetailDTO created = eventService.addEvent(token, new EventCreationDTO(
                 companyId, name, name + " — seeded event", List.of(headliner(name)), category,
-                null, new Location("Israel", city), List.of(show), nonePolicy()));
+                cmd.doubleNamed("rating"), new Location("Israel", city), List.of(show), nonePolicy()));
         int eventId = Integer.parseInt(created.eventId());
         eventService.configureVenueMap(token, companyId, buildVenueMap(created.eventId(), city + " venue", zones));
         if (cmd.boolNamed("publish", false)) {

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
@@ -129,4 +129,12 @@ public class JpaEventRepository implements IEventRepository {
                 .and((root, query, cb) -> cb.equal(root.get("status"), EventStatus.ON_SALE));
         return data.findAll(spec);
     }
+
+    @Override
+    public List<Event> searchByCompanyAll(int companyId, CatalogSearchFiltersDTO filters) {
+        // "comapnyid" is the Event field name (a domain typo) — see SpringDataEventRepository.
+        Specification<Event> spec = EventSearchSpecification.from(filters)
+                .and((root, query, cb) -> cb.equal(root.get("comapnyid"), companyId));
+        return data.findAll(spec);
+    }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -143,6 +143,15 @@ public class MemoryEventRepository implements IEventRepository {
                 .collect(Collectors.toList());
     }
 
+    // Owner event list: a single company's events (all statuses) narrowed by the same filters.
+    @Override
+    public List<Event> searchByCompanyAll(int companyId, CatalogSearchFiltersDTO filters) {
+        return events.values().stream()
+                .filter(e -> e.getCompanyId() == companyId)
+                .filter(e -> matchesSearch(e, filters))
+                .collect(Collectors.toList());
+    }
+
     /*
      * A helper method to apply the various search filters to an event and return a boolean indicating
      * whether the event matches the filters; used in the search() implementation above.

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/EventCompletionSweeper.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/EventCompletionSweeper.java
@@ -1,0 +1,95 @@
+package com.ticketing.system.Infrastructure.scheduling;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+
+/**
+ * Lifecycle sweeper: scans live events (ON_SALE / SOLD_OUT) whose last show date has
+ * passed and transitions them to {@link EventStatus#COMPLETED}.
+ *
+ * <p>Runs on a fixed delay (default 60s; override via {@code event-completion.fixed-delay-ms}).
+ * Once an event is COMPLETED the existing gates take over automatically: the buyer detail
+ * view disables purchasing ("Event Ended" / "PAST" badge), {@code CheckoutService} rejects
+ * it, and the buyer catalog/search (ON_SALE only) drop it.
+ *
+ * <p>The sweep is exposed as a public method so tests can drive it directly with a
+ * controllable {@code now} (no need to wait for the {@code @Scheduled} cadence).
+ */
+@Component
+@Slf4j
+public class EventCompletionSweeper {
+
+    private final IEventRepository eventRepository;
+    private final Clock clock;
+
+    public EventCompletionSweeper(IEventRepository eventRepository, Clock clock) {
+        this.eventRepository = eventRepository;
+        this.clock = clock;
+    }
+
+    @Scheduled(fixedDelayString = "${event-completion.fixed-delay-ms:60000}")
+    public void sweep() {
+        int completed = completeFinishedEvents(LocalDateTime.now(clock));
+        if (completed > 0) {
+            log.info("event-completion tick: {} event(s) marked COMPLETED", completed);
+        }
+    }
+
+    /**
+     * Completes every live event whose last show has ended as of {@code now}.
+     * Returns the number of events transitioned. Public so unit tests can drive the
+     * sweep independently of the {@code @Scheduled} cadence.
+     *
+     * <p>Each event is locked, re-read, re-validated, mutated and unlocked one at a time
+     * — never holding more than one event lock — so there is no lock-ordering concern with
+     * the multi-event {@code SessionAndOrderSweeper}.
+     */
+    public int completeFinishedEvents(LocalDateTime now) {
+        // Unlocked scan: collect candidates, then re-validate each under its write lock below.
+        List<Event> candidates = new ArrayList<>();
+        candidates.addAll(eventRepository.findByStatus(EventStatus.ON_SALE));
+        candidates.addAll(eventRepository.findByStatus(EventStatus.SOLD_OUT));
+
+        int completed = 0;
+        for (Event candidate : candidates) {
+            if (!candidate.hasFinishedAsOf(now)) {
+                continue;
+            }
+            int eventId = candidate.getId();
+            eventRepository.lockForUpdate(eventId);
+            try {
+                Event fresh = eventRepository.findById(eventId);
+                // Re-validate under the write lock: status/dates may have changed since the
+                // unlocked scan (owner cancel, inventory release reverting SOLD_OUT, a prior
+                // tick). transitionToCompleted is idempotent, but checking first avoids the
+                // guard throwing on a now-stale candidate.
+                if ((fresh.getStatus() == EventStatus.ON_SALE || fresh.getStatus() == EventStatus.SOLD_OUT)
+                        && fresh.hasFinishedAsOf(now)) {
+                    fresh.transitionToCompleted();
+                    eventRepository.save(fresh);
+                    completed++;
+                }
+            } catch (EventNotFoundException e) {
+                // Event was deleted between the scan and acquiring the lock — nothing to do.
+                log.warn("event-completion: event {} vanished before completion; skipping", eventId);
+            } catch (RuntimeException e) {
+                // One bad event must not abort the rest of the tick.
+                log.warn("event-completion: failed to complete event {}; continuing", eventId, e);
+            } finally {
+                eventRepository.unlock(eventId);
+            }
+        }
+        return completed;
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/EventCompletionSweeper.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/EventCompletionSweeper.java
@@ -51,12 +51,16 @@ public class EventCompletionSweeper {
      * Returns the number of events transitioned. Public so unit tests can drive the
      * sweep independently of the {@code @Scheduled} cadence.
      *
-     * <p>Each event is locked, re-read, re-validated, mutated and unlocked one at a time
-     * — never holding more than one event lock — so there is no lock-ordering concern with
-     * the multi-event {@code SessionAndOrderSweeper}.
+     * <p>Concurrency safety does NOT rely on {@code lockForUpdate} — that is a no-op on the JPA
+     * repository (it locks only under the in-memory repo). Each candidate is re-read and
+     * re-validated, and the real guard is the {@code Event} {@code @Version} optimistic lock: a
+     * racing sale bumps the version, so a stale completion fails on {@code save} and is retried on
+     * the next tick. The transition is idempotent and monotonic ({@code -> COMPLETED}) and mutates
+     * status only (no inventory side effects), and the {@code @Scheduled} pool is single-threaded —
+     * so there is no lock-ordering concern with the multi-event {@code SessionAndOrderSweeper}.
      */
     public int completeFinishedEvents(LocalDateTime now) {
-        // Unlocked scan: collect candidates, then re-validate each under its write lock below.
+        // Scan first, then re-read + re-validate each candidate before transitioning it below.
         List<Event> candidates = new ArrayList<>();
         candidates.addAll(eventRepository.findByStatus(EventStatus.ON_SALE));
         candidates.addAll(eventRepository.findByStatus(EventStatus.SOLD_OUT));
@@ -67,13 +71,13 @@ public class EventCompletionSweeper {
                 continue;
             }
             int eventId = candidate.getId();
-            eventRepository.lockForUpdate(eventId);
+            eventRepository.lockForUpdate(eventId); // no-op under JPA; a real lock only on the in-memory repo
             try {
                 Event fresh = eventRepository.findById(eventId);
-                // Re-validate under the write lock: status/dates may have changed since the
-                // unlocked scan (owner cancel, inventory release reverting SOLD_OUT, a prior
-                // tick). transitionToCompleted is idempotent, but checking first avoids the
-                // guard throwing on a now-stale candidate.
+                // Re-read + re-validate before transitioning: status/dates may have changed since the
+                // scan (owner cancel, inventory release reverting SOLD_OUT, a prior tick). The actual
+                // concurrency guard is Event's @Version on save; transitionToCompleted is idempotent,
+                // but checking first avoids the guard throwing on a now-stale candidate.
                 if ((fresh.getStatus() == EventStatus.ON_SALE || fresh.getStatus() == EventStatus.SOLD_OUT)
                         && fresh.hasFinishedAsOf(now)) {
                     fresh.transitionToCompleted();
@@ -81,7 +85,7 @@ public class EventCompletionSweeper {
                     completed++;
                 }
             } catch (EventNotFoundException e) {
-                // Event was deleted between the scan and acquiring the lock — nothing to do.
+                // Event was deleted between the scan and the re-read — nothing to do.
                 log.warn("event-completion: event {} vanished before completion; skipping", eventId);
             } catch (RuntimeException e) {
                 // One bad event must not abort the rest of the tick.

--- a/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeLegend.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/admin/OrgTreeLegend.java
@@ -1,0 +1,41 @@
+package com.ticketing.system.Presentation.components.admin;
+
+import com.vaadin.flow.component.Composite;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+
+/**
+ * Shared legend row for the organizational-tree views — the admin all-companies view
+ * ({@code OrganizationalTreeView}) and the owner-workspace single-company view
+ * ({@code CompanyOrgTreeView}). Explains the Founder / Owner / Manager node styling so
+ * the two views render an identical key. Wrap it in a card (e.g. {@code new LkCard("Legend")}).
+ */
+public class OrgTreeLegend extends Composite<Div> {
+
+    public OrgTreeLegend() {
+        Div row = getContent();
+        row.getStyle().set("display", "flex").set("gap", "20px").set("flex-wrap", "wrap");
+        row.add(
+            item("founder", "Founder", "Immutable — created the company."),
+            item("owner",   "Owner",   "Appointed by founder or another owner."),
+            item("manager", "Manager", "Appointed by an owner with granular permissions.")
+        );
+    }
+
+    private static Div item(String variant, String roleLabel, String desc) {
+        Div item = new Div();
+        item.getStyle().set("display", "flex").set("gap", "10px").set("align-items", "center");
+
+        Span dot = new Span("●");
+        dot.addClassName("oc-avatar");
+        dot.addClassName("oc-av-" + variant);
+        dot.getStyle().set("width", "26px").set("height", "26px").set("font-size", "12px");
+
+        Span text = new Span();
+        text.getElement().setProperty("innerHTML", "<b>" + roleLabel + "</b> · " + desc);
+        text.getStyle().set("font-size", "13px");
+
+        item.add(dot, text);
+        return item;
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/components/kit/LkNotifPanel.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/kit/LkNotifPanel.java
@@ -84,6 +84,12 @@ public class LkNotifPanel extends Div {
         return this;
     }
 
+    /** Hide the "Mark All Read" action — used when there is nothing to mark. */
+    public LkNotifPanel hideMarkAll() {
+        markAll.setVisible(false);
+        return this;
+    }
+
     public static LkNotifPanel buyer() {
         return new LkNotifPanel("Notifications", List.of(
             new Item("", "ticket", "Your Coldplay seats are confirmed", "Receipt #TKT-20847 · $504.00 paid", "2m", true, null),
@@ -147,7 +153,7 @@ public class LkNotifPanel extends Div {
         if (notifications == null || notifications.isEmpty()) {
             return new LkNotifPanel("Notifications", List.of(
                 new Item("", "bell", "You're all caught up", "No new notifications", "", false, null)
-            ), "View all notifications");
+            ), "View all notifications").hideMarkAll();
         }
         List<Item> items = notifications.stream()
             .map(n -> new Item(

--- a/src/main/java/com/ticketing/system/Presentation/components/kit/LkTextRows.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/kit/LkTextRows.java
@@ -1,0 +1,147 @@
+package com.ticketing.system.Presentation.components.kit;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeLabel;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * A labeled, repeatable single-line text input: a vertical stack of rows, each a
+ * {@link TextField} plus a "✕" remove control, with a "+ Add" button that appends a new
+ * empty row. Lets a user enter a list of short free-text values (e.g. an event's artists)
+ * one-per-row instead of as a single comma-separated field.
+ *
+ * <p>House-style kit component — reuses {@link LkBtn} and mirrors the add/remove-row idiom
+ * from {@code VenueMapEditorView} (keep a state list, {@code removeAll()} then rebuild; a
+ * "✕" {@link Span} with {@code event.stopPropagation()}). The backend contract is
+ * unchanged: {@link #getValues()} returns a trimmed, blank-free {@code List<String>} in row
+ * order (the same shape the old comma-split parser produced).
+ */
+public class LkTextRows extends Div {
+
+    private final NativeLabel label = new NativeLabel();
+    private final Div rowsHolder = new Div();
+    private final LkBtn addBtn;
+    private final List<TextField> rows = new ArrayList<>();
+    private String placeholder = "";
+    private boolean readOnly = false;
+
+    public LkTextRows(String labelText, String addButtonLabel) {
+        addClassName("lk-text-rows");
+        getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "6px");
+
+        label.setText(labelText);
+        label.getStyle().set("font-size", "0.875rem").set("font-weight", "500")
+                .set("color", "var(--lumo-secondary-text-color, #5f6b7a)");
+
+        rowsHolder.getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "8px");
+
+        addBtn = new LkBtn(addButtonLabel).variant(LkBtn.Variant.secondary).size(LkBtn.Size.s)
+                .onClick(e -> addAndFocusRow());
+        // Wrap so the button stays content-width and left-aligned inside the flex column.
+        Div addWrap = new Div(addBtn);
+        addWrap.getStyle().set("display", "flex");
+
+        add(label, rowsHolder, addWrap);
+
+        addRowField("");   // one empty row to start
+        rebuild();
+    }
+
+    public LkTextRows placeholder(String p) {
+        this.placeholder = p == null ? "" : p;
+        rows.forEach(t -> t.setPlaceholder(this.placeholder));
+        return this;
+    }
+
+    /**
+     * Replace all rows with the given values (one row per value). When the list is
+     * empty/null an editable instance keeps a single empty row; a read-only instance keeps
+     * none.
+     */
+    public LkTextRows setValues(List<String> values) {
+        rows.clear();
+        if (values != null) {
+            for (String v : values) {
+                addRowField(v == null ? "" : v);
+            }
+        }
+        if (rows.isEmpty() && !readOnly) {
+            addRowField("");
+        }
+        rebuild();
+        return this;
+    }
+
+    /** Trimmed, blank-free values in row order (mirrors the old comma-split parser). */
+    public List<String> getValues() {
+        List<String> out = new ArrayList<>();
+        for (TextField f : rows) {
+            String v = f.getValue();
+            if (v != null && !v.trim().isBlank()) {
+                out.add(v.trim());
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** Read-only display mode: no "+ Add", no "✕", and the rows are not editable. */
+    public LkTextRows readOnly(boolean ro) {
+        this.readOnly = ro;
+        addBtn.setVisible(!ro);
+        rows.forEach(f -> f.setReadOnly(ro));
+        rebuild();
+        return this;
+    }
+
+    private void addAndFocusRow() {
+        TextField field = addRowField("");
+        rebuild();
+        field.focus();   // let the user keep typing the next name immediately
+    }
+
+    private TextField addRowField(String value) {
+        TextField field = new TextField();
+        field.setValue(value == null ? "" : value);
+        field.setPlaceholder(placeholder);
+        field.setWidthFull();
+        field.setReadOnly(readOnly);
+        rows.add(field);
+        return field;
+    }
+
+    private void removeRow(TextField field) {
+        rows.remove(field);
+        if (rows.isEmpty() && !readOnly) {
+            addRowField("");   // always leave somewhere to type
+        }
+        rebuild();
+    }
+
+    private void rebuild() {
+        rowsHolder.removeAll();
+        for (TextField field : rows) {
+            Div row = new Div();
+            row.getStyle().set("display", "flex").set("align-items", "center").set("gap", "8px");
+            field.getStyle().set("flex", "1");
+            row.add(field);
+            if (!readOnly) {
+                row.add(removeControl(field));
+            }
+            rowsHolder.add(row);
+        }
+    }
+
+    private Component removeControl(TextField field) {
+        Span x = new Span("✕");
+        x.getStyle().set("cursor", "pointer").set("color", "var(--lk-danger, #c0392b)")
+                .set("padding", "0 4px").set("flex", "0 0 auto");
+        x.getElement().addEventListener("click", e -> removeRow(field))
+                .addEventData("event.stopPropagation()");
+        return x;
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Presentation.layouts;
 
+import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Presentation.components.NotificationBellComponent;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
@@ -49,9 +50,11 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
     private LkTopBar topBar;
     private LkSideNav adminNav;
     private final SignOutFlow signOutFlow;
+    private final INotificationService notificationService;
 
-    public PlatformAdminLayout(SignOutFlow signOutFlow) {
+    public PlatformAdminLayout(SignOutFlow signOutFlow, INotificationService notificationService) {
         this.signOutFlow = signOutFlow;
+        this.notificationService = notificationService;
         rebuildTopBar();
         buildDrawerOnce();
     }
@@ -69,7 +72,10 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
             // No navigation target — the brand is inert; "Back to Site" (right) is the way out.
             .brand("Event Ticket Platform", " · Admin")
             .rightLink("Back to Site", "arrowLeft", LandingView.class)
-            .bell(new NotificationBellComponent(null))
+            .bell(new NotificationBellComponent(notifId -> {
+                Integer userId = AuthSession.userId();
+                if (userId != null) notificationService.markRead(userId, notifId);
+            }))
             .account(initials(name), name, buildAdminMenu(name), "#fff", "#c2410c");
         addToNavbar(topBar);
     }

--- a/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
@@ -18,6 +18,7 @@ import com.ticketing.system.Presentation.views.auth.LoginView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.ticketing.system.Presentation.views.company.CompanyEventListView;
 import com.ticketing.system.Presentation.views.company.CompanyInquiryInboxView;
+import com.ticketing.system.Presentation.views.company.CompanyOrgTreeView;
 import com.ticketing.system.Presentation.views.company.ManagerListView;
 import com.ticketing.system.Presentation.views.company.MyCompaniesView;
 import com.ticketing.system.Presentation.views.company.OwnerAppointmentView;
@@ -61,6 +62,7 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
         new DrawerEntry(new LkSideNav.Item("chart",     "Company Sales",     CompanySalesView.class),         Capability.VIEW_COMPANY_SALES),
         new DrawerEntry(new LkSideNav.Item("users",     "Managers",          ManagerListView.class),          Capability.APPOINT_MANAGER),
         new DrawerEntry(new LkSideNav.Item("crown",     "Appoint Co-Owner",  OwnerAppointmentView.class),     Capability.APPOINT_CO_OWNER),
+        new DrawerEntry(new LkSideNav.Item("org",       "Organizational Tree", CompanyOrgTreeView.class),     Capability.VIEW_COMPANY_ORG_TREE),
         new DrawerEntry(new LkSideNav.Item("policy",    "Purchase Policies", PurchasePolicyEditorView.class), Capability.EDIT_PURCHASE_POLICIES)
     );
 
@@ -72,6 +74,7 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
         CompanySalesView.class,         "Company Sales",
         ManagerListView.class,          "Managers",
         OwnerAppointmentView.class,     "Appoint Co-Owner",
+        CompanyOrgTreeView.class,       "Organizational Tree",
         PurchasePolicyEditorView.class, "Purchase Policies"
     );
 

--- a/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Presentation.layouts;
 
+import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Presentation.components.NotificationBellComponent;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
@@ -78,9 +79,11 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
     private LkSideNav ownerNav;
     private final Div drawerWrap = new Div();
     private final SignOutFlow signOutFlow;
+    private final INotificationService notificationService;
 
-    public WorkspaceLayout(SignOutFlow signOutFlow) {
+    public WorkspaceLayout(SignOutFlow signOutFlow, INotificationService notificationService) {
         this.signOutFlow = signOutFlow;
+        this.notificationService = notificationService;
         rebuildTopBar();
         addToDrawer(drawerWrap);
         rebuildDrawer(null);
@@ -101,7 +104,10 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
                 new LkTopBar.NavItem("Browse",     BrowseEventsView.class),
                 new LkTopBar.NavItem("My Tickets", MyAccountView.class)
             ), null)
-            .bell(new NotificationBellComponent(null))
+            .bell(new NotificationBellComponent(notifId -> {
+                Integer userId = AuthSession.userId();
+                if (userId != null) notificationService.markRead(userId, notifId);
+            }))
             .account(initials(name), name, buildOwnerMenu(name));
         addToNavbar(topBar);
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/EventDetailsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/EventDetailsPresenter.java
@@ -62,13 +62,22 @@ public class EventDetailsPresenter {
             log.debug("No accessible venue map for eventId {}: {}", eventId, e.getMessage());
         }
 
-        return new Outcome.Success(event, zones, gridRows, gridCols);
+        // Organizer's DERIVED rating (mean of the company's events' ratings) — best-effort so a
+        // failure here never blocks the page.
+        Double companyRating = null;
+        try {
+            companyRating = catalogService.companyRating(Integer.parseInt(event.companyId()));
+        } catch (RuntimeException e) {
+            log.debug("Could not resolve company rating for eventId {}: {}", eventId, e.getMessage());
+        }
+
+        return new Outcome.Success(event, zones, gridRows, gridCols, companyRating);
     }
 
     /** Sealed outcome the view switches on to render the page or an error banner. */
     public sealed interface Outcome {
         record Success(EventDetailDTO event, List<InventoryZoneDTO> zones,
-                       int gridRows, int gridCols) implements Outcome { }
+                       int gridRows, int gridCols, Double companyRating) implements Outcome { }
         record NotFound(String message) implements Outcome { }
         record Failure(String message)  implements Outcome { }
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
@@ -25,13 +26,13 @@ public class CompanyEventListPresenter {
         this.companyManagementService = companyManagementService;
     }
 
-    public Outcome load(String token) {
+    public Outcome load(String token, CatalogSearchFiltersDTO filters) {
         if (token == null) return new Outcome.NotAuthenticated();
         try {
             List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
             if (owned.isEmpty()) return new Outcome.NoCompany();
             int companyId = owned.get(0).companyId();
-            List<EventDetailDTO> events = eventService.listEventsForCompany(token, companyId);
+            List<EventDetailDTO> events = eventService.listEventsForCompany(token, companyId, filters);
             return new Outcome.Success(events);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -32,7 +32,10 @@ public class CompanyEventListPresenter {
             List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
             if (owned.isEmpty()) return new Outcome.NoCompany();
             int companyId = owned.get(0).companyId();
-            List<EventDetailDTO> events = eventService.listEventsForCompany(token, companyId, filters);
+            // Null filters means "unfiltered" — substitute an empty filter set so the service's
+            // filters.withoutCompanyRating() call can't NPE into a generic Failure.
+            CatalogSearchFiltersDTO effectiveFilters = filters == null ? CatalogSearchFiltersDTO.empty() : filters;
+            List<EventDetailDTO> events = eventService.listEventsForCompany(token, companyId, effectiveFilters);
             return new Outcome.Success(events);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -67,7 +67,8 @@ public class EventManagementPresenter {
      */
     public CreateOutcome create(String token, Integer preferredCompanyId, String name,
                                 String description, String categoryName, String country, String city,
-                                LocalDateTime starts, LocalDateTime ends, List<String> artists) {
+                                LocalDateTime starts, LocalDateTime ends, List<String> artists,
+                                Double rating) {
         if (token == null) return new CreateOutcome.NotAuthenticated();
 
         // Validate required inputs up front so bad/missing data surfaces as InvalidInput rather than
@@ -80,6 +81,8 @@ public class EventManagementPresenter {
                                    return new CreateOutcome.InvalidInput("A start and an end time are required.");
         if (artists == null || artists.isEmpty())
                                    return new CreateOutcome.InvalidInput("At least one artist is required.");
+        if (rating != null && (rating < 0 || rating > 5))
+                                   return new CreateOutcome.InvalidInput("Rating must be between 0 and 5.");
 
         try {
             Integer companyId = resolveCompanyId(token, preferredCompanyId);
@@ -91,7 +94,7 @@ public class EventManagementPresenter {
                 description,
                 artists,
                 EventCategory.valueOf(categoryName),
-                null,                                   // rating — set later
+                rating,                                 // optional 0–5 rating set by the organizer
                 new Location(country, city),
                 List.of(new ShowDate(starts, ends)),
                 null);                                  // purchase policy — inherits company policy

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -81,7 +81,8 @@ public class EventManagementPresenter {
                                    return new CreateOutcome.InvalidInput("A start and an end time are required.");
         if (artists == null || artists.isEmpty())
                                    return new CreateOutcome.InvalidInput("At least one artist is required.");
-        if (rating != null && (rating < 0 || rating > 5))
+        if (rating == null)        return new CreateOutcome.InvalidInput("A rating (0–5) is required.");
+        if (rating < 0 || rating > 5)
                                    return new CreateOutcome.InvalidInput("Rating must be between 0 and 5.");
 
         try {
@@ -94,7 +95,7 @@ public class EventManagementPresenter {
                 description,
                 artists,
                 EventCategory.valueOf(categoryName),
-                rating,                                 // optional 0–5 rating set by the organizer
+                rating,                                 // required 0–5 rating set by the organizer
                 new Location(country, city),
                 List.of(new ShowDate(starts, ends)),
                 null);                                  // purchase policy — inherits company policy

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -82,7 +82,9 @@ public class EventManagementPresenter {
         if (artists == null || artists.isEmpty())
                                    return new CreateOutcome.InvalidInput("At least one artist is required.");
         if (rating == null)        return new CreateOutcome.InvalidInput("A rating (0–5) is required.");
-        if (rating < 0 || rating > 5)
+        // Double.isFinite guards against NaN/Infinity, for which `< 0`/`> 5` are both false and would
+        // otherwise let an invalid rating slip past the range check into the domain.
+        if (!Double.isFinite(rating) || rating < 0 || rating > 5)
                                    return new CreateOutcome.InvalidInput("Rating must be between 0 and 5.");
 
         try {

--- a/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
@@ -55,7 +55,8 @@ public final class Capabilities {
             Capability.APPOINT_CO_OWNER,
             Capability.EDIT_MANAGER_PERMISSIONS,
             Capability.REVOKE_MANAGER,
-            Capability.CANCEL_EVENT));
+            Capability.CANCEL_EVENT,
+            Capability.VIEW_COMPANY_ORG_TREE));
 
     /** Extra capabilities the founder holds on top of {@link #OWNER_BUNDLE}. */
     private static final Set<Capability> FOUNDER_EXTRA = unmodifiable(EnumSet.of(

--- a/src/main/java/com/ticketing/system/Presentation/security/Capability.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capability.java
@@ -49,6 +49,7 @@ public enum Capability {
     EDIT_MANAGER_PERMISSIONS,
     REVOKE_MANAGER,
     CANCEL_EVENT,
+    VIEW_COMPANY_ORG_TREE,
 
     // ---- Founder-only ----
     DISSOLVE_COMPANY,

--- a/src/main/java/com/ticketing/system/Presentation/session/NotificationSession.java
+++ b/src/main/java/com/ticketing/system/Presentation/session/NotificationSession.java
@@ -52,6 +52,7 @@ public final class NotificationSession {
 
     /** Mark one notification READ in the session snapshot. */
     public static void markRead(String notificationId) {
+        if (notificationId == null || notificationId.isBlank()) return;
         List<NotificationDTO> updated = getAll().stream()
                 .map(n -> notificationId.equals(n.notificationId())
                         ? new NotificationDTO(n.notificationId(), n.type(), "READ", n.message(), n.createdAt())

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -2,6 +2,7 @@ package com.ticketing.system.Presentation.views.admin;
 
 import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Presentation.components.admin.OrgTreeLegend;
 import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
 import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkCard;
@@ -125,31 +126,7 @@ public class OrganizationalTreeView extends LkPage {
 
     private Component buildLegendCard() {
         LkCard card = new LkCard("Legend").pad(16);
-        Div row = new Div();
-        row.getStyle().set("display", "flex").set("gap", "20px").set("flex-wrap", "wrap");
-        row.add(
-            legendItem("founder", "Founder",  "Immutable — created the company."),
-            legendItem("owner",   "Owner",    "Appointed by founder or another owner."),
-            legendItem("manager", "Manager",  "Appointed by an owner with granular permissions.")
-        );
-        card.add(row);
+        card.add(new OrgTreeLegend());
         return card;
-    }
-
-    private Component legendItem(String variant, String roleLabel, String desc) {
-        Div item = new Div();
-        item.getStyle().set("display", "flex").set("gap", "10px").set("align-items", "center");
-
-        Span dot = new Span("●");
-        dot.addClassName("oc-avatar");
-        dot.addClassName("oc-av-" + variant);
-        dot.getStyle().set("width", "26px").set("height", "26px").set("font-size", "12px");
-
-        Span text = new Span();
-        text.getElement().setProperty("innerHTML", "<b>" + roleLabel + "</b> · " + desc);
-        text.getStyle().set("font-size", "13px");
-
-        item.add(dot, text);
-        return item;
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/OrganizationalTreeView.java
@@ -5,10 +5,8 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
 import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkCard;
-import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
-import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.PlatformAdminLayout;
 import com.ticketing.system.Presentation.presenters.admin.OrgTreePresenter;
 import com.ticketing.system.Presentation.security.Capability;
@@ -36,7 +34,7 @@ public class OrganizationalTreeView extends LkPage {
     public OrganizationalTreeView(OrgTreePresenter presenter) {
         this.presenter = presenter;
         title("Organizational Tree");
-        subtitle("Founder → owners → managers hierarchy for the selected company, with audit lines.");
+        subtitle("Pick a company on the left to see its founder → owners → managers hierarchy.");
         add(body);
         render();
     }
@@ -56,35 +54,67 @@ public class OrganizationalTreeView extends LkPage {
             case OrgTreePresenter.Outcome.Failure fail ->
                 body.add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
                     "Could not load the tree: " + fail.reason()));
-            case OrgTreePresenter.Outcome.Success ok -> {
-                body.add(buildFilters(ok.companies(), ok.selected()));
-                body.add(buildTreeCard(ok.selected().name(), ok.tree()));
-                body.add(buildLegendCard());
-            }
+            case OrgTreePresenter.Outcome.Success ok ->
+                body.add(buildMasterDetail(ok.companies(), ok.selected(), ok.tree()));
         }
     }
 
-    private Component buildFilters(List<ProductionCompanyDTO> companies, ProductionCompanyDTO selected) {
-        LkRow row = new LkRow().gap(8);
+    /** Two-column master/detail: all companies on the left, the selected company's tree on the right. */
+    private Component buildMasterDetail(List<ProductionCompanyDTO> companies,
+                                        ProductionCompanyDTO selected,
+                                        OrganizationalTreeNodeDTO tree) {
+        Div split = new Div();
+        split.getStyle().set("display", "flex").set("gap", "16px")
+            .set("align-items", "flex-start").set("flex-wrap", "wrap");
 
-        List<String> names = companies.stream().map(ProductionCompanyDTO::name).toList();
-        LkFilterChip companyChip = new LkFilterChip("Company", names, true, List.of(selected.name()));
-        companyChip.onApply(() -> {
-            String picked = companyChip.getSelected().stream().findFirst().orElse(selected.name());
-            selectedCompanyId = companies.stream()
-                    .filter(c -> c.name().equals(picked))
-                    .map(ProductionCompanyDTO::companyId)
-                    .findFirst()
-                    .orElse(selected.companyId());
+        Div left = new Div();
+        left.getStyle().set("flex", "0 0 280px").set("min-width", "240px");
+        left.add(buildCompanyList(companies, selected));
+
+        Div right = new Div();
+        right.getStyle().set("flex", "1 1 480px").set("min-width", "320px")
+            .set("display", "flex").set("flex-direction", "column").set("gap", "16px");
+        right.add(buildTreeCard(selected.name(), tree), buildLegendCard());
+
+        split.add(left, right);
+        return split;
+    }
+
+    private Component buildCompanyList(List<ProductionCompanyDTO> companies, ProductionCompanyDTO selected) {
+        LkCard card = new LkCard("Companies (" + companies.size() + ")").pad(12);
+
+        Div list = new Div();
+        list.getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "8px")
+            .set("max-height", "70vh").set("overflow", "auto");
+        for (ProductionCompanyDTO c : companies) {
+            list.add(companyItem(c, c.companyId() == selected.companyId()));
+        }
+        card.add(list);
+        return card;
+    }
+
+    private Component companyItem(ProductionCompanyDTO c, boolean active) {
+        Div item = new Div();
+        item.getStyle()
+            .set("display", "flex").set("flex-direction", "column").set("gap", "2px")
+            .set("padding", "10px 12px").set("border-radius", "8px").set("cursor", "pointer")
+            .set("border", "1px solid " + (active ? "#0f172a" : "#e2e8f0"))
+            .set("background", active ? "#0f172a" : "#fff");
+
+        Span name = new Span(c.name());
+        name.getStyle().set("font-weight", "700").set("font-size", "13.5px")
+            .set("color", active ? "#fff" : "#1e293b");
+
+        Span meta = new Span(c.status());
+        meta.getStyle().set("font-size", "12px")
+            .set("color", active ? "#cbd5e1" : "#94a3b8");
+
+        item.add(name, meta);
+        item.addClickListener(e -> {
+            selectedCompanyId = c.companyId();
             render();
         });
-
-        row.add(
-            companyChip,
-            new LkFilterChip("Roles", List.of("Founder", "Owners", "Managers"), true,
-                List.of("Founder", "Owners", "Managers"))
-        );
-        return row;
+        return item;
     }
 
     private Component buildTreeCard(String companyName, OrganizationalTreeNodeDTO root) {

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -30,17 +31,14 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 @Route(value = "browse", layout = MainLayout.class)
 @PageTitle("Browse Events · TicketHub")
@@ -51,29 +49,22 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
 
     private record EventRow(String name, String category, String venue,
             String date, LocalDateTime startsAt, int priceCents,
-            LkStatusDot.Tone tone, String status, String id) {
+            LkStatusDot.Tone tone, String status, String id,
+            Double rating, List<String> artists) {
     }
-
-    /** A resolved from/to date range for a date-range preset; either bound may be null (unbounded). */
-    record DateWindow(LocalDate from, LocalDate to) { }
 
     private final BrowseEventsPresenter presenter;
     private final SessionIdentity identity;
 
-    private static final String CAT_ALL     = "All categories";
-    private static final String COUNTRY_ALL = "All countries";
-    private static final String CITY_ALL    = "All cities";
-    private static final String DATE_ANY    = "Any time";
+    // Filter option lists + label→value mappings live in CatalogFilterSupport (shared with the owner
+    // event list); these aliases keep the in-view references terse.
+    private static final String CAT_ALL     = CatalogFilterSupport.CAT_ALL;
+    private static final String COUNTRY_ALL = CatalogFilterSupport.COUNTRY_ALL;
+    private static final String CITY_ALL    = CatalogFilterSupport.CITY_ALL;
+    private static final String DATE_ANY    = CatalogFilterSupport.DATE_ANY;
 
-    private static final List<String> CATEGORIES = List.of(
-            CAT_ALL, "Concerts", "Sports", "Theatre", "Festivals", "Comedy");
-
-    private static final Map<String, List<String>> CITIES_BY_COUNTRY = Map.of(
-            "Israel", List.of("Tel Aviv", "Jerusalem", "Haifa", "Caesarea", "Be'er Sheva"),
-            "USA",    List.of("New York", "Los Angeles", "Chicago"),
-            "UK",     List.of("London", "Manchester", "Birmingham"));
-
-    private static final List<String> COUNTRIES = List.of(COUNTRY_ALL, "Israel", "USA", "UK");
+    private static final List<String> CATEGORIES = CatalogFilterSupport.CATEGORIES;
+    private static final List<String> COUNTRIES  = CatalogFilterSupport.COUNTRIES;
 
     private static final List<String> SORTS = List.of(
             "Date · soonest", "Date · latest", "Price · low to high", "Price · high to low", "Popularity");
@@ -84,10 +75,16 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private String filterCountry   = COUNTRY_ALL;
     private String filterCity      = CITY_ALL;
     private String filterArtist    = "";
+    private String filterEventName = "";
+    private String filterKeywords  = "";
     private String filterDateRange = DATE_ANY;
     private String filterSort      = SORTS.get(0);
     private Integer filterPriceMin = null;
     private Integer filterPriceMax = null;
+    private Double filterMinEventRating   = null;
+    private Double filterMaxEventRating   = null;
+    private Double filterMinCompanyRating = null;
+    private Double filterMaxCompanyRating = null;
 
     // ---- ui references for re-render / reset ----
 
@@ -100,8 +97,14 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private DatePicker customToPicker;
     private Div customRangeRow;
     private TextField artistField;
+    private TextField eventNameField;
+    private TextField keywordsField;
     private IntegerField priceMin;
     private IntegerField priceMax;
+    private NumberField eventRatingMin;
+    private NumberField eventRatingMax;
+    private NumberField companyRatingMin;
+    private NumberField companyRatingMax;
     private Div gridSlot;
     private Span resultsCountSpan;
 
@@ -183,6 +186,32 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         categorySelect = new LkSelect(CAT_ALL, CATEGORIES).label("Category");
         categorySelect.onChange(this::setCategory);
 
+        // Event name — case-insensitive substring on the event name.
+        eventNameField = new TextField();
+        eventNameField.setPlaceholder("e.g. Coldplay");
+        eventNameField.setValueChangeMode(ValueChangeMode.LAZY);
+        eventNameField.getStyle().set("width", "100%");
+        eventNameField.addValueChangeListener(e -> {
+            String v = e.getValue() == null ? "" : e.getValue();
+            if (Objects.equals(filterEventName, v)) return;
+            filterEventName = v;
+            runSearch();
+        });
+        Div eventNameWrap = labelledWrap("Event name", eventNameField);
+
+        // Keywords — matches the event name OR any artist in the line-up.
+        keywordsField = new TextField();
+        keywordsField.setPlaceholder("Search name or artist");
+        keywordsField.setValueChangeMode(ValueChangeMode.LAZY);
+        keywordsField.getStyle().set("width", "100%");
+        keywordsField.addValueChangeListener(e -> {
+            String v = e.getValue() == null ? "" : e.getValue();
+            if (Objects.equals(filterKeywords, v)) return;
+            filterKeywords = v;
+            runSearch();
+        });
+        Div keywordsWrap = labelledWrap("Keywords", keywordsField);
+
         // Artist
         artistField = new TextField();
         artistField.setPlaceholder("e.g. Taylor Swift");
@@ -238,7 +267,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
             if (Objects.equals(filterCountry, v)) return;
             filterCountry = v;
             filterCity = CITY_ALL;
-            citySelect.setOptions(cityOptionsFor(v));
+            citySelect.setOptions(CatalogFilterSupport.cityOptionsFor(v));
             citySelect.enabled(!COUNTRY_ALL.equals(v));
             runSearch();
         });
@@ -260,8 +289,9 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         });
 
         LkCol col = new LkCol().gap(16);
-        col.add(categorySelect, artistWrap, dateRangeField, customRangeRow,
-                buildPriceRange(), countrySelect, citySelect, sortSelect);
+        col.add(categorySelect, eventNameWrap, keywordsWrap, artistWrap, dateRangeField, customRangeRow,
+                buildPriceRange(), buildEventRatingRange(), buildCompanyRatingRange(),
+                countrySelect, citySelect, sortSelect);
         card.add(col);
         return card;
     }
@@ -306,6 +336,59 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         return wrap;
     }
 
+    private Component buildEventRatingRange() {
+        eventRatingMin = ratingField("Min", v -> {
+            if (Objects.equals(filterMinEventRating, v)) return;
+            filterMinEventRating = v;
+            runSearch();
+        });
+        eventRatingMax = ratingField("Max", v -> {
+            if (Objects.equals(filterMaxEventRating, v)) return;
+            filterMaxEventRating = v;
+            runSearch();
+        });
+        return ratingRangeWrap("Event rating", eventRatingMin, eventRatingMax);
+    }
+
+    private Component buildCompanyRatingRange() {
+        companyRatingMin = ratingField("Min", v -> {
+            if (Objects.equals(filterMinCompanyRating, v)) return;
+            filterMinCompanyRating = v;
+            runSearch();
+        });
+        companyRatingMax = ratingField("Max", v -> {
+            if (Objects.equals(filterMaxCompanyRating, v)) return;
+            filterMaxCompanyRating = v;
+            runSearch();
+        });
+        return ratingRangeWrap("Organizer rating", companyRatingMin, companyRatingMax);
+    }
+
+    /** A 0–5 rating bound input (NumberField, half-star step) wired to {@code onChange}. */
+    private static NumberField ratingField(String placeholder, Consumer<Double> onChange) {
+        NumberField f = new NumberField();
+        f.setPlaceholder(placeholder);
+        f.setMin(0);
+        f.setMax(5);
+        f.setStep(0.5);
+        f.setValueChangeMode(ValueChangeMode.LAZY);
+        f.getStyle().set("flex", "1 1 0");
+        f.addValueChangeListener(e -> onChange.accept(e.getValue()));
+        return f;
+    }
+
+    private static Component ratingRangeWrap(String labelText, NumberField min, NumberField max) {
+        Div wrap = new Div();
+        Span label = new Span(labelText);
+        label.addClassName("lk-label");
+        label.getStyle().set("display", "block").set("margin-bottom", "6px");
+        wrap.add(label);
+        LkRow row = new LkRow().gap(8);
+        row.add(min, max);
+        wrap.add(row);
+        return wrap;
+    }
+
     private Component buildGridSlot() {
         gridSlot = new Div();
         gridSlot.getStyle().set("min-width", "0").set("width", "100%");
@@ -320,16 +403,24 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         filterCountry   = COUNTRY_ALL;
         filterCity      = CITY_ALL;
         filterArtist    = "";
+        filterEventName = "";
+        filterKeywords  = "";
         filterDateRange = DATE_ANY;
         filterSort      = SORTS.get(0);
         filterPriceMin  = null;
         filterPriceMax  = null;
+        filterMinEventRating   = null;
+        filterMaxEventRating   = null;
+        filterMinCompanyRating = null;
+        filterMaxCompanyRating = null;
 
         categorySelect.setValue(CAT_ALL);
         countrySelect.setValue(COUNTRY_ALL);
         citySelect.setOptions(List.of(CITY_ALL));
         citySelect.enabled(false);
         artistField.clear();
+        eventNameField.clear();
+        keywordsField.clear();
         dateRangeField.setValue(DATE_ANY);
         customRangeRow.setVisible(false);
         customFromPicker.clear();
@@ -337,6 +428,10 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         sortSelect.setValue(SORTS.get(0));
         priceMin.clear();
         priceMax.clear();
+        eventRatingMin.clear();
+        eventRatingMax.clear();
+        companyRatingMin.clear();
+        companyRatingMax.clear();
         runSearch();
     }
 
@@ -357,7 +452,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
      */
     private void runCustomSearchIfValid() {
         if (!"Custom range".equals(filterDateRange)) return;
-        if (isValidCustomRange(customFromPicker.getValue(), customToPicker.getValue()))
+        if (CatalogFilterSupport.isValidCustomRange(customFromPicker.getValue(), customToPicker.getValue()))
             runSearch();
     }
 
@@ -367,61 +462,25 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
             from = customFromPicker.getValue();
             to   = customToPicker.getValue();
         } else {
-            DateWindow dw = dateWindow(filterDateRange, LocalDate.now());
+            CatalogFilterSupport.DateWindow dw = CatalogFilterSupport.dateWindow(filterDateRange, LocalDate.now());
             from = dw.from();
             to   = dw.to();
         }
         return new CatalogSearchFiltersDTO(
-                null,
+                filterEventName.isBlank() ? null : filterEventName,
                 filterArtist.isBlank() ? null : filterArtist,
-                categoryFilterValue(filterCategory),
-                null,
+                CatalogFilterSupport.categoryFilterValue(filterCategory),
+                filterKeywords.isBlank() ? null : filterKeywords,
                 filterPriceMin == null ? null : filterPriceMin.doubleValue(),
                 filterPriceMax == null ? null : filterPriceMax.doubleValue(),
                 from, to,
                 locationFilter(),
-                null, null, null, null);
+                filterMinEventRating, filterMaxEventRating,
+                filterMinCompanyRating, filterMaxCompanyRating);
     }
 
     private String locationFilter() {
-        return locationFilter(filterCity, filterCountry);
-    }
-
-    /** City (if selected) beats country so the DB predicate is as narrow as possible. */
-    static String locationFilter(String filterCity, String filterCountry) {
-        if (!CITY_ALL.equals(filterCity))       return filterCity;
-        if (!COUNTRY_ALL.equals(filterCountry)) return filterCountry;
-        return null;
-    }
-
-    /** UI category label → EventCategory enum name (null = no filter). */
-    static String categoryFilterValue(String label) {
-        if (label == null) return null;
-        return switch (label) {
-            case "Concerts"  -> "CONCERT";
-            case "Sports"    -> "SPORTS";
-            case "Theatre"   -> "THEATER";
-            case "Festivals" -> "FESTIVAL";
-            case "Comedy"    -> "COMEDY";
-            default          -> null;
-        };
-    }
-
-    /** Date-range preset → concrete [from, to] window relative to {@code today} (null bounds = open). */
-    static DateWindow dateWindow(String preset, LocalDate today) {
-        if (preset == null) return new DateWindow(null, null);
-        return switch (preset) {
-            case "Today" -> new DateWindow(today, today);
-            case "This weekend" -> {
-                LocalDate sat = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
-                yield new DateWindow(sat, sat.plusDays(1));
-            }
-            case "Next 7 days"   -> new DateWindow(today, today.plusDays(7));
-            case "Next 30 days"  -> new DateWindow(today, today.plusDays(30));
-            case "This month"    -> new DateWindow(today, today.with(TemporalAdjusters.lastDayOfMonth()));
-            case "Next 3 months" -> new DateWindow(today, today.plusMonths(3));
-            default              -> new DateWindow(null, null); // "Any time" and "Custom range"
-        };
+        return CatalogFilterSupport.locationFilter(filterCity, filterCountry);
     }
 
     private void renderGrid(List<EventRow> rows) {
@@ -472,6 +531,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
                 .col("Venue", "venue")
                 .col("Date", "date")
                 .col("From", "from", LkGrid.Align.RIGHT)
+                .col("Rating", "rating", LkGrid.Align.RIGHT)
                 .col("Status", "status")
                 .col("", "act", LkGrid.Align.RIGHT);
         for (EventRow ev : events)
@@ -483,12 +543,13 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private void addRow(LkGrid grid, EventRow ev) {
         LinkedHashMap<String, Object> row = new LinkedHashMap<>();
         Span name = new Span();
-        name.getElement().setProperty("innerHTML", "<b>" + escape(ev.name) + "</b>");
+        name.getElement().setProperty("innerHTML", nameCellHtml(ev));
         row.put("name", name);
         row.put("cat", ev.category);
         row.put("venue", ev.venue);
         row.put("date", ev.date);
         row.put("from", "$" + (ev.priceCents / 100));
+        row.put("rating", ev.rating == null ? "—" : "★ " + ratingText(ev.rating));
         row.put("status", new LkStatusDot(ev.tone, ev.status));
         LkBtn reserve = new LkBtn("Reserve")
                 .variant(LkBtn.Variant.primary)
@@ -509,20 +570,6 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
 
     // ---- helpers ----
 
-    static List<String> cityOptionsFor(String country) {
-        List<String> cities = CITIES_BY_COUNTRY.get(country);
-        if (cities == null) return List.of(CITY_ALL);
-        List<String> opts = new ArrayList<>(cities.size() + 1);
-        opts.add(CITY_ALL);
-        opts.addAll(cities);
-        return opts;
-    }
-
-    /** A custom range is searchable unless it's the from&gt;to inversion; an open bound (null) is fine. */
-    static boolean isValidCustomRange(LocalDate from, LocalDate to) {
-        return from == null || to == null || !from.isAfter(to);
-    }
-
     private static Div labelledWrap(String labelText, Component field) {
         Div wrap = new Div();
         Span label = new Span(labelText);
@@ -542,7 +589,8 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         LkStatusDot.Tone tone = dto.soldOut() ? LkStatusDot.Tone.muted : LkStatusDot.Tone.ok;
         String status = dto.soldOut() ? "Sold out" : "On sale";
         return new EventRow(dto.name(), prettyCategory(dto.category()), dto.location(),
-                date, start, priceCents, tone, status, String.valueOf(dto.eventId()));
+                date, start, priceCents, tone, status, String.valueOf(dto.eventId()),
+                dto.rating(), dto.artistsNames());
     }
 
     private static Comparator<EventRow> comparatorFor(String sort) {
@@ -573,5 +621,20 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
 
     private static String escape(String s) {
         return s == null ? "" : s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    /** Event name in bold, with the line-up (if any) as a muted second line. */
+    private static String nameCellHtml(EventRow ev) {
+        String html = "<b>" + escape(ev.name) + "</b>";
+        if (ev.artists != null && !ev.artists.isEmpty()) {
+            String lineup = String.join(" · ", ev.artists.stream().map(BrowseEventsView::escape).toList());
+            html += "<div style=\"color:var(--muted);font-size:12.5px;margin-top:2px;\">" + lineup + "</div>";
+        }
+        return html;
+    }
+
+    /** Rating shown without a trailing ".0" (e.g. 4.5 → "4.5", 4.0 → "4"). */
+    private static String ratingText(double rating) {
+        return rating == Math.floor(rating) ? String.valueOf((int) rating) : String.valueOf(rating);
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/CatalogFilterSupport.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/CatalogFilterSupport.java
@@ -1,0 +1,89 @@
+package com.ticketing.system.Presentation.views.catalog;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared, layout-independent options and pure helpers for the catalogue event filters — the single
+ * source of truth used by both the buyer browse page ({@link BrowseEventsView}) and the owner event
+ * list ({@code CompanyEventListView}). Holds the filter option lists and the label→value mappings;
+ * each view builds its own controls and lays them out as it sees fit.
+ */
+public final class CatalogFilterSupport {
+
+    private CatalogFilterSupport() { }
+
+    public static final String CAT_ALL     = "All categories";
+    public static final String COUNTRY_ALL = "All countries";
+    public static final String CITY_ALL    = "All cities";
+    public static final String DATE_ANY    = "Any time";
+
+    public static final List<String> CATEGORIES = List.of(
+            CAT_ALL, "Concerts", "Sports", "Theatre", "Festivals", "Comedy");
+
+    public static final Map<String, List<String>> CITIES_BY_COUNTRY = Map.of(
+            "Israel", List.of("Tel Aviv", "Jerusalem", "Haifa", "Caesarea", "Be'er Sheva"),
+            "USA",    List.of("New York", "Los Angeles", "Chicago"),
+            "UK",     List.of("London", "Manchester", "Birmingham"));
+
+    public static final List<String> COUNTRIES = List.of(COUNTRY_ALL, "Israel", "USA", "UK");
+
+    /** A resolved from/to date range for a date-range preset; either bound may be null (unbounded). */
+    public record DateWindow(LocalDate from, LocalDate to) { }
+
+    /** UI category label → EventCategory enum name (null = no filter). */
+    public static String categoryFilterValue(String label) {
+        if (label == null) return null;
+        return switch (label) {
+            case "Concerts"  -> "CONCERT";
+            case "Sports"    -> "SPORTS";
+            case "Theatre"   -> "THEATER";
+            case "Festivals" -> "FESTIVAL";
+            case "Comedy"    -> "COMEDY";
+            default          -> null;
+        };
+    }
+
+    /** Date-range preset → concrete [from, to] window relative to {@code today} (null bounds = open). */
+    public static DateWindow dateWindow(String preset, LocalDate today) {
+        if (preset == null) return new DateWindow(null, null);
+        return switch (preset) {
+            case "Today" -> new DateWindow(today, today);
+            case "This weekend" -> {
+                LocalDate sat = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+                yield new DateWindow(sat, sat.plusDays(1));
+            }
+            case "Next 7 days"   -> new DateWindow(today, today.plusDays(7));
+            case "Next 30 days"  -> new DateWindow(today, today.plusDays(30));
+            case "This month"    -> new DateWindow(today, today.with(TemporalAdjusters.lastDayOfMonth()));
+            case "Next 3 months" -> new DateWindow(today, today.plusMonths(3));
+            default              -> new DateWindow(null, null); // "Any time" and "Custom range"
+        };
+    }
+
+    /** City (if selected) beats country so the DB predicate is as narrow as possible. */
+    public static String locationFilter(String filterCity, String filterCountry) {
+        if (!CITY_ALL.equals(filterCity))       return filterCity;
+        if (!COUNTRY_ALL.equals(filterCountry)) return filterCountry;
+        return null;
+    }
+
+    /** City options for a country: "All cities" first, then the country's cities (or just "All cities"). */
+    public static List<String> cityOptionsFor(String country) {
+        List<String> cities = CITIES_BY_COUNTRY.get(country);
+        if (cities == null) return List.of(CITY_ALL);
+        List<String> opts = new ArrayList<>(cities.size() + 1);
+        opts.add(CITY_ALL);
+        opts.addAll(cities);
+        return opts;
+    }
+
+    /** A custom range is searchable unless it's the from&gt;to inversion; an open bound (null) is fine. */
+    public static boolean isValidCustomRange(LocalDate from, LocalDate to) {
+        return from == null || to == null || !from.isAfter(to);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
@@ -119,6 +119,9 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         if (detail.category() != null) {
             badges.add(new LkBadge(prettify(detail.category().toString()), LkBadge.Tone.muted).small());
         }
+        if (detail.rating() != null) {
+            badges.add(new LkBadge("★ " + ratingText(detail.rating()), LkBadge.Tone.muted).small());
+        }
 
         Div title = new Div();
         title.addClassName("bz-evt-title");
@@ -359,6 +362,11 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
             return "EVENT";
         }
         return name.trim().substring(0, 1).toUpperCase(Locale.US);
+    }
+
+    /** Rating shown without a trailing ".0" (e.g. 4.5 → "4.5", 4.0 → "4"). */
+    private static String ratingText(double rating) {
+        return rating == Math.floor(rating) ? String.valueOf((int) rating) : String.valueOf(rating);
     }
 
     private static LkBadge statusBadge(EventStatus status) {

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
@@ -48,6 +48,7 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
 
     private int eventId;
     private EventDetailDTO detail;
+    private Double companyRating;
     private List<InventoryZoneDTO> zones = List.of();
     private int gridRows = 3;
     private int gridCols = 3;
@@ -76,6 +77,7 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
     private void loadAndBuild() {
         bodyHolder.removeAll();
         this.detail = null;
+        this.companyRating = null;
         this.zones = List.of();
         this.selectedZoneId = null;
 
@@ -87,6 +89,7 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         switch (presenter.load(sessionIdentity.credential(), eventId)) {
             case EventDetailsPresenter.Outcome.Success s -> {
                 this.detail = s.event();
+                this.companyRating = s.companyRating();
                 this.zones = s.zones();
                 this.gridRows = s.gridRows();
                 this.gridCols = s.gridCols();
@@ -128,6 +131,17 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
         title.setText(detail.name());
 
         meta.add(badges, title);
+
+        // Organizer (production company) name, with its DERIVED rating shown beside it when available.
+        if (detail.companyName() != null && !detail.companyName().isBlank()) {
+            String organizerLine = detail.companyName();
+            if (companyRating != null) {
+                organizerLine += "  ·  ★ " + ratingText(companyRating);
+            }
+            Span organizer = Lk.muted(organizerLine);
+            organizer.getStyle().set("font-size", "14px").set("font-weight", "600");
+            meta.add(organizer);
+        }
 
         String lineup = detail.artistsNames() == null ? "" : String.join(" · ", detail.artistsNames());
         if (!lineup.isBlank()) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -1,17 +1,19 @@
 package com.ticketing.system.Presentation.views.company;
 
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Domain.events.EventStatus;
 import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
-import com.ticketing.system.Presentation.components.kit.LkFilterChip;
+import com.ticketing.system.Presentation.components.kit.LkDateRangeField;
 import com.ticketing.system.Presentation.components.kit.LkGrid;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkIconBtn;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
+import com.ticketing.system.Presentation.components.kit.LkSelect;
 import com.ticketing.system.Presentation.components.kit.LkStatusDot;
 import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.presenters.company.CompanyEventListPresenter;
@@ -19,18 +21,28 @@ import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.views.admin.CompanySalesView;
+import com.ticketing.system.Presentation.views.catalog.CatalogFilterSupport;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.confirmdialog.ConfirmDialog;
+import com.vaadin.flow.component.datepicker.DatePicker;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.IntegerField;
+import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 @Route(value = "owner/events", layout = WorkspaceLayout.class)
 @PageTitle("My Events · TicketHub")
@@ -38,11 +50,45 @@ import java.util.Map;
 @RequireCapability(Capability.VIEW_COMPANY_EVENTS)
 public class CompanyEventListView extends LkPage {
 
+    private static final String STATUS_ALL = "All statuses";
+    private static final List<String> STATUS_OPTIONS = List.of(
+            STATUS_ALL, "Draft", "Scheduled", "On sale", "Sold out", "Cancelled", "Completed");
+
     private final CompanyEventListPresenter presenter;
     private final LkCard eventsCard = new LkCard().pad(0);
 
+    // ---- filter state (mirrors /browse, minus company-rating; status is owner-only & client-side) ----
+    private String filterCategory  = CatalogFilterSupport.CAT_ALL;
+    private String filterCountry   = CatalogFilterSupport.COUNTRY_ALL;
+    private String filterCity      = CatalogFilterSupport.CITY_ALL;
+    private String filterArtist    = "";
+    private String filterEventName = "";
+    private String filterKeywords  = "";
+    private String filterDateRange = CatalogFilterSupport.DATE_ANY;
+    private Integer filterPriceMin = null;
+    private Integer filterPriceMax = null;
+    private Double filterMinEventRating = null;
+    private Double filterMaxEventRating = null;
+    private String filterStatus = STATUS_ALL;
 
-        public CompanyEventListView(CompanyEventListPresenter presenter) {
+    // ---- ui references for reset ----
+    private LkSelect categorySelect;
+    private LkSelect countrySelect;
+    private LkSelect citySelect;
+    private LkSelect statusSelect;
+    private LkDateRangeField dateRangeField;
+    private DatePicker customFromPicker;
+    private DatePicker customToPicker;
+    private Div customRangeRow;
+    private TextField eventNameField;
+    private TextField keywordsField;
+    private TextField artistField;
+    private IntegerField priceMin;
+    private IntegerField priceMax;
+    private NumberField eventRatingMin;
+    private NumberField eventRatingMax;
+
+    public CompanyEventListView(CompanyEventListPresenter presenter) {
         this.presenter = presenter;
         title("My Events");
         subtitle("All events under the selected company.");
@@ -69,13 +115,22 @@ public class CompanyEventListView extends LkPage {
             .col("Venue",   "venue")
             .col("Status",  "status")
             .col("Actions", "act", LkGrid.Align.RIGHT);
-        switch (presenter.load(AuthSession.token())) {
+        switch (presenter.load(AuthSession.token(), currentFilters())) {
             case CompanyEventListPresenter.Outcome.Success ok -> {
-                for (EventDetailDTO ev : ok.events()) {
-                    addEventRow(grid, ev);
+                // Status isn't a CatalogSearchFiltersDTO field — apply it client-side on the result.
+                EventStatus wanted = statusValue(filterStatus);
+                List<EventDetailDTO> events = ok.events().stream()
+                    .filter(ev -> wanted == null || ev.status() == wanted)
+                    .toList();
+                if (events.isEmpty()) {
+                    eventsCard.add(Lk.muted("No events match your filters."));
+                } else {
+                    for (EventDetailDTO ev : events) {
+                        addEventRow(grid, ev);
+                    }
+                    grid.build();
+                    eventsCard.add(grid);
                 }
-                grid.build();
-                eventsCard.add(grid);
             }
             case CompanyEventListPresenter.Outcome.NoCompany ignored ->
                 eventsCard.add(Lk.muted("You don't own a company yet."));
@@ -86,17 +141,194 @@ public class CompanyEventListView extends LkPage {
         }
     }
 
+    // ---- filter bar (same controls as /browse minus company-rating, plus an owner-only Status) ----
 
     private Component buildFilters() {
-        LkRow row = new LkRow().gap(8);
-        row.add(
-            new LkFilterChip("Status", List.of("Live", "Selling fast", "Draft", "Sold out", "Cancelled")),
-            new LkFilterChip("Date range", List.of("Any time", "This week", "This month", "Next 3 months", "Past events"), true, List.of()),
-            new LkFilterChip("Venue", List.of(
-                "Park HaYarkon", "Bloomfield Stadium", "Teddy Stadium", "Habima Theatre",
-                "Caesarea Amphitheatre", "TLV Convention Center"))
-        );
-        return row;
+        categorySelect = new LkSelect(CatalogFilterSupport.CAT_ALL, CatalogFilterSupport.CATEGORIES).label("Category");
+        categorySelect.onChange(v -> { if (!Objects.equals(filterCategory, v)) { filterCategory = v; reload(); } });
+
+        eventNameField = textFilter("e.g. Othello", v -> { filterEventName = v; reload(); });
+        keywordsField  = textFilter("Search name or artist", v -> { filterKeywords = v; reload(); });
+        artistField    = textFilter("e.g. Taylor Swift", v -> { filterArtist = v; reload(); });
+
+        dateRangeField = new LkDateRangeField().label("Date range");
+        dateRangeField.onChange(v -> {
+            if (Objects.equals(filterDateRange, v)) return;
+            filterDateRange = v;
+            customRangeRow.setVisible("Custom range".equals(v));
+            if ("Custom range".equals(v)) reloadCustomIfValid();
+            else reload();
+        });
+
+        customFromPicker = new DatePicker();
+        customFromPicker.setPlaceholder("Start date");
+        customFromPicker.addValueChangeListener(e -> { customToPicker.setMin(e.getValue()); reloadCustomIfValid(); });
+        customToPicker = new DatePicker();
+        customToPicker.setPlaceholder("End date");
+        customToPicker.addValueChangeListener(e -> { customFromPicker.setMax(e.getValue()); reloadCustomIfValid(); });
+        customRangeRow = new Div();
+        customRangeRow.getStyle().set("display", "flex").set("gap", "6px");
+        customRangeRow.add(customFromPicker, customToPicker);
+        customRangeRow.setVisible(false);
+
+        priceMin = numberRangeField("Min", v -> { filterPriceMin = v; reload(); });
+        priceMax = numberRangeField("Max", v -> { filterPriceMax = v; reload(); });
+
+        eventRatingMin = ratingField("Min", v -> { filterMinEventRating = v; reload(); });
+        eventRatingMax = ratingField("Max", v -> { filterMaxEventRating = v; reload(); });
+
+        countrySelect = new LkSelect(CatalogFilterSupport.COUNTRY_ALL, CatalogFilterSupport.COUNTRIES).label("Country");
+        countrySelect.onChange(v -> {
+            if (Objects.equals(filterCountry, v)) return;
+            filterCountry = v;
+            filterCity = CatalogFilterSupport.CITY_ALL;
+            citySelect.setOptions(CatalogFilterSupport.cityOptionsFor(v));
+            citySelect.enabled(!CatalogFilterSupport.COUNTRY_ALL.equals(v));
+            reload();
+        });
+        citySelect = new LkSelect(CatalogFilterSupport.CITY_ALL, List.of(CatalogFilterSupport.CITY_ALL)).label("City");
+        citySelect.enabled(false);
+        citySelect.onChange(v -> { if (!Objects.equals(filterCity, v)) { filterCity = v; reload(); } });
+
+        statusSelect = new LkSelect(STATUS_ALL, STATUS_OPTIONS).label("Status");
+        statusSelect.onChange(v -> { if (!Objects.equals(filterStatus, v)) { filterStatus = v; reload(); } });
+
+        LkBtn clear = new LkBtn("Clear").variant(LkBtn.Variant.tertiary).onClick(e -> clearFilters());
+
+        Div bar = new Div();
+        bar.getStyle()
+                .set("display", "flex").set("flex-wrap", "wrap")
+                .set("gap", "12px").set("align-items", "flex-end").set("margin-bottom", "14px");
+        bar.add(
+            categorySelect,
+            labelled("Event name", eventNameField),
+            labelled("Keywords", keywordsField),
+            labelled("Artist", artistField),
+            dateRangeField, customRangeRow,
+            labelled("Price range", priceMin, priceMax),
+            labelled("Event rating", eventRatingMin, eventRatingMax),
+            countrySelect, citySelect, statusSelect,
+            clear);
+        return bar;
+    }
+
+    private void clearFilters() {
+        filterCategory = CatalogFilterSupport.CAT_ALL;
+        filterCountry  = CatalogFilterSupport.COUNTRY_ALL;
+        filterCity     = CatalogFilterSupport.CITY_ALL;
+        filterArtist = "";
+        filterEventName = "";
+        filterKeywords = "";
+        filterDateRange = CatalogFilterSupport.DATE_ANY;
+        filterPriceMin = null;
+        filterPriceMax = null;
+        filterMinEventRating = null;
+        filterMaxEventRating = null;
+        filterStatus = STATUS_ALL;
+
+        categorySelect.setValue(CatalogFilterSupport.CAT_ALL);
+        countrySelect.setValue(CatalogFilterSupport.COUNTRY_ALL);
+        citySelect.setOptions(List.of(CatalogFilterSupport.CITY_ALL));
+        citySelect.enabled(false);
+        statusSelect.setValue(STATUS_ALL);
+        eventNameField.clear();
+        keywordsField.clear();
+        artistField.clear();
+        dateRangeField.setValue(CatalogFilterSupport.DATE_ANY);
+        customRangeRow.setVisible(false);
+        customFromPicker.clear();
+        customToPicker.clear();
+        priceMin.clear();
+        priceMax.clear();
+        eventRatingMin.clear();
+        eventRatingMax.clear();
+        reload();
+    }
+
+    /** Re-query for the custom-range flow only when the picker values aren't inverted. */
+    private void reloadCustomIfValid() {
+        if (!"Custom range".equals(filterDateRange)) return;
+        if (CatalogFilterSupport.isValidCustomRange(customFromPicker.getValue(), customToPicker.getValue()))
+            reload();
+    }
+
+    private CatalogSearchFiltersDTO currentFilters() {
+        LocalDate from, to;
+        if ("Custom range".equals(filterDateRange)) {
+            from = customFromPicker.getValue();
+            to   = customToPicker.getValue();
+        } else {
+            CatalogFilterSupport.DateWindow dw = CatalogFilterSupport.dateWindow(filterDateRange, LocalDate.now());
+            from = dw.from();
+            to   = dw.to();
+        }
+        return new CatalogSearchFiltersDTO(
+                filterEventName.isBlank() ? null : filterEventName,
+                filterArtist.isBlank() ? null : filterArtist,
+                CatalogFilterSupport.categoryFilterValue(filterCategory),
+                filterKeywords.isBlank() ? null : filterKeywords,
+                filterPriceMin == null ? null : filterPriceMin.doubleValue(),
+                filterPriceMax == null ? null : filterPriceMax.doubleValue(),
+                from, to,
+                CatalogFilterSupport.locationFilter(filterCity, filterCountry),
+                filterMinEventRating, filterMaxEventRating,
+                null, null);
+    }
+
+    private static EventStatus statusValue(String label) {
+        return switch (label) {
+            case "Draft"     -> EventStatus.DRAFT;
+            case "Scheduled" -> EventStatus.SCHEDULED;
+            case "On sale"   -> EventStatus.ON_SALE;
+            case "Sold out"  -> EventStatus.SOLD_OUT;
+            case "Cancelled" -> EventStatus.CANCELED;
+            case "Completed" -> EventStatus.COMPLETED;
+            default          -> null; // All statuses
+        };
+    }
+
+    private TextField textFilter(String placeholder, Consumer<String> onChange) {
+        TextField f = new TextField();
+        f.setPlaceholder(placeholder);
+        f.setValueChangeMode(ValueChangeMode.LAZY);
+        f.setWidth("180px");
+        f.addValueChangeListener(e -> onChange.accept(e.getValue() == null ? "" : e.getValue()));
+        return f;
+    }
+
+    private IntegerField numberRangeField(String placeholder, Consumer<Integer> onChange) {
+        IntegerField f = new IntegerField();
+        f.setPlaceholder(placeholder);
+        f.setMin(0);
+        f.setStep(10);
+        f.setPrefixComponent(new Span("$"));
+        f.setValueChangeMode(ValueChangeMode.LAZY);
+        f.setWidth("100px");
+        f.addValueChangeListener(e -> onChange.accept(e.getValue()));
+        return f;
+    }
+
+    private NumberField ratingField(String placeholder, Consumer<Double> onChange) {
+        NumberField f = new NumberField();
+        f.setPlaceholder(placeholder);
+        f.setMin(0);
+        f.setMax(5);
+        f.setStep(0.5);
+        f.setValueChangeMode(ValueChangeMode.LAZY);
+        f.setWidth("90px");
+        f.addValueChangeListener(e -> onChange.accept(e.getValue()));
+        return f;
+    }
+
+    private static Component labelled(String labelText, Component... fields) {
+        Div wrap = new Div();
+        Span label = new Span(labelText);
+        label.addClassName("lk-label");
+        label.getStyle().set("display", "block").set("margin-bottom", "6px").set("font-size", "12.5px");
+        LkRow row = new LkRow().gap(6);
+        row.add(fields);
+        wrap.add(label, row);
+        return wrap;
     }
 
     private void addEventRow(LkGrid grid, EventDetailDTO ev) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -113,6 +113,7 @@ public class CompanyEventListView extends LkPage {
             .col("Event",   "name")
             .col("Date",    "date")
             .col("Venue",   "venue")
+            .col("Rating",  "rating", LkGrid.Align.RIGHT)
             .col("Status",  "status")
             .col("Actions", "act", LkGrid.Align.RIGHT);
         switch (presenter.load(AuthSession.token(), currentFilters())) {
@@ -334,7 +335,7 @@ public class CompanyEventListView extends LkPage {
     private void addEventRow(LkGrid grid, EventDetailDTO ev) {
         Map<String, Object> row = new LinkedHashMap<>();
         Span name = new Span();
-        name.getElement().setProperty("innerHTML", "<b>" + escape(ev.name()) + "</b>");
+        name.getElement().setProperty("innerHTML", nameCellHtml(ev));
         row.put("name", name);
 
         String date = ev.showDates() != null && !ev.showDates().isEmpty()
@@ -343,6 +344,8 @@ public class CompanyEventListView extends LkPage {
 
         String venue = ev.location() != null ? ev.location().toString() : "—";
         row.put("venue", venue);
+
+        row.put("rating", ev.rating() == null ? "—" : "★ " + ratingText(ev.rating()));
 
         LkStatusDot.Tone tone = ev.status() == EventStatus.ON_SALE ? LkStatusDot.Tone.ok
             : ev.status() == EventStatus.DRAFT ? LkStatusDot.Tone.muted
@@ -469,6 +472,21 @@ public class CompanyEventListView extends LkPage {
         LkIconBtn b = new LkIconBtn(new LkIcon(iconName, 15), tooltip);
         b.addClickListener(e -> r.run());
         return b;
+    }
+
+    /** Event name in bold, with the line-up (if any) as a muted second line — matches /browse. */
+    private static String nameCellHtml(EventDetailDTO ev) {
+        String html = "<b>" + escape(ev.name()) + "</b>";
+        if (ev.artistsNames() != null && !ev.artistsNames().isEmpty()) {
+            String lineup = String.join(" · ", ev.artistsNames().stream().map(CompanyEventListView::escape).toList());
+            html += "<div style=\"color:var(--muted);font-size:12.5px;margin-top:2px;\">" + lineup + "</div>";
+        }
+        return html;
+    }
+
+    /** Rating shown without a trailing ".0" (e.g. 4.5 → "4.5", 4.0 → "4"). */
+    private static String ratingText(double rating) {
+        return rating == Math.floor(rating) ? String.valueOf((int) rating) : String.valueOf(rating);
     }
 
     private static String escape(String s) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyOrgTreeView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyOrgTreeView.java
@@ -1,0 +1,81 @@
+package com.ticketing.system.Presentation.views.company;
+
+import com.ticketing.system.Core.Application.dto.OrganizationalTreeNodeDTO;
+import com.ticketing.system.Presentation.components.admin.OrgTreeLegend;
+import com.ticketing.system.Presentation.components.admin.OrgTreeRenderer;
+import com.ticketing.system.Presentation.components.kit.LkBanner;
+import com.ticketing.system.Presentation.components.kit.LkCard;
+import com.ticketing.system.Presentation.components.kit.LkIcon;
+import com.ticketing.system.Presentation.components.kit.LkPage;
+import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
+import com.ticketing.system.Presentation.presenters.admin.OrgTreePresenter;
+import com.ticketing.system.Presentation.security.Capability;
+import com.ticketing.system.Presentation.security.RequireCapability;
+import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.session.CurrentCompanies;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import jakarta.annotation.security.PermitAll;
+
+/**
+ * Owner-workspace view of the current company's organizational tree (founder → owners →
+ * managers). Reuses {@link OrgTreePresenter}'s owner path — scoped to the company in focus
+ * ({@link CurrentCompanies}), falling back to the caller's first owned company — and the shared
+ * {@link OrgTreeRenderer} / {@link OrgTreeLegend}. The admin all-companies variant lives in
+ * {@code OrganizationalTreeView}; a Vaadin view binds to one layout, so the two shells need
+ * separate view classes. Gated by {@link Capability#VIEW_COMPANY_ORG_TREE} (Founder + Co-owner;
+ * managers cannot view it, matching {@code CompanyManagementService.viewOrganizationalTree}).
+ */
+@Route(value = "owner/org-tree", layout = WorkspaceLayout.class)
+@PageTitle("Organizational Tree · Workspace")
+@PermitAll
+@RequireCapability(Capability.VIEW_COMPANY_ORG_TREE)
+public class CompanyOrgTreeView extends LkPage {
+
+    private final OrgTreePresenter presenter;
+    private final Div body = new Div();
+
+    public CompanyOrgTreeView(OrgTreePresenter presenter) {
+        this.presenter = presenter;
+        title("Organizational Tree");
+        subtitle("Your company's founder → owners → managers hierarchy.");
+        add(body);
+        render();
+    }
+
+    private void render() {
+        body.removeAll();
+
+        // Owner path (isAdmin = false): scoped to the workspace's current company, with the
+        // presenter falling back to the first owned company when none is selected.
+        switch (presenter.load(AuthSession.token(), CurrentCompanies.currentCompanyId(), false)) {
+            case OrgTreePresenter.Outcome.NotAuthenticated ignored ->
+                body.add(new LkBanner(LkBanner.Tone.warn, new LkIcon("lock", 16),
+                    "Your session has expired — please sign in again."));
+            case OrgTreePresenter.Outcome.NoCompany ignored ->
+                body.add(new LkBanner(LkBanner.Tone.info, new LkIcon("info", 16),
+                    "You have no owned companies yet."));
+            case OrgTreePresenter.Outcome.Failure fail ->
+                body.add(new LkBanner(LkBanner.Tone.error, new LkIcon("warning", 16),
+                    "Could not load the tree: " + fail.reason()));
+            case OrgTreePresenter.Outcome.Success ok -> {
+                body.add(buildTreeCard(ok.selected().name(), ok.tree()));
+                body.add(buildLegendCard());
+            }
+        }
+    }
+
+    private Component buildTreeCard(String companyName, OrganizationalTreeNodeDTO root) {
+        LkCard card = new LkCard(companyName + " — Appointment Hierarchy").pad(20);
+        card.add(new OrgTreeRenderer(root));
+        return card;
+    }
+
+    private Component buildLegendCard() {
+        LkCard card = new LkCard("Legend").pad(16);
+        card.add(new OrgTreeLegend());
+        return card;
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.select.Select;
+import com.vaadin.flow.component.textfield.NumberField;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.BeforeEnterEvent;
@@ -55,6 +56,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private final LkTextRows artists = new LkTextRows("Artists", "+ Add artist").placeholder("e.g. The Beatles");
     private final DateTimePicker start = new DateTimePicker("Starts");
     private final DateTimePicker end = new DateTimePicker("Ends");
+    private final NumberField rating = new NumberField("Rating (0–5)");
     private final TextArea description = new TextArea("Description");
 
     /** Status badge lives in its own slot so the loader can fill it after the DTO arrives. */
@@ -126,6 +128,9 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             start.setValue(loadedShowDates.get(0).getStartTime());
             end.setValue(loadedShowDates.get(0).getEndTime());
         }
+        // Rating isn't part of EventUpdateDTO (set only at creation) — show it read-only here.
+        rating.setValue(ev.rating());
+        rating.setReadOnly(true);
         description.setValue(ev.description() != null ? ev.description() : "");
         renderStatus(ev.status());
     }
@@ -200,7 +205,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
 
         switch (presenter.create(AuthSession.token(), CurrentCompanies.currentCompanyId(),
                 name, blankToNull(description.getValue()), category.getValue(),
-                co, ci, start.getValue(), end.getValue(), artistList)) {
+                co, ci, start.getValue(), end.getValue(), artistList, rating.getValue())) {
             case EventManagementPresenter.CreateOutcome.Success ok -> {
                 Toasts.success("Event created as a draft — configure the venue map and publish when ready.");
                 UI.getCurrent().navigate("owner/events/" + ok.eventId());
@@ -274,6 +279,11 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         start.setWidthFull();
         end.setWidthFull();
 
+        rating.setMin(0);
+        rating.setMax(5);
+        rating.setStep(0.5);
+        rating.setWidthFull();
+
         description.setMinHeight("120px");
         description.setWidthFull();
 
@@ -282,7 +292,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
                 .set("display", "grid")
                 .set("grid-template-columns", "repeat(auto-fit, minmax(min(100%, 220px), 1fr))")
                 .set("gap", "14px");
-        grid.add(title, category, country, city, start, end);
+        grid.add(title, category, country, city, start, end, rating);
 
         LkCol col = new LkCol().gap(14);
         col.add(grid, artists, description);

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -14,6 +14,7 @@ import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkCol;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
+import com.ticketing.system.Presentation.components.kit.LkTextRows;
 import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.presenters.company.EventManagementPresenter;
 import com.ticketing.system.Presentation.security.Capabilities;
@@ -51,7 +52,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private final Select<String> category = new Select<>();
     private final TextField country = new TextField("Country");
     private final TextField city = new TextField("City");
-    private final TextField artists = new TextField("Artists");
+    private final LkTextRows artists = new LkTextRows("Artists", "+ Add artist").placeholder("e.g. The Beatles");
     private final DateTimePicker start = new DateTimePicker("Starts");
     private final DateTimePicker end = new DateTimePicker("Ends");
     private final TextArea description = new TextArea("Description");
@@ -90,11 +91,11 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             title("Create Event");
             subtitle("Create the event as a draft, then configure its venue and publish it.");
             saveBtn.label("Create Event");
-            artists.setReadOnly(false);
+            artists.readOnly(false);
             // Linked editors, status and the danger zone all act on a persisted event.
             sideCol.setVisible(false);
         } else {
-            artists.setReadOnly(true);
+            artists.readOnly(true);
             loadEvent(eventId);
         }
     }
@@ -115,7 +116,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
     private void applyEvent(EventDetailDTO ev) {
         title.setValue(ev.name() != null ? ev.name() : "");
         category.setValue(ev.category() != null ? ev.category().name() : null);
-        artists.setValue(ev.artistsNames() == null ? "" : String.join(", ", ev.artistsNames()));
+        artists.setValues(ev.artistsNames());
         if (ev.location() != null) {
             country.setValue(ev.location().country() != null ? ev.location().country() : "");
             city.setValue(ev.location().city() != null ? ev.location().city() : "");
@@ -194,7 +195,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             return;
         }
 
-        List<String> artistList = parseArtists(artists.getValue());
+        List<String> artistList = artists.getValues();
         if (artistList.isEmpty()) { Toasts.failure("Please list at least one artist."); return; }
 
         switch (presenter.create(AuthSession.token(), CurrentCompanies.currentCompanyId(),
@@ -213,17 +214,6 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.CreateOutcome.Failure fail ->
                 Toasts.failure("Could not create event: " + fail.reason());
         }
-    }
-
-    /** Split a comma-separated artists field into a trimmed, blank-free list. */
-    private static List<String> parseArtists(String csv) {
-        if (csv == null || csv.isBlank()) {
-            return List.of();
-        }
-        return Arrays.stream(csv.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isBlank())
-                .toList();
     }
 
     /** Location is country+city in the domain; both are required, so only send it when both are present. */
@@ -280,7 +270,6 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         city.setWidthFull();
 
         artists.setWidthFull();
-        artists.setHelperText("Comma-separated");
 
         start.setWidthFull();
         end.setWidthFull();
@@ -293,10 +282,10 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
                 .set("display", "grid")
                 .set("grid-template-columns", "repeat(auto-fit, minmax(min(100%, 220px), 1fr))")
                 .set("gap", "14px");
-        grid.add(title, category, country, city, artists, start, end);
+        grid.add(title, category, country, city, start, end);
 
         LkCol col = new LkCol().gap(14);
-        col.add(grid, description);
+        col.add(grid, artists, description);
         card.add(col);
         return card;
     }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -203,6 +203,8 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         List<String> artistList = artists.getValues();
         if (artistList.isEmpty()) { Toasts.failure("Please list at least one artist."); return; }
 
+        if (rating.getValue() == null) { Toasts.failure("Please set a rating (0–5)."); return; }
+
         switch (presenter.create(AuthSession.token(), CurrentCompanies.currentCompanyId(),
                 name, blankToNull(description.getValue()), category.getValue(),
                 co, ci, start.getValue(), end.getValue(), artistList, rating.getValue())) {
@@ -282,6 +284,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
         rating.setMin(0);
         rating.setMax(5);
         rating.setStep(0.5);
+        rating.setRequiredIndicatorVisible(true);
         rating.setWidthFull();
 
         description.setMinHeight("120px");

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
@@ -122,13 +122,23 @@ public class OwnerDashboardView extends LkPage {
             inquiries.delta("needs reply", LkStat.Tone.warn);
         }
 
+        // Company rating is derived from the average of this company's events' ratings.
+        LkStat rating = new LkStat("Rating",
+            stats.rating() == null ? "—" : "★ " + ratingText(stats.rating()));
+
         row.add(
+            rating,
             new LkStat("Live events",        String.valueOf(stats.activeEvents())),
             new LkStat("Tickets sold · 30d",  String.format("%,d", stats.ticketsSold30d())),
             new LkStat("Revenue · 30d",       "$" + String.format("%,.0f", stats.revenue30d())),
             inquiries
         );
         return row;
+    }
+
+    /** Rating shown without a trailing ".0" (e.g. 4.5 → "4.5", 4.0 → "4"). */
+    private static String ratingText(double rating) {
+        return rating == Math.floor(rating) ? String.valueOf((int) rating) : String.valueOf(rating);
     }
 
     /**

--- a/src/main/resources/scenarios/demo.scenario
+++ b/src/main/resources/scenarios/demo.scenario
@@ -32,9 +32,9 @@ confirm bob live
 open-company carol habima "Habima Theatre" "Israel's national theatre"
 
 # --- events (published, on sale) ---
-add-event alice live   coldplay seated:3x8@220 seated:4x10@140 standing:250@90 name="Coldplay" category=CONCERT days=20 publish=true
-add-event alice live   beyonce  standing:200@320 standing:500@180             name="Beyonce"  category=CONCERT days=35 publish=true
-add-event carol habima othello  seated:4x10@200 seated:3x10@130               name="Othello"  category=THEATER days=14 publish=true
+add-event alice live   coldplay seated:3x8@220 seated:4x10@140 standing:250@90 name="Coldplay" category=CONCERT days=20 rating=4.8 publish=true
+add-event alice live   beyonce  standing:200@320 standing:500@180             name="Beyonce"  category=CONCERT days=35 rating=4.9 publish=true
+add-event carol habima othello  seated:4x10@200 seated:3x10@130               name="Othello"  category=THEATER days=14 rating=4.6 publish=true
 
 # --- purchases: member standing, member seated, and a guest ---
 reserve carol coldplay standing qty=2

--- a/src/main/resources/scenarios/demo.scenario
+++ b/src/main/resources/scenarios/demo.scenario
@@ -48,20 +48,20 @@ checkout g1 email=g1@guest.demo.test age=27
 reserve erin coldplay standing qty=2
 
 # --- sold-out: a one-zone event bought out entirely, then asserted SOLD_OUT ---
-add-event alice live indie standing:6@80 name="Indie Night" category=CONCERT days=25 publish=true
+add-event alice live indie standing:6@80 name="Indie Night" category=CONCERT days=25 rating=4.3 publish=true
 reserve dave indie standing qty=6
 checkout dave
 assert-status indie SOLD_OUT by=alice
 
 # --- cancellation + refund: a buyer, then cancel, then asserted CANCELED ---
-add-event carol habima gala standing:50@150 name="Postponed Gala" category=OTHER days=30 publish=true
+add-event carol habima gala standing:50@150 name="Postponed Gala" category=OTHER days=30 rating=4.0 publish=true
 reserve carol gala standing qty=2
 checkout carol
 cancel-event carol gala
 assert-status gala CANCELED by=carol
 
 # --- negative check: reserving on an unpublished (SCHEDULED) event must fail ---
-add-event alice live draft standing:100@100 name="Not On Sale Yet" days=40
+add-event alice live draft standing:100@100 name="Not On Sale Yet" days=40 rating=4.2
 expect-error reserve carol draft standing qty=1
 
 # --- messaging (centralized Conversation aggregate) ---

--- a/src/main/resources/scenarios/review.scenario
+++ b/src/main/resources/scenarios/review.scenario
@@ -75,7 +75,7 @@ confirm u3 p1
 
 # 10. u2 adds event e1 to p1: a standing zone of 30 tickets @ 50,
 #     and a seated zone of 100 tickets (10x10) @ 100
-add-event u2 p1 e1 standing:30@50 seated:10x10@100 name="e1"
+add-event u2 p1 e1 standing:30@50 seated:10x10@100 name="e1" rating=4.5
 
 # 11. u2 adds a 20% company-wide coupon, code "sale123"
 #     -> SKIPPED: coupons are out of scope in this system (no discount feature).

--- a/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
@@ -12,55 +12,55 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for the pure filter-mapping helpers of {@link BrowseEventsView} (#271) — the UI
- * category label → enum-name mapping and the date-range preset → concrete window. Lives in the
- * view's package to reach the package-private static helpers; needs no Vaadin/Spring.
+ * Unit tests for the pure filter-mapping helpers of {@link CatalogFilterSupport} (#271) — the UI
+ * category label → enum-name mapping and the date-range preset → concrete window. Shared by the
+ * browse and owner event-list filters; needs no Vaadin/Spring.
  */
 class BrowseEventsFilterTest {
 
     @Test
     void categoryFilterValue_mapsLabelsToEnumNames() {
-        assertEquals("CONCERT",  BrowseEventsView.categoryFilterValue("Concerts"));
-        assertEquals("SPORTS",   BrowseEventsView.categoryFilterValue("Sports"));
-        assertEquals("THEATER",  BrowseEventsView.categoryFilterValue("Theatre"));
-        assertEquals("FESTIVAL", BrowseEventsView.categoryFilterValue("Festivals"));
-        assertEquals("COMEDY",   BrowseEventsView.categoryFilterValue("Comedy"));
+        assertEquals("CONCERT",  CatalogFilterSupport.categoryFilterValue("Concerts"));
+        assertEquals("SPORTS",   CatalogFilterSupport.categoryFilterValue("Sports"));
+        assertEquals("THEATER",  CatalogFilterSupport.categoryFilterValue("Theatre"));
+        assertEquals("FESTIVAL", CatalogFilterSupport.categoryFilterValue("Festivals"));
+        assertEquals("COMEDY",   CatalogFilterSupport.categoryFilterValue("Comedy"));
     }
 
     @Test
     void categoryFilterValue_allOrUnknownOrNull_isNull() {
-        assertNull(BrowseEventsView.categoryFilterValue("All categories"));
-        assertNull(BrowseEventsView.categoryFilterValue("Nonsense"));
-        assertNull(BrowseEventsView.categoryFilterValue(null));
+        assertNull(CatalogFilterSupport.categoryFilterValue("All categories"));
+        assertNull(CatalogFilterSupport.categoryFilterValue("Nonsense"));
+        assertNull(CatalogFilterSupport.categoryFilterValue(null));
     }
 
     @Test
     void dateWindow_anyTimeOrNull_isOpen() {
-        assertEquals(new BrowseEventsView.DateWindow(null, null),
-                BrowseEventsView.dateWindow("Any time", LocalDate.of(2026, 6, 24)));
-        assertEquals(new BrowseEventsView.DateWindow(null, null),
-                BrowseEventsView.dateWindow(null, LocalDate.of(2026, 6, 24)));
+        assertEquals(new CatalogFilterSupport.DateWindow(null, null),
+                CatalogFilterSupport.dateWindow("Any time", LocalDate.of(2026, 6, 24)));
+        assertEquals(new CatalogFilterSupport.DateWindow(null, null),
+                CatalogFilterSupport.dateWindow(null, LocalDate.of(2026, 6, 24)));
     }
 
     @Test
     void dateWindow_relativePresets_resolveAgainstToday() {
         LocalDate today = LocalDate.of(2026, 6, 24);
-        assertEquals(new BrowseEventsView.DateWindow(today, today),
-                BrowseEventsView.dateWindow("Today", today));
-        assertEquals(new BrowseEventsView.DateWindow(today, today.plusDays(7)),
-                BrowseEventsView.dateWindow("Next 7 days", today));
-        assertEquals(new BrowseEventsView.DateWindow(today, today.plusDays(30)),
-                BrowseEventsView.dateWindow("Next 30 days", today));
-        assertEquals(new BrowseEventsView.DateWindow(today, today.plusMonths(3)),
-                BrowseEventsView.dateWindow("Next 3 months", today));
-        assertEquals(new BrowseEventsView.DateWindow(today, LocalDate.of(2026, 6, 30)),
-                BrowseEventsView.dateWindow("This month", today));
+        assertEquals(new CatalogFilterSupport.DateWindow(today, today),
+                CatalogFilterSupport.dateWindow("Today", today));
+        assertEquals(new CatalogFilterSupport.DateWindow(today, today.plusDays(7)),
+                CatalogFilterSupport.dateWindow("Next 7 days", today));
+        assertEquals(new CatalogFilterSupport.DateWindow(today, today.plusDays(30)),
+                CatalogFilterSupport.dateWindow("Next 30 days", today));
+        assertEquals(new CatalogFilterSupport.DateWindow(today, today.plusMonths(3)),
+                CatalogFilterSupport.dateWindow("Next 3 months", today));
+        assertEquals(new CatalogFilterSupport.DateWindow(today, LocalDate.of(2026, 6, 30)),
+                CatalogFilterSupport.dateWindow("This month", today));
     }
 
     @Test
     void dateWindow_thisWeekend_isUpcomingSaturdayToSunday() {
         LocalDate today = LocalDate.of(2026, 6, 24); // a Wednesday
-        BrowseEventsView.DateWindow w = BrowseEventsView.dateWindow("This weekend", today);
+        CatalogFilterSupport.DateWindow w = CatalogFilterSupport.dateWindow("This weekend", today);
         assertEquals(DayOfWeek.SATURDAY, w.from().getDayOfWeek());
         assertEquals(w.from().plusDays(1), w.to());          // Saturday → Sunday
         assertFalse(w.from().isBefore(today));               // upcoming, not in the past
@@ -70,38 +70,38 @@ class BrowseEventsFilterTest {
     void dateWindow_customRange_isOpenBounds() {
         // "Custom range" falls through to the default case — the view reads the
         // DatePicker values directly instead of using dateWindow().
-        assertEquals(new BrowseEventsView.DateWindow(null, null),
-                BrowseEventsView.dateWindow("Custom range", LocalDate.of(2026, 6, 24)));
+        assertEquals(new CatalogFilterSupport.DateWindow(null, null),
+                CatalogFilterSupport.dateWindow("Custom range", LocalDate.of(2026, 6, 24)));
     }
 
     // ── locationFilter ────────────────────────────────────────────────────────
 
     @Test
     void locationFilter_citySelected_returnsCity() {
-        assertEquals("Tel Aviv", BrowseEventsView.locationFilter("Tel Aviv", "Israel"));
+        assertEquals("Tel Aviv", CatalogFilterSupport.locationFilter("Tel Aviv", "Israel"));
     }
 
     @Test
     void locationFilter_citySelectedIgnoresCountry() {
         // city takes priority — country is redundant once city is known
-        assertEquals("Tel Aviv", BrowseEventsView.locationFilter("Tel Aviv", "All countries"));
+        assertEquals("Tel Aviv", CatalogFilterSupport.locationFilter("Tel Aviv", "All countries"));
     }
 
     @Test
     void locationFilter_onlyCountrySelected_returnsCountry() {
-        assertEquals("Israel", BrowseEventsView.locationFilter("All cities", "Israel"));
+        assertEquals("Israel", CatalogFilterSupport.locationFilter("All cities", "Israel"));
     }
 
     @Test
     void locationFilter_nothingSelected_returnsNull() {
-        assertNull(BrowseEventsView.locationFilter("All cities", "All countries"));
+        assertNull(CatalogFilterSupport.locationFilter("All cities", "All countries"));
     }
 
     // ── cityOptionsFor ────────────────────────────────────────────────────────
 
     @Test
     void cityOptionsFor_knownCountry_prependsAllCities() {
-        List<String> opts = BrowseEventsView.cityOptionsFor("Israel");
+        List<String> opts = CatalogFilterSupport.cityOptionsFor("Israel");
         assertEquals("All cities", opts.get(0));
         assertTrue(opts.contains("Tel Aviv"));
         assertTrue(opts.contains("Jerusalem"));
@@ -110,37 +110,37 @@ class BrowseEventsFilterTest {
 
     @Test
     void cityOptionsFor_unknownCountry_returnsOnlyAllCities() {
-        assertEquals(List.of("All cities"), BrowseEventsView.cityOptionsFor("Mars"));
+        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptionsFor("Mars"));
     }
 
     @Test
     void cityOptionsFor_allCountries_returnsOnlyAllCities() {
-        assertEquals(List.of("All cities"), BrowseEventsView.cityOptionsFor("All countries"));
+        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptionsFor("All countries"));
     }
 
     // ── isValidCustomRange ────────────────────────────────────────────────────
 
     @Test
     void isValidCustomRange_fromBeforeTo_isValid() {
-        assertTrue(BrowseEventsView.isValidCustomRange(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30)));
+        assertTrue(CatalogFilterSupport.isValidCustomRange(LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30)));
     }
 
     @Test
     void isValidCustomRange_sameDay_isValid() {
         LocalDate day = LocalDate.of(2026, 6, 15);
-        assertTrue(BrowseEventsView.isValidCustomRange(day, day));
+        assertTrue(CatalogFilterSupport.isValidCustomRange(day, day));
     }
 
     @Test
     void isValidCustomRange_fromAfterTo_isInvalid() {
-        assertFalse(BrowseEventsView.isValidCustomRange(LocalDate.of(2026, 6, 30), LocalDate.of(2026, 6, 1)));
+        assertFalse(CatalogFilterSupport.isValidCustomRange(LocalDate.of(2026, 6, 30), LocalDate.of(2026, 6, 1)));
     }
 
     @Test
     void isValidCustomRange_openBounds_areValid() {
         // a single open-ended bound (or none) is a legitimate query, not an inversion
-        assertTrue(BrowseEventsView.isValidCustomRange(null, LocalDate.of(2026, 6, 1)));
-        assertTrue(BrowseEventsView.isValidCustomRange(LocalDate.of(2026, 6, 1), null));
-        assertTrue(BrowseEventsView.isValidCustomRange(null, null));
+        assertTrue(CatalogFilterSupport.isValidCustomRange(null, LocalDate.of(2026, 6, 1)));
+        assertTrue(CatalogFilterSupport.isValidCustomRange(LocalDate.of(2026, 6, 1), null));
+        assertTrue(CatalogFilterSupport.isValidCustomRange(null, null));
     }
 }

--- a/src/test/java/com/ticketing/system/integration/AdminSessionPersistenceJpaTest.java
+++ b/src/test/java/com/ticketing/system/integration/AdminSessionPersistenceJpaTest.java
@@ -1,0 +1,58 @@
+package com.ticketing.system.integration;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.interfaces.ISessionManager;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.users.ISessionRepository;
+
+/**
+ * Regression test for the admin "session expired" bug: {@code AuthenticationService.signInAsAdmin}
+ * persists a brand-new {@code Session} row (via {@code generateAdminToken}). It was annotated
+ * {@code @Transactional(readOnly = true)}, so under the {@code jpa} profile Hibernate's MANUAL
+ * flush mode discarded the assigned-id INSERT — the row was never written and every admin token
+ * then failed validation as "session not found", stranding admins on every admin page.
+ *
+ * <p>This runs under {@code {"test", "jpa"}} on purpose: {@code jpa} swaps in the real
+ * {@link com.ticketing.system.Infrastructure.persistence.SessionPersistence.JpaSessionRepository}
+ * (the in-memory repo used by the rest of the suite has no flush semantics, which is exactly why
+ * the bug slipped through), while {@code test} keeps the in-process external-service stubs and the
+ * H2 datasource. Fails before the {@code @Transactional} fix, passes after.
+ */
+@SpringBootTest
+@ActiveProfiles({"test", "jpa"})
+class AdminSessionPersistenceJpaTest {
+
+    @Autowired
+    private AuthenticationService authService;
+    @Autowired
+    private SystemAdminService systemAdminService;
+    @Autowired
+    private ISessionManager sessionManager;
+    @Autowired
+    private ISessionRepository sessionRepository;
+
+    @Test
+    void adminSignIn_persistsSessionRow_soTheTokenValidates() {
+        // PlatformInitializationRunner is @Profile("!test"), so seed the default admin explicitly
+        // (admin/admin from platform.admin.* in application.yml), as acceptance tests do.
+        systemAdminService.createDefaultAdminIfMissing();
+
+        AuthTokenDTO token = authService.signInAsAdmin("admin", "admin");
+        assertNotNull(token.token());
+
+        // The admin Session row must have been flushed: its token validates and the row is findable.
+        assertTrue(authService.validateToken(token.token()),
+                "admin token must validate — its backing Session row must be persisted under jpa");
+        assertTrue(sessionRepository.findById(sessionManager.extractSessionId(token.token())).isPresent(),
+                "admin Session row must be persisted (was lost under @Transactional(readOnly=true))");
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
@@ -142,6 +142,11 @@ class CatalogServiceTest {
         when(mockEventRepository.searchONSALE(filters)).thenReturn(List.of(event1, event2));
         when(mockCompanyRepository.getCompanyById(10)).thenReturn(highRated);
         when(mockCompanyRepository.getCompanyById(20)).thenReturn(lowRated);
+        // Company rating is derived from the company's events: 4.5 (>=3.5) vs 2.0 (<3.5).
+        Event company10Event = eventRated(4.5);
+        Event company20Event = eventRated(2.0);
+        when(mockEventRepository.findByCompanyId(10)).thenReturn(List.of(company10Event));
+        when(mockEventRepository.findByCompanyId(20)).thenReturn(List.of(company20Event));
 
         List<EventSummaryDTO> results = catalogService.searchGlobal(VALID_TOKEN, filters);
 
@@ -164,6 +169,11 @@ class CatalogServiceTest {
         when(mockEventRepository.searchONSALE(filters)).thenReturn(List.of(event1, event2));
         when(mockCompanyRepository.getCompanyById(10)).thenReturn(highRated);
         when(mockCompanyRepository.getCompanyById(20)).thenReturn(lowRated);
+        // Company rating is derived from the company's events: 4.5 (>3.0) vs 2.0 (<=3.0).
+        Event company10Event = eventRated(4.5);
+        Event company20Event = eventRated(2.0);
+        when(mockEventRepository.findByCompanyId(10)).thenReturn(List.of(company10Event));
+        when(mockEventRepository.findByCompanyId(20)).thenReturn(List.of(company20Event));
 
         List<EventSummaryDTO> results = catalogService.searchGlobal(VALID_TOKEN, filters);
 
@@ -781,6 +791,13 @@ class CatalogServiceTest {
         when(mockCompany.getRating()).thenReturn(rating);
         when(mockCompany.getStatus()).thenReturn(CompanyStatus.ACTIVE);
         return mockCompany;
+    }
+
+    // A bare event carrying only a rating — company rating is derived from these (CompanyRatings).
+    private Event eventRated(double rating) {
+        Event e = mock(Event.class);
+        when(e.getRating()).thenReturn(rating);
+        return e;
     }
 
     // A fully-stubbed event for getEventDetail tests (mapper reads

--- a/src/test/java/com/ticketing/system/unit/application/CompanyAnalyticsServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CompanyAnalyticsServiceTest.java
@@ -1,6 +1,7 @@
 package com.ticketing.system.unit.application;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -87,6 +88,12 @@ class CompanyAnalyticsServiceTest {
         return c;
     }
 
+    private static Event ratedEvent(Double rating) {
+        Event e = mock(Event.class);
+        when(e.getRating()).thenReturn(rating);
+        return e;
+    }
+
     @Test
     void dashboard_aggregatesLiveCountersForTheCompany() {
         LocalDateTime now = LocalDateTime.now();
@@ -133,6 +140,21 @@ class CompanyAnalyticsServiceTest {
         assertEquals(0, stats.ticketsSold30d());
         assertEquals(0.0, stats.revenue30d());
         assertEquals(0, stats.openInquiries());
+        assertNull(stats.rating()); // no events → no derived rating
+    }
+
+    @Test
+    void dashboard_derivesRatingAsMeanOfCompanyEventRatings() {
+        when(eventRepository.findActiveByCompany(COMPANY_ID)).thenReturn(List.of());
+        when(eventRepository.findIdsByCompany(COMPANY_ID)).thenReturn(List.of());
+        when(conversationRepository.findByCompanyAsCounterparty(COMPANY_ID)).thenReturn(List.of());
+        // Two rated events + one unrated: mean(4.8, 4.9) = 4.85 -> 4.9 (unrated ignored).
+        Event r1 = ratedEvent(4.8);
+        Event r2 = ratedEvent(4.9);
+        Event unrated = ratedEvent(null);
+        when(eventRepository.findByCompanyId(COMPANY_ID)).thenReturn(List.of(r1, r2, unrated));
+
+        assertEquals(4.9, service.dashboard(COMPANY_ID).rating(), 0.0001);
     }
 
 

--- a/src/test/java/com/ticketing/system/unit/application/CompanyRatingsTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CompanyRatingsTest.java
@@ -1,0 +1,42 @@
+package com.ticketing.system.unit.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.services.CompanyRatings;
+import com.ticketing.system.Core.Domain.events.Event;
+
+/** A company's rating is the mean of its events' (non-null) ratings, 1-decimal, or null if none. */
+class CompanyRatingsTest {
+
+    private static Event rated(Double rating) {
+        Event e = mock(Event.class);
+        when(e.getRating()).thenReturn(rating);
+        return e;
+    }
+
+    @Test
+    void averagesNonNullRatings_roundedToOneDecimal() {
+        // (4.8 + 4.9) / 2 = 4.85 -> 4.9
+        assertEquals(4.9, CompanyRatings.fromEvents(List.of(rated(4.8), rated(4.9))), 0.0001);
+    }
+
+    @Test
+    void ignoresUnratedEvents() {
+        assertEquals(4.6, CompanyRatings.fromEvents(Arrays.asList(rated(4.6), rated(null))), 0.0001);
+    }
+
+    @Test
+    void nullWhenNoRatedEventsOrEmptyOrNull() {
+        assertNull(CompanyRatings.fromEvents(List.of(rated(null))));
+        assertNull(CompanyRatings.fromEvents(List.of()));
+        assertNull(CompanyRatings.fromEvents(null));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -694,7 +695,7 @@ class EventManagementServiceTest {
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
                 when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
                 when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
-                when(mockEventRepo.findByCompanyId(COMPANY_ID)).thenReturn(List.of(event));
+                when(mockEventRepo.searchByCompanyAll(eq(COMPANY_ID), any())).thenReturn(List.of(event));
 
                 List<EventDetailDTO> result = eventService.listEventsForCompany(OWNER_TOKEN, COMPANY_ID);
 
@@ -720,7 +721,7 @@ class EventManagementServiceTest {
                 when(sessionManager.extractUserId(OWNER_TOKEN)).thenReturn(OWNER_ID);
                 when(userRepository.getUserById(OWNER_ID)).thenReturn(ownerUser);
                 when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
-                when(mockEventRepo.findByCompanyId(COMPANY_ID)).thenReturn(List.of());
+                when(mockEventRepo.searchByCompanyAll(eq(COMPANY_ID), any())).thenReturn(List.of());
 
                 List<EventDetailDTO> result = eventService.listEventsForCompany(OWNER_TOKEN, COMPANY_ID);
 

--- a/src/test/java/com/ticketing/system/unit/domain/EventTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/EventTest.java
@@ -1,7 +1,9 @@
 package com.ticketing.system.unit.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -479,7 +481,111 @@ class EventTest extends BaseDomainTest {
         assertEquals(0, standingZone.getSoldAmount());
     }
 
+    // -- hasFinishedAsOf (auto-completion predicate) ---------------------
+
+    // Drives the completion sweeper: true once `now` is strictly past the last show's end.
+    @Test
+    void GivenSingleShow_WhenHasFinishedAsOf_ThenStrictlyAfterEndTime() {
+        LocalDateTime end = LocalDateTime.now().plusDays(10);
+        Event e = eventWithShowDates(List.of(new ShowDate(end.minusHours(2), end)));
+
+        assertFalse(e.hasFinishedAsOf(end.minusSeconds(1)), "before the show ends");
+        assertFalse(e.hasFinishedAsOf(end), "exactly at the end is not yet past (strict isAfter)");
+        assertTrue(e.hasFinishedAsOf(end.plusSeconds(1)), "after the show ends");
+    }
+
+    // A multi-leg event is finished only after its LATEST leg ends — uses max(endTime),
+    // not the first/last element of the list. The earlier-ending leg is placed last to
+    // expose any "use the last element" bug.
+    @Test
+    void GivenMultiShow_WhenHasFinishedAsOf_ThenUsesLatestEnd() {
+        LocalDateTime lastEnd = LocalDateTime.now().plusDays(20);
+        LocalDateTime earlierEnd = LocalDateTime.now().plusDays(10);
+        Event e = eventWithShowDates(List.of(
+                new ShowDate(lastEnd.minusHours(2), lastEnd),
+                new ShowDate(earlierEnd.minusHours(2), earlierEnd)));
+
+        // Past the earlier leg but before the latest leg → not finished.
+        assertFalse(e.hasFinishedAsOf(earlierEnd.plusDays(1)));
+        // Past the latest leg → finished.
+        assertTrue(e.hasFinishedAsOf(lastEnd.plusSeconds(1)));
+    }
+
+    // -- ON_SALE / SOLD_OUT -> COMPLETED transition ----------------------
+
+    @Test
+    void GivenOnSaleEvent_WhenTransitionToCompleted_ThenCompleted() {
+        Event event = createEventWithZones(List.of(track(new StandingZone(1, "General", 5, 50.0))));
+        event.transitionToOnSale();
+
+        event.transitionToCompleted();
+
+        assertEquals(EventStatus.COMPLETED, event.getStatus());
+    }
+
+    @Test
+    void GivenSoldOutEvent_WhenTransitionToCompleted_ThenCompleted() {
+        StandingZone zone = track(new StandingZone(1, "General", 2, 50.0));
+        Event event = createEventWithZones(List.of(zone));
+        event.transitionToOnSale();
+        event.reserveInventory(1, InventorySelection.standing(2)); // exhaust inventory -> SOLD_OUT
+        assertEquals(EventStatus.SOLD_OUT, event.getStatus());
+
+        event.transitionToCompleted();
+
+        assertEquals(EventStatus.COMPLETED, event.getStatus());
+    }
+
+    @Test
+    void GivenCompletedEvent_WhenTransitionToCompletedAgain_ThenIdempotent() {
+        Event event = createEventWithZones(List.of(track(new StandingZone(1, "General", 5, 50.0))));
+        event.transitionToOnSale();
+        event.transitionToCompleted();
+
+        event.transitionToCompleted(); // no throw
+
+        assertEquals(EventStatus.COMPLETED, event.getStatus());
+    }
+
+    @Test
+    void GivenScheduledEvent_WhenTransitionToCompleted_ThenThrows() {
+        Event event = createEventWithZones(List.of(track(new StandingZone(1, "General", 5, 50.0))));
+
+        assertThrows(IllegalStateException.class, event::transitionToCompleted);
+    }
+
+    @Test
+    void GivenDraftEvent_WhenTransitionToCompleted_ThenThrows() {
+        Event event = createDraftEvent();
+
+        assertThrows(IllegalStateException.class, event::transitionToCompleted);
+    }
+
+    @Test
+    void GivenCanceledEvent_WhenTransitionToCompleted_ThenThrows() {
+        Event event = createEventWithZones(List.of(track(new StandingZone(1, "General", 5, 50.0))));
+        event.transitionToOnSale();
+        event.transitionToCanceled("done");
+
+        assertThrows(IllegalStateException.class, event::transitionToCompleted);
+    }
+
     // test helper functions:
+
+    private Event eventWithShowDates(List<ShowDate> showDates) {
+        return track(new Event(
+                EVENT_ID,
+                "Concert",
+                4.5,
+                ARTISTS,
+                EventCategory.CONCERT,
+                COMPANY_ID,
+                EventStatus.ON_SALE,
+                new VenueMap(1, LOCATION, List.of(track(new StandingZone(ZONE_ID, "VIP", 10, 100)))),
+                showDates,
+                acceptingPurchasePolicy(),
+                noDiscountPolicy()));
+    }
 
     private PurchasePolicy acceptingPurchasePolicy() {
         return new NoPurchasePolicy();

--- a/src/test/java/com/ticketing/system/unit/domain/NotificationTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/NotificationTest.java
@@ -1,24 +1,49 @@
 package com.ticketing.system.unit.domain;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
+import com.ticketing.system.Core.Domain.notifications.Notification;
+import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
+import com.ticketing.system.Core.Domain.notifications.NotificationType;
 import com.ticketing.system.support.BaseDomainTest;
 
 // Unit tests for the Notification aggregate (UC-35/36/37).
-// Extends BaseDomainTest so future (currently @Disabled) tests get automatic
-// invariant verification via track(aggregate).
+// Extends BaseDomainTest so each tracked aggregate gets automatic
+// invariant verification via track(aggregate) after the test runs.
 class NotificationTest extends BaseDomainTest {
 
-    @Test
-    @Disabled("V1: markSent transitions PENDING -> SENT (UC-37)")
-    void givenPendingNotification_whenMarkSent_thenStatusSent() {}
+    /** A freshly-built PENDING notification, tracked for post-test invariant checks. */
+    private Notification pending() {
+        return track(new Notification(
+                "n1", 7, NotificationType.PURCHASE_CONFIRMED,
+                NotificationStatus.PENDING, "Your purchase is confirmed",
+                LocalDateTime.now()));
+    }
 
     @Test
-    @Disabled("V1: markRead transitions SENT -> READ")
-    void givenSentNotification_whenMarkRead_thenStatusRead() {}
+    void givenPendingNotification_whenMarkSent_thenStatusSent() {
+        Notification n = pending();
+        n.markSent();
+        assertTrue(n.isSent());
+    }
 
     @Test
-    @Disabled("V1: markRead from PENDING is invalid")
-    void givenPendingNotification_whenMarkRead_thenThrows() {}
+    void givenSentNotification_whenMarkRead_thenStatusRead() {
+        Notification n = pending();
+        n.markSent();
+        n.markRead();
+        assertTrue(n.isRead());
+    }
+
+    @Test
+    void givenPendingNotification_whenMarkRead_thenThrows() {
+        Notification n = pending();
+        // markRead requires SENT; from PENDING it must throw before mutating state.
+        assertThrows(IllegalStateException.class, n::markRead);
+    }
 }

--- a/src/test/java/com/ticketing/system/unit/domain/ProductionCompanyTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/ProductionCompanyTest.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.unit.domain;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -72,6 +73,36 @@ class ProductionCompanyTest extends BaseDomainTest {
         @Test
         public void GivenUserIsNotOwner_WhenCheckOwner_ThenThrowException() {
                 assertThrows(UnauthorizedActionException.class, () -> company.checkowner(TARGET_USER_ID));
+        }
+
+        ////////////////////////////////////////////////////////////////// Rating invariant
+
+        @Test
+        public void GivenRatingAboveFive_WhenConstruct_ThenThrowException() {
+                // A throwing constructor produces no object — nothing to track().
+                assertThrows(IllegalStateException.class, () -> new ProductionCompany(
+                                COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 6.0));
+        }
+
+        @Test
+        public void GivenNegativeRating_WhenConstruct_ThenThrowException() {
+                assertThrows(IllegalStateException.class, () -> new ProductionCompany(
+                                COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, -1.0));
+        }
+
+        @Test
+        public void GivenNullRating_WhenConstruct_ThenSucceeds() {
+                // The main-code path (registerCompany) constructs with a null rating — must stay valid.
+                assertDoesNotThrow(() -> track(new ProductionCompany(
+                                COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, null)));
+        }
+
+        @Test
+        public void GivenBoundaryRatings_WhenConstruct_ThenSucceeds() {
+                assertDoesNotThrow(() -> track(new ProductionCompany(
+                                COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 0.0)));
+                assertDoesNotThrow(() -> track(new ProductionCompany(
+                                COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, 5.0)));
         }
 
 }

--- a/src/test/java/com/ticketing/system/unit/domain/ProductionCompanyTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/ProductionCompanyTest.java
@@ -92,7 +92,8 @@ class ProductionCompanyTest extends BaseDomainTest {
 
         @Test
         public void GivenNullRating_WhenConstruct_ThenSucceeds() {
-                // The main-code path (registerCompany) constructs with a null rating — must stay valid.
+                // A null rating models an unrated company (rating is derived, see CompanyRatings); the
+                // constructor invariant must permit it even though registerCompany seeds new companies with 0.0.
                 assertDoesNotThrow(() -> track(new ProductionCompany(
                                 COMPANY_ID, OWNER_ID, COMPANY_1_NAME, CompanyStatus.ACTIVE, COMPANY_1_DESCRIPTION, null)));
         }

--- a/src/test/java/com/ticketing/system/unit/domain/RuntimeInvariantGuardTest.java
+++ b/src/test/java/com/ticketing/system/unit/domain/RuntimeInvariantGuardTest.java
@@ -131,4 +131,16 @@ class RuntimeInvariantGuardTest extends BaseDomainTest {
         // Rolled back: the ticket keeps its original positive id.
         assertEquals(5, ticket.getId());
     }
+
+    @Test
+    void setRating_outOfRange_throwsAndRollsBack() {
+        ProductionCompany company = track(new ProductionCompany(
+                COMPANY_ID, OWNER_ID, "Acme", CompanyStatus.ACTIVE, "desc", 4.5));
+
+        // Rating must stay within 0–5 — an out-of-range value must be rejected.
+        assertThrows(IllegalStateException.class, () -> company.setRating(6.0));
+
+        // Rolled back: the company keeps its original valid rating.
+        assertEquals(4.5, company.getRating());
+    }
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
@@ -302,6 +302,43 @@ public abstract class IEventRepositoryContractTest {
         assertTrue(result.isEmpty());
     }
 
+    // === searchAll — event rating range ===
+
+    @Test
+    void givenEventRatingAtOrAboveMin_whensearchAll_thenReturnsMatchingEvent() {
+        eventRepo.save(buildEvent(1, "Top Rated", 4.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(2, "Low Rated", 2.0, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+
+        List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
+                null, null, null, null, null, null, null, null, null, 4.0, null, null, null));
+
+        assertEquals(1, result.size());
+        assertEquals("Top Rated", result.get(0).getName());
+    }
+
+    @Test
+    void givenEventRatingAboveMax_whensearchAll_thenReturnsEmpty() {
+        eventRepo.save(buildEvent(1, "Top Rated", 4.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+
+        List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
+                null, null, null, null, null, null, null, null, null, null, 4.0, null, null));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void givenEventRatingWithinRange_whensearchAll_thenReturnsOnlyEventInBand() {
+        eventRepo.save(buildEvent(1, "Mid Rated", 3.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(2, "Low Rated", 1.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(3, "Top Rated", 5.0, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+
+        List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
+                null, null, null, null, null, null, null, null, null, 3.0, 4.0, null, null));
+
+        assertEquals(1, result.size());
+        assertEquals("Mid Rated", result.get(0).getName());
+    }
+
     // === searchAll — all-null filters ===
 
     @Test
@@ -313,5 +350,32 @@ public abstract class IEventRepositoryContractTest {
                 null, null, null, null, null, null, null, null, null, null, null, null, null));
 
         assertEquals(2, result.size());
+    }
+
+    // === searchByCompanyAll — company scope (all statuses) + filters ===
+
+    @Test
+    void givenEventsForMultipleCompanies_whenSearchByCompanyAll_thenReturnsOnlyThatCompanyAllStatuses() {
+        eventRepo.save(buildEvent(1, "Draft One", 4.5, 10, EventStatus.DRAFT, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(2, "Live One", 4.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(3, "Other Co", 4.5, 20, EventStatus.ON_SALE, EventCategory.CONCERT));
+
+        List<Event> result = eventRepo.searchByCompanyAll(10, CatalogSearchFiltersDTO.empty());
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(e -> e.getCompanyId() == 10));
+    }
+
+    @Test
+    void givenCompanyEvents_whenSearchByCompanyAllWithNameFilter_thenFiltersWithinThatCompany() {
+        eventRepo.save(buildEvent(1, "Jazz Night", 4.5, 10, EventStatus.DRAFT, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(2, "Rock Show", 4.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(3, "Jazz Night", 4.5, 20, EventStatus.ON_SALE, EventCategory.CONCERT));
+
+        List<Event> result = eventRepo.searchByCompanyAll(10, new CatalogSearchFiltersDTO(
+                "Jazz", null, null, null, null, null, null, null, null, null, null, null, null));
+
+        assertEquals(1, result.size());
+        assertEquals(1, result.get(0).getId());
     }
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/EventCompletionSweeperTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/EventCompletionSweeperTest.java
@@ -1,0 +1,224 @@
+package com.ticketing.system.unit.infrastructure.scheduling;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import com.ticketing.system.Core.Domain.events.DiscountPolicy;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.InventorySelection;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.events.StandingZone;
+import com.ticketing.system.Core.Domain.events.VenueMap;
+import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
+import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
+import com.ticketing.system.Core.Domain.policies.purchase.PurchasePolicy;
+import com.ticketing.system.Infrastructure.scheduling.EventCompletionSweeper;
+
+/**
+ * Drives {@link EventCompletionSweeper#completeFinishedEvents(LocalDateTime)} directly with a
+ * controllable {@code now} (mirrors {@code SessionAndOrderSweeperTest}). Real {@link Event}
+ * aggregates are used so the actual {@code hasFinishedAsOf} / {@code transitionToCompleted}
+ * domain logic is exercised end-to-end; only the repository is mocked.
+ *
+ * <p>{@link ShowDate}'s public ctor forbids past dates, so every event is built with a
+ * future show date and each test picks {@code now} before/after that date to simulate the
+ * show having ended or not.
+ */
+class EventCompletionSweeperTest {
+
+    private static final Instant T0 = Instant.parse("2026-01-01T00:00:00Z");
+    private static final Location LOCATION = new Location("Israel", "Tel Aviv");
+
+    private static final LocalDateTime SHOW_END = LocalDateTime.now().plusDays(10);
+    private static final LocalDateTime AFTER_SHOW = SHOW_END.plusDays(1);
+    private static final LocalDateTime BEFORE_SHOW = LocalDateTime.now();
+
+    private IEventRepository eventRepo;
+    private EventCompletionSweeper sweeper;
+
+    @BeforeEach
+    void setUp() {
+        eventRepo = mock(IEventRepository.class);
+        Clock fixedClock = Clock.fixed(T0, ZoneOffset.UTC);
+        sweeper = new EventCompletionSweeper(eventRepo, fixedClock);
+
+        // Defaults: nothing live.
+        when(eventRepo.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of());
+        when(eventRepo.findByStatus(EventStatus.SOLD_OUT)).thenReturn(List.of());
+    }
+
+    @Test
+    void emptyScan_completesNothing() {
+        int completed = sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        assertEquals(0, completed);
+        verify(eventRepo, never()).lockForUpdate(Mockito.anyInt());
+        verify(eventRepo, never()).save(Mockito.any());
+    }
+
+    @Test
+    void pastOnSaleEvent_isCompletedAndSaved() {
+        Event e = onSaleEvent(1, SHOW_END);
+        when(eventRepo.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+        when(eventRepo.findById(1)).thenReturn(e);
+
+        int completed = sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        assertEquals(1, completed);
+        assertEquals(EventStatus.COMPLETED, e.getStatus());
+        // Mutate only under the lock; release it after saving.
+        InOrder inOrder = Mockito.inOrder(eventRepo);
+        inOrder.verify(eventRepo).lockForUpdate(1);
+        inOrder.verify(eventRepo).save(e);
+        inOrder.verify(eventRepo).unlock(1);
+    }
+
+    @Test
+    void pastSoldOutEvent_isCompletedAndSaved() {
+        Event e = soldOutEvent(2, SHOW_END);
+        when(eventRepo.findByStatus(EventStatus.SOLD_OUT)).thenReturn(List.of(e));
+        when(eventRepo.findById(2)).thenReturn(e);
+
+        int completed = sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        assertEquals(1, completed);
+        assertEquals(EventStatus.COMPLETED, e.getStatus());
+        verify(eventRepo).save(e);
+    }
+
+    @Test
+    void futureEvent_isUntouched() {
+        Event e = onSaleEvent(3, SHOW_END);
+        when(eventRepo.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(e));
+
+        int completed = sweeper.completeFinishedEvents(BEFORE_SHOW);
+
+        assertEquals(0, completed);
+        assertEquals(EventStatus.ON_SALE, e.getStatus());
+        verify(eventRepo, never()).lockForUpdate(3);
+        verify(eventRepo, never()).save(Mockito.any());
+    }
+
+    // Only ON_SALE and SOLD_OUT are scanned — DRAFT/SCHEDULED/CANCELED/COMPLETED are never queried.
+    @Test
+    void onlyLiveStatusesAreScanned() {
+        sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        verify(eventRepo).findByStatus(EventStatus.ON_SALE);
+        verify(eventRepo).findByStatus(EventStatus.SOLD_OUT);
+        verify(eventRepo, never()).findByStatus(EventStatus.DRAFT);
+        verify(eventRepo, never()).findByStatus(EventStatus.SCHEDULED);
+        verify(eventRepo, never()).findByStatus(EventStatus.CANCELED);
+        verify(eventRepo, never()).findByStatus(EventStatus.COMPLETED);
+    }
+
+    // Raced: scanned as ON_SALE, but by the time it's locked the owner has canceled it. The
+    // re-check under the lock skips it — no completion — and the lock is still released.
+    @Test
+    void statusChangedUnderLock_isSkipped() {
+        Event scanned = onSaleEvent(4, SHOW_END);       // looked finished + ON_SALE during the scan
+        Event canceledNow = canceledEvent(4, SHOW_END); // re-read under the lock returns CANCELED
+        when(eventRepo.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(scanned));
+        when(eventRepo.findById(4)).thenReturn(canceledNow);
+
+        int completed = sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        assertEquals(0, completed);
+        assertEquals(EventStatus.CANCELED, canceledNow.getStatus());
+        verify(eventRepo).lockForUpdate(4);
+        verify(eventRepo).unlock(4);
+        verify(eventRepo, never()).save(Mockito.any());
+    }
+
+    // Resilience: an event vanishing between scan and lock is skipped, its lock is still
+    // released, and the rest of the tick proceeds.
+    @Test
+    void vanishedEvent_isSkipped_lockReleased_sweepContinues() {
+        Event gone = onSaleEvent(5, SHOW_END);
+        Event ok = onSaleEvent(6, SHOW_END);
+        when(eventRepo.findByStatus(EventStatus.ON_SALE)).thenReturn(List.of(gone, ok));
+        when(eventRepo.findById(5)).thenThrow(new EventNotFoundException("gone"));
+        when(eventRepo.findById(6)).thenReturn(ok);
+
+        int completed = sweeper.completeFinishedEvents(AFTER_SHOW);
+
+        assertEquals(1, completed);
+        verify(eventRepo).lockForUpdate(5);
+        verify(eventRepo).unlock(5);            // released despite the exception
+        verify(eventRepo, never()).save(gone);
+        assertEquals(EventStatus.COMPLETED, ok.getStatus());
+        verify(eventRepo).save(ok);
+    }
+
+    // -- helpers ---------------------------------------------------------
+
+    private Event onSaleEvent(int id, LocalDateTime showEnd) {
+        return buildEvent(id, EventStatus.ON_SALE, showEnd, 10);
+    }
+
+    private Event soldOutEvent(int id, LocalDateTime showEnd) {
+        Event e = buildEvent(id, EventStatus.ON_SALE, showEnd, 2);
+        e.reserveInventory(1, InventorySelection.standing(2)); // exhaust inventory -> SOLD_OUT
+        assertEquals(EventStatus.SOLD_OUT, e.getStatus());
+        return e;
+    }
+
+    private Event canceledEvent(int id, LocalDateTime showEnd) {
+        Event e = buildEvent(id, EventStatus.ON_SALE, showEnd, 10);
+        e.transitionToCanceled("raced cancel");
+        return e;
+    }
+
+    private Event buildEvent(int id, EventStatus status, LocalDateTime showEnd, int capacity) {
+        StandingZone zone = new StandingZone(1, "General Admission", capacity, 50.0);
+        return new Event(
+                id,
+                "Concert",
+                4.5,
+                List.of("Artist"),
+                EventCategory.CONCERT,
+                100,
+                status,
+                new VenueMap(1, LOCATION, List.of(zone)),
+                List.of(new ShowDate(showEnd.minusHours(2), showEnd)),
+                acceptingPurchasePolicy(),
+                noDiscountPolicy());
+    }
+
+    private PurchasePolicy acceptingPurchasePolicy() {
+        return new NoPurchasePolicy();
+    }
+
+    private DiscountPolicy noDiscountPolicy() {
+        return new DiscountPolicy(0) {
+            @Override
+            public double calculate(int quantity, Double priceAtOneTicketReservation, LocalDateTime now) {
+                return quantity * priceAtOneTicketReservation;
+            }
+
+            @Override
+            public double calculatePriceforoneticket(int quantity, Double priceAtOneTicketReservation,
+                    LocalDateTime now) {
+                return priceAtOneTicketReservation;
+            }
+        };
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/EventCompletionSweeperTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/EventCompletionSweeperTest.java
@@ -49,7 +49,8 @@ class EventCompletionSweeperTest {
 
     private static final LocalDateTime SHOW_END = LocalDateTime.now().plusDays(10);
     private static final LocalDateTime AFTER_SHOW = SHOW_END.plusDays(1);
-    private static final LocalDateTime BEFORE_SHOW = LocalDateTime.now();
+    // Derived from SHOW_END (not a fresh now()) so the ordering BEFORE_SHOW < SHOW_END is explicit and clock-stable.
+    private static final LocalDateTime BEFORE_SHOW = SHOW_END.minusDays(1);
 
     private IEventRepository eventRepo;
     private EventCompletionSweeper sweeper;

--- a/src/test/java/com/ticketing/system/unit/presentation/BrowseEventsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/BrowseEventsPresenterTest.java
@@ -32,7 +32,7 @@ class BrowseEventsPresenterTest {
 
     private static EventSummaryDTO summary() {
         return new EventSummaryDTO(1, "Coldplay", "ON_SALE", 4.8, "Live Nation",
-                "CONCERT", "Tel Aviv, Israel", List.of(), 90.0, 250.0, false);
+                "CONCERT", "Tel Aviv, Israel", List.of(), 90.0, 250.0, false, List.of("Coldplay"));
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.unit.presentation;
 
+import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
@@ -16,6 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,7 +45,7 @@ class CompanyEventListPresenterTest {
     @Test
     void load_nullToken_returnsNotAuthenticated() {
         assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
-                presenter.load(null));
+                presenter.load(null, CatalogSearchFiltersDTO.empty()));
         verifyNoInteractions(eventService, companyService);
     }
 
@@ -52,7 +54,7 @@ class CompanyEventListPresenterTest {
         when(companyService.findOwnedCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad"));
 
         assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
-                presenter.load(TOKEN));
+                presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
     }
 
     @Test
@@ -60,7 +62,7 @@ class CompanyEventListPresenterTest {
         when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
 
         assertInstanceOf(CompanyEventListPresenter.Outcome.NoCompany.class,
-                presenter.load(TOKEN));
+                presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
         verifyNoInteractions(eventService);
     }
 
@@ -68,23 +70,37 @@ class CompanyEventListPresenterTest {
     void load_success_returnsEventsForFirstOwnedCompany() {
         when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         List<EventDetailDTO> events = List.of(event(EVENT_ID, "Gala Night"));
-        when(eventService.listEventsForCompany(TOKEN, COMPANY_ID)).thenReturn(events);
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(events);
 
         CompanyEventListPresenter.Outcome.Success ok =
-                assertInstanceOf(CompanyEventListPresenter.Outcome.Success.class, presenter.load(TOKEN));
+                assertInstanceOf(CompanyEventListPresenter.Outcome.Success.class,
+                        presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
 
         assertEquals(1, ok.events().size());
         assertEquals("Gala Night", ok.events().get(0).name());
     }
 
     @Test
+    void load_passesFiltersThroughToService() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        CatalogSearchFiltersDTO filters = new CatalogSearchFiltersDTO(
+                "Othello", null, null, null, null, null, null, null, null, null, null, null, null);
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), eq(filters))).thenReturn(List.of());
+
+        presenter.load(TOKEN, filters);
+
+        verify(eventService).listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), eq(filters));
+    }
+
+    @Test
     void load_serviceThrowsRuntime_returnsFailure() {
         when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
-        when(eventService.listEventsForCompany(anyString(), anyInt()))
+        when(eventService.listEventsForCompany(anyString(), anyInt(), any()))
                 .thenThrow(new RuntimeException("db error"));
 
         CompanyEventListPresenter.Outcome.Failure fail =
-                assertInstanceOf(CompanyEventListPresenter.Outcome.Failure.class, presenter.load(TOKEN));
+                assertInstanceOf(CompanyEventListPresenter.Outcome.Failure.class,
+                        presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
 
         assertEquals("db error", fail.reason());
     }

--- a/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
@@ -57,6 +57,7 @@ class EventDetailsPresenterTest {
         EventDetailDTO detail = detail();
         when(catalogService.getEventDetail(CRED, EVENT_ID)).thenReturn(detail);
         when(catalogService.getEventVenueMap(CRED, EVENT_ID)).thenReturn(venueMap());
+        when(catalogService.companyRating(10)).thenReturn(4.7); // detail()'s companyId is "10"
 
         EventDetailsPresenter.Outcome outcome = presenter.load(CRED, EVENT_ID);
 
@@ -66,6 +67,7 @@ class EventDetailsPresenterTest {
         assertEquals(1, ok.zones().size());
         assertEquals(4, ok.gridRows());
         assertEquals(4, ok.gridCols());
+        assertEquals(4.7, ok.companyRating(), 0.0001);
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -151,6 +151,17 @@ class EventManagementPresenterTest {
     }
 
     @Test
+    void create_nullRating_returnsInvalidInput() {
+        // Rating is required — a null rating maps to InvalidInput and touches no service.
+        EventManagementPresenter.CreateOutcome outcome = presenter.create(TOKEN, 1, "Gala", "desc",
+                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", futureStart(), futureEnd(),
+                List.of("Headliner"), null);
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.InvalidInput.class, outcome);
+        verifyNoInteractions(companyService, eventService);
+    }
+
+    @Test
     void create_pastShowDate_returnsInvalidInput() {
         when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
 

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -63,7 +63,7 @@ class EventManagementPresenterTest {
     private EventManagementPresenter.CreateOutcome createWith(Integer preferredCompanyId,
                                                              LocalDateTime starts, LocalDateTime ends) {
         return presenter.create(TOKEN, preferredCompanyId, "Gala Night", "A great show",
-                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", starts, ends, List.of("Headliner"));
+                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", starts, ends, List.of("Headliner"), 4.5);
     }
 
     @Test
@@ -113,7 +113,7 @@ class EventManagementPresenterTest {
     void create_nullToken_returnsNotAuthenticated() {
         EventManagementPresenter.CreateOutcome outcome = presenter.create(null, 1, "Gala", "d",
                 EventCategory.COMEDY.name(), "Israel", "Tel Aviv", futureStart(), futureEnd(),
-                List.of("Headliner"));
+                List.of("Headliner"), 4.5);
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.NotAuthenticated.class, outcome);
         verifyNoInteractions(companyService, eventService);
@@ -133,7 +133,18 @@ class EventManagementPresenterTest {
         // Required inputs are validated before any service call, so a null category maps to
         // InvalidInput (not a leaked NPE → Failure) and touches neither service.
         EventManagementPresenter.CreateOutcome outcome = presenter.create(TOKEN, 1, "Gala", "desc",
-                null, "Israel", "Tel Aviv", futureStart(), futureEnd(), List.of("Headliner"));
+                null, "Israel", "Tel Aviv", futureStart(), futureEnd(), List.of("Headliner"), 4.5);
+
+        assertInstanceOf(EventManagementPresenter.CreateOutcome.InvalidInput.class, outcome);
+        verifyNoInteractions(companyService, eventService);
+    }
+
+    @Test
+    void create_ratingOutOfRange_returnsInvalidInput() {
+        // Rating is validated up front (0–5), so a bad value maps to InvalidInput and touches no service.
+        EventManagementPresenter.CreateOutcome outcome = presenter.create(TOKEN, 1, "Gala", "desc",
+                EventCategory.COMEDY.name(), "Israel", "Tel Aviv", futureStart(), futureEnd(),
+                List.of("Headliner"), 6.0);
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.InvalidInput.class, outcome);
         verifyNoInteractions(companyService, eventService);

--- a/src/test/java/com/ticketing/system/unit/presentation/LandingPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/LandingPresenterTest.java
@@ -28,7 +28,7 @@ class LandingPresenterTest {
 
     private static EventSummaryDTO event(int id, String name) {
         return new EventSummaryDTO(id, name, "ON_SALE", 4.5, "Acme", "MUSIC",
-            "Tel Aviv", List.of(), 80.0, 250.0, false);
+            "Tel Aviv", List.of(), 80.0, 250.0, false, List.of(name));
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/LkTextRowsTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/LkTextRowsTest.java
@@ -1,0 +1,112 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Presentation.components.kit.LkBtn;
+import com.ticketing.system.Presentation.components.kit.LkTextRows;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.textfield.TextField;
+
+/**
+ * Unit tests for {@link LkTextRows} — the repeatable add-row text input behind the
+ * event-creation "Artists" field. Constructed headless (no UI), like {@code VaadinSmokeTest}.
+ */
+class LkTextRowsTest {
+
+    @Test
+    void newComponent_startsWithOneEmptyRow_noValues() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+
+        assertEquals(List.of(), rows.getValues());
+        assertEquals(1, textFieldCount(rows), "should start with a single empty row");
+    }
+
+    @Test
+    void setValues_roundTripsInOrder_oneRowEach() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+
+        rows.setValues(List.of("The Beatles", "Pink Floyd", "Queen"));
+
+        assertEquals(List.of("The Beatles", "Pink Floyd", "Queen"), rows.getValues());
+        assertEquals(3, textFieldCount(rows));
+    }
+
+    @Test
+    void getValues_trimsAndDropsBlanks() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+
+        rows.setValues(List.of("The Beatles", "   ", " Pink Floyd ", "", "  Queen"));
+
+        // Mirrors the old comma-split parser: trim each, drop blanks, preserve order.
+        assertEquals(List.of("The Beatles", "Pink Floyd", "Queen"), rows.getValues());
+    }
+
+    @Test
+    void setValues_emptyOrNull_keepsOneEmptyRow_whenEditable() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+
+        rows.setValues(List.of());
+        assertEquals(List.of(), rows.getValues());
+        assertEquals(1, textFieldCount(rows));
+
+        rows.setValues(null);
+        assertEquals(List.of(), rows.getValues());
+        assertEquals(1, textFieldCount(rows));
+    }
+
+    @Test
+    void editable_showsAddButtonAndRemoveControls() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+        rows.setValues(List.of("A", "B"));
+
+        assertTrue(addButtonVisible(rows), "add button visible while editable");
+        assertEquals(2, removeControlCount(rows), "one ✕ remove control per row");
+    }
+
+    @Test
+    void readOnly_hidesAddButtonAndRemoveControls_butStillReportsValues() {
+        LkTextRows rows = new LkTextRows("Artists", "+ Add artist");
+        rows.setValues(List.of("A", "B"));
+
+        rows.readOnly(true);
+
+        assertFalse(addButtonVisible(rows), "add button hidden in read-only mode");
+        assertEquals(0, removeControlCount(rows), "no ✕ remove controls in read-only mode");
+        assertEquals(List.of("A", "B"), rows.getValues(), "values still readable when read-only");
+    }
+
+    // -- helpers: walk the component subtree (no UI/rendering needed) -----
+
+    private static int textFieldCount(Component root) {
+        return descendantsOf(root, TextField.class).size();
+    }
+
+    private static int removeControlCount(Component root) {
+        return (int) descendantsOf(root, Span.class).stream()
+                .filter(s -> "✕".equals(s.getText()))
+                .count();
+    }
+
+    private static boolean addButtonVisible(Component root) {
+        return descendantsOf(root, LkBtn.class).stream().anyMatch(Component::isVisible);
+    }
+
+    private static <T extends Component> List<T> descendantsOf(Component root, Class<T> type) {
+        List<T> out = new ArrayList<>();
+        root.getChildren().forEach(child -> {
+            if (type.isInstance(child)) {
+                out.add(type.cast(child));
+            }
+            out.addAll(descendantsOf(child, type));
+        });
+        return out;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/OwnerDashboardPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/OwnerDashboardPresenterTest.java
@@ -37,7 +37,7 @@ class OwnerDashboardPresenterTest {
     }
 
     private static CompanyDashboardDTO stats() {
-        return new CompanyDashboardDTO(1, 2, 3.0, 4);
+        return new CompanyDashboardDTO(1, 2, 3.0, 4, 4.5);
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -326,7 +326,7 @@ class VaadinSmokeTest {
         MyCompanyDTO company = new MyCompanyDTO(1, "Acme", "Founder");
         when(presenter.loadFor(any(), any())).thenReturn(
             new OwnerDashboardPresenter.Outcome.Success(
-                List.of(company), company, new CompanyDashboardDTO(0, 0, 0.0, 0)));
+                List.of(company), company, new CompanyDashboardDTO(0, 0, 0.0, 0, 4.5)));
         assertDoesNotThrow(() -> new OwnerDashboardView(presenter),
             "OwnerDashboardView failed to construct");
     }

--- a/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VaadinSmokeTest.java
@@ -8,6 +8,7 @@ import com.ticketing.system.Presentation.components.kit.LkConfirm;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkSearchPanel;
 import com.ticketing.system.Presentation.components.kit.LkSideNav;
+import com.ticketing.system.Presentation.components.kit.LkTextRows;
 import com.ticketing.system.Presentation.components.venue.VkQuantitySelector;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatLegend;
@@ -483,6 +484,12 @@ class VaadinSmokeTest {
         assertDoesNotThrow(() -> new LkBtn("Sign in"),    "LkBtn failed");
         assertDoesNotThrow(() -> new LkCard("Card"),      "LkCard failed");
         assertDoesNotThrow(() -> new LkBadge("OK"),       "LkBadge failed");
+        // Repeatable add-row text input (event-creation Artists field).
+        assertDoesNotThrow(() -> {
+            LkTextRows rows = new LkTextRows("Artists", "+ Add artist").placeholder("e.g. The Beatles");
+            rows.setValues(List.of("The Beatles", "Pink Floyd"));
+            rows.readOnly(true);
+        }, "LkTextRows failed");
         // Live top-bar search panel (#281) — debounced input + search-fn callback, no DI needed.
         assertDoesNotThrow(() -> new LkSearchPanel(List.of("Coldplay"), q -> List.of()),
             "live LkSearchPanel failed");


### PR DESCRIPTION
## Summary

General UI fixes and feature work across the admin shell, owner workspace, and buyer catalog. The headline item is a backend auth fix that was silently breaking **every** admin page under the `jpa` profile; the rest is event-rating support, an organizational-tree rework, and notification read-state fixes.

## Admin authentication fix (unblocks all admin pages)

- **Persist the admin session row.** `AuthenticationService.signInAsAdmin` was annotated `@Transactional(readOnly = true)`, but `generateAdminToken` writes a brand-new `Session` row. Under the `jpa` profile a read-only transaction leaves Hibernate in `MANUAL` flush mode, so the assigned-id `INSERT` never flushed — the admin `Session` was never written, and every later request rejected the token as "session not found". The UI surfaced this as **"Your session has expired — please sign in again."** on the Complaint queue, Org tree, and every other admin page. Fixed by making the method read-write `@Transactional` (matching member `login()`).
- **Regression test under `{test, jpa}`.** The default suite runs in-memory (`Memory*Repository`, `@Profile("!jpa")`), where `save` is a map put with no flush semantics, so it masked the bug. `AdminSessionPersistenceJpaTest` signs in as admin under the real `jpa` profile and asserts the token validates and the `Session` row is persisted. It fails before the annotation change and passes after.

## Organizational Tree

- **Admin view reworked to master-detail.** `OrganizationalTreeView` now lists **all** companies on the left; clicking one renders that company's founder → owners → managers hierarchy on the right (replacing the old single-tree + filter-chip dropdown).
- **New owner-workspace page.** Founders and co-owners get an **Organizational Tree** entry in the workspace sidebar (`CompanyOrgTreeView`), scoped to the company in focus. Gated by a new `VIEW_COMPANY_ORG_TREE` capability (owner-only; not manager-grantable). Managers do not see it, matching `CompanyManagementService.viewOrganizationalTree`.
- Extracted a shared `OrgTreeLegend` component so both views render an identical Founder / Owner / Manager key.

## Event ratings

- Every event now carries a rating; the rating is required on create/edit.
- Derived **company rating** (`CompanyRatings`) aggregated from an organizer's event ratings, shown on the event page alongside the organizer name.
- Rating + artist columns on the owner "My Events" list, with browse-catalog and owner-events **filters** by rating.
- Artists are entered as an add-row list (`LkTextRows`) instead of a single comma-separated field.

## Events lifecycle

- **Auto-complete past events.** `EventCompletionSweeper` transitions events whose last show date has passed to the completed state.

## Notifications

- Persist read-state from the admin and owner notification bells (#414).
- Null-safe `markRead`; hide the dead "Mark all read" action on an empty inbox.
- Enabled the `Notification` `markSent` / `markRead` domain tests.

## Verification

- `mvn -B clean verify -Pno-vaadin` is green (1432 tests, 0 failures), including the new `jpa`-profile admin-session regression test.
- The admin auth bug is `jpa`-only; it was verified by running the dev app under the real profile and confirming the Complaint queue and Org tree render without the "session expired" banner.

## Notes for reviewers

The admin auth fix is the one to scrutinize: confirm the read-only → read-write transaction change is the right scope, and that the `{test, jpa}` regression test genuinely guards the flush path.
