### PR TITLE
fix(auth): admin login crashes on a clean DB (disjoint-pool capability lookup)

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
@@ -99,7 +99,12 @@ public final class Capabilities {
         Set<Capability> caps = EnumSet.copyOf(GUEST_BASE);
 
         if (AuthSession.isAdmin()) {
+            // Admins are a SEPARATE pool from members — the admin's id lives in the `admins` table,
+            // not `users`. Return here so we never resolve company memberships for an admin: falling
+            // through to listForUser(userId) -> getUserById(userId) throws UserNotFoundException
+            // whenever no member happens to share that id (always, on a clean DB).
             caps.addAll(ADMIN_BUNDLE);
+            return caps;
         }
 
         if (!AuthSession.isSignedIn()) {


### PR DESCRIPTION
Admin login threw `UserNotFoundException: User not found: 1` on a fresh DB. `Capabilities.forCurrentUser` added the admin bundle but then fell through to `listForUser(userId)` -> `getUserById(userId)` for the admin too. Admins/members are **disjoint pools** (admin id is in `admins`, not `users`), so with no member at that id it crashed. Now returns right after the admin bundle — admins never resolve company memberships; members unaffected. Surfaced on a fresh Supabase DB (masked in dev by the seeder). Full suite green (1388).