### PR TITLE
feat(V3-INIT-01 + V3-DEPLOY-01): Supabase run profile + seeder modes & reset safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ logs/
 
 # settings
 .settings/
+
+# Local Supabase run script — holds the DB password, never commit
+run-supabase.sh
+.env
+.env.*

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -321,7 +321,7 @@ public class AuthenticationService {
      * — disjoint-pool rule), applies the shared lock-after-N policy, audit-logs every failure, and
      * issues an ADMIN-role JWT so the backend admin gate can authorize it.
      */
-    @Transactional(readOnly = true)
+    @Transactional
     public AuthTokenDTO signInAsAdmin(String username, String rawPassword) {
         String lockKey = lockoutKey("a", username);
 

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/JpaRepoCleaner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/JpaRepoCleaner.java
@@ -1,0 +1,85 @@
+package com.ticketing.system.Infrastructure.dev.seed;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ticketing.system.Infrastructure.persistence.ActiveOrderPersistence.SpringDataActiveOrderRepository;
+import com.ticketing.system.Infrastructure.persistence.ConversationPersistence.SpringDataConversationRepository;
+import com.ticketing.system.Infrastructure.persistence.EventPersistence.SpringDataEventRepository;
+import com.ticketing.system.Infrastructure.persistence.NotificationPersistence.SpringDataNotificationRepository;
+import com.ticketing.system.Infrastructure.persistence.OrderReceiptPersistence.SpringDataOrderReceiptRepository;
+import com.ticketing.system.Infrastructure.persistence.ProductionCompanyPersistence.SpringDataProductionCompanyRepository;
+import com.ticketing.system.Infrastructure.persistence.SessionPersistence.SpringDataSessionRepository;
+import com.ticketing.system.Infrastructure.persistence.TicketPersistence.SpringDataTicketRepository;
+import com.ticketing.system.Infrastructure.persistence.UserPersistence.SpringDataUserRepository;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The real database wipe behind {@code seed.mode=wipe}/{@code reset} (#366), active on the
+ * {@code jpa} profile (dev's H2 and the Supabase Postgres alike).
+ *
+ * <p>{@code deleteAll()} per aggregate root removes the root rows and cascades to their owned
+ * sub-tables (venue maps → zones → seats, receipt lines, messages, …). Cross-aggregate references
+ * are by-id (no FK between roots), so the order between roots is irrelevant; it's still written
+ * leaf-first for clarity. Pure JPA — no native SQL — so it behaves identically on H2 and Postgres.
+ *
+ * <p>The {@code admins} table is <strong>deliberately not</strong> cleared: the bootstrap platform
+ * admin is infrastructure (re-created by {@code PlatformInitializationRunner} anyway), and a reset
+ * needs an admin to re-open the market for the reseed's checkouts.
+ *
+ * <p><strong>DESTRUCTIVE.</strong> Only invoked from a {@code wipe}/{@code reset} run, which is
+ * opt-in (default {@code seed.mode=off}) and gated behind an interactive confirmation in the runner.
+ */
+@Component
+@Profile("jpa")
+@Slf4j
+public class JpaRepoCleaner implements RepoCleaner {
+
+    private final SpringDataTicketRepository tickets;
+    private final SpringDataOrderReceiptRepository receipts;
+    private final SpringDataActiveOrderRepository activeOrders;
+    private final SpringDataEventRepository events;
+    private final SpringDataProductionCompanyRepository companies;
+    private final SpringDataConversationRepository conversations;
+    private final SpringDataNotificationRepository notifications;
+    private final SpringDataSessionRepository sessions;
+    private final SpringDataUserRepository users;
+
+    public JpaRepoCleaner(
+            SpringDataTicketRepository tickets,
+            SpringDataOrderReceiptRepository receipts,
+            SpringDataActiveOrderRepository activeOrders,
+            SpringDataEventRepository events,
+            SpringDataProductionCompanyRepository companies,
+            SpringDataConversationRepository conversations,
+            SpringDataNotificationRepository notifications,
+            SpringDataSessionRepository sessions,
+            SpringDataUserRepository users) {
+        this.tickets = tickets;
+        this.receipts = receipts;
+        this.activeOrders = activeOrders;
+        this.events = events;
+        this.companies = companies;
+        this.conversations = conversations;
+        this.notifications = notifications;
+        this.sessions = sessions;
+        this.users = users;
+    }
+
+    @Override
+    @Transactional
+    public void clearAll() {
+        log.warn("seed wipe — deleting all business data from the database (keeping the bootstrap admin)");
+        tickets.deleteAll();
+        receipts.deleteAll();
+        activeOrders.deleteAll();
+        events.deleteAll();
+        companies.deleteAll();
+        conversations.deleteAll();
+        notifications.deleteAll();
+        sessions.deleteAll();
+        users.deleteAll();
+    }
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/MemoryRepoCleaner.java
@@ -45,12 +45,13 @@ import java.util.stream.Stream;
  * {@code seed.mode} reset-safety work, #366). So this cleaner keeps working through the
  * whole Memory→JPA migration without edits.
  *
- * <p>{@code @Profile("dev")} only — never instantiated in production.
+ * <p>{@code @Profile("!jpa")} — active on the in-memory backends (test / default-fast). Under the
+ * {@code jpa} profile (dev / supabase / deploy) {@code JpaRepoCleaner} performs the wipe instead.
  */
 @Component
-@Profile("dev")
+@Profile("!jpa")
 @Slf4j
-public class MemoryRepoCleaner {
+public class MemoryRepoCleaner implements RepoCleaner {
 
     private final List<Object> repositories;
 
@@ -75,6 +76,7 @@ public class MemoryRepoCleaner {
             .toList();
     }
 
+    @Override
     public void clearAll() {
         for (Object repo : repositories) {
             try {

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/RepoCleaner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/RepoCleaner.java
@@ -1,0 +1,13 @@
+package com.ticketing.system.Infrastructure.dev.seed;
+
+/**
+ * Wipes all application data for a {@code seed.mode=wipe}/{@code reset} run (#366).
+ *
+ * <p>One implementation per persistence backend, selected by profile:
+ * {@link MemoryRepoCleaner} ({@code @Profile("!jpa")}) clears the in-memory maps;
+ * {@code JpaRepoCleaner} ({@code @Profile("jpa")}) deletes the rows from the database.
+ * {@code ScenarioRunner} depends only on this interface, so it wipes whichever backend is live.
+ */
+public interface RepoCleaner {
+    void clearAll();
+}

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioRunner.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/seed/scenario/ScenarioRunner.java
@@ -1,5 +1,7 @@
 package com.ticketing.system.Infrastructure.dev.seed.scenario;
 
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Application.services.CatalogService;
 import com.ticketing.system.Core.Application.services.CheckoutService;
@@ -7,55 +9,69 @@ import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Application.services.MessagingService;
 import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Infrastructure.dev.seed.DemoClock;
-import com.ticketing.system.Infrastructure.dev.seed.MemoryRepoCleaner;
+import com.ticketing.system.Infrastructure.dev.seed.RepoCleaner;
 import com.ticketing.system.Infrastructure.dev.seed.SeedHarness;
 import com.ticketing.system.Infrastructure.dev.seed.SeedReport;
 import com.ticketing.system.Presentation.dev.DevUserSeeder;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
- * Initializes the system from an editable scenario file at startup — the
- * config-driven replacement for the old hardcoded {@code DemoDataSeeder}.
- * Reads the file named by {@code seed.scenario}, parses it into operations, and
- * runs each through the real application services via {@link ScenarioOps},
- * classifying every step in a {@link SeedReport} (PASS / SKIPPED / FAIL /
- * BLOCKED) that is logged at the end. Because each line is a real service call,
- * the run doubles as a smoke test — a grader who edits the file and mistypes a
- * step sees exactly which line failed and why.
+ * Boots the system from an editable scenario file (#366). Reads {@code seed.scenario}, parses it, and
+ * runs each line through the real application services via {@link ScenarioOps}, classifying every step
+ * in a {@link SeedReport}. Because each line is a real service call, the run doubles as a smoke test.
  *
- * <p>Properties:
+ * <p>Present on every non-{@code test} profile but <strong>inert by default</strong>
+ * ({@code seed.mode=off}) — it never seeds or wipes prod/cloud unless explicitly asked. Works against
+ * the live database (the {@code jpa} backend), not just the in-memory dev repos.
+ *
+ * <p>{@code seed.mode}:
  * <ul>
- *   <li>{@code seed.scenario} — the file to run (default
- *       {@code classpath:scenarios/demo.scenario}; the TA review scenario is
- *       {@code classpath:scenarios/review.scenario}; a filesystem file works
- *       too: {@code file:/path/to/my.scenario}).</li>
- *   <li>{@code seed.mode} — {@code off} (skip), {@code wipe} (clear repos +
- *       re-seed dev personas, then run), anything else runs the scenario (the
- *       in-memory dev repos start empty each boot).</li>
- *   <li>{@code seed.fail-fast} — {@code true} stops at the first unexpected
- *       error (the partial report is still logged); {@code false} (default)
- *       runs every line and collects failures.</li>
+ *   <li>{@code off} (default) — do nothing.</li>
+ *   <li>{@code reseed} — run the scenario (creates what's missing); opens the market first so the
+ *       scenario's purchases can run.</li>
+ *   <li>{@code wipe} — delete all business data, then stop.</li>
+ *   <li>{@code reset} — {@code wipe} then reseed.</li>
+ *   <li>{@code ask} — interactive startup menu: choose the mode <em>and</em> the scenario on the
+ *       console at boot, then run that choice.</li>
  * </ul>
+ * {@code wipe}/{@code reset} are destructive and gated by an ENV FLAG, not a console prompt: they only
+ * proceed when {@code seed.assume-yes=true} (e.g. {@code SEED_ASSUME_YES=true}); otherwise they log what
+ * would be deleted plus the command to enable it, and refuse. This holds whether the mode came from
+ * {@code SEED_MODE} directly or was chosen in the {@code ask} menu — picking a destructive mode is not by
+ * itself sufficient. The wipe keeps the bootstrap admin (see {@code JpaRepoCleaner}). The {@code ask} menu
+ * reads stdin only to choose mode/scenario; with no terminal it falls back to {@code off} (safe).
+ * {@code seed.fail-fast=true} stops the scenario at the first unexpected error.
  */
 @Component
-@Profile("dev")
+@Profile("!test")
 @Order(2)
 @Slf4j
 public class ScenarioRunner implements ApplicationRunner {
+
+    // Mirrors SystemAdminService.DEFAULT_ADMIN_ID — the bootstrap admin used to open the market.
+    private static final int DEFAULT_ADMIN_ID = 1;
+    private static final List<String> MODES = List.of("off", "reseed", "wipe", "reset");
+    private static final List<String> SCENARIOS = List.of("demo", "review");
 
     private final AuthenticationService authenticationService;
     private final CompanyManagementService companyManagementService;
@@ -65,13 +81,23 @@ public class ScenarioRunner implements ApplicationRunner {
     private final CatalogService catalogService;
     private final MessagingService messagingService;
     private final IUserRepository userRepository;
-    private final MemoryRepoCleaner memoryRepoCleaner;
-    private final DevUserSeeder devUserSeeder;
+    private final RepoCleaner repoCleaner;
+    private final ObjectProvider<DevUserSeeder> devUserSeeder;
+    private final SystemAdminService systemAdminService;
+    private final ISessionManager sessionManager;
     private final ResourceLoader resourceLoader;
+    private final Environment environment;
     private final java.time.Clock clock;
     private final String seedMode;
     private final boolean failFast;
+    private final boolean assumeYes;
     private final String scenarioLocation;
+    private final String adminUsername;
+    private final String datasourceUrl;
+
+    // One reader for the whole interactive session: a fresh BufferedReader per prompt would
+    // discard input the previous one read-ahead and buffered.
+    private BufferedReader consoleReader;
 
     public ScenarioRunner(
             AuthenticationService authenticationService,
@@ -82,13 +108,19 @@ public class ScenarioRunner implements ApplicationRunner {
             CatalogService catalogService,
             MessagingService messagingService,
             IUserRepository userRepository,
-            MemoryRepoCleaner memoryRepoCleaner,
-            DevUserSeeder devUserSeeder,
+            RepoCleaner repoCleaner,
+            ObjectProvider<DevUserSeeder> devUserSeeder,
+            SystemAdminService systemAdminService,
+            ISessionManager sessionManager,
             ResourceLoader resourceLoader,
+            Environment environment,
             java.time.Clock clock,
-            @Value("${seed.mode:idempotent}") String seedMode,
+            @Value("${seed.mode:off}") String seedMode,
             @Value("${seed.fail-fast:false}") boolean failFast,
-            @Value("${seed.scenario:classpath:scenarios/demo.scenario}") String scenarioLocation) {
+            @Value("${seed.assume-yes:false}") boolean assumeYes,
+            @Value("${seed.scenario:classpath:scenarios/demo.scenario}") String scenarioLocation,
+            @Value("${platform.admin.username:admin}") String adminUsername,
+            @Value("${spring.datasource.url:unknown}") String datasourceUrl) {
         this.authenticationService = authenticationService;
         this.companyManagementService = companyManagementService;
         this.eventManagementService = eventManagementService;
@@ -97,42 +129,142 @@ public class ScenarioRunner implements ApplicationRunner {
         this.catalogService = catalogService;
         this.messagingService = messagingService;
         this.userRepository = userRepository;
-        this.memoryRepoCleaner = memoryRepoCleaner;
+        this.repoCleaner = repoCleaner;
         this.devUserSeeder = devUserSeeder;
+        this.systemAdminService = systemAdminService;
+        this.sessionManager = sessionManager;
         this.resourceLoader = resourceLoader;
+        this.environment = environment;
         this.clock = clock;
-        this.seedMode = seedMode == null ? "idempotent" : seedMode.trim().toLowerCase();
+        this.seedMode = seedMode == null ? "off" : seedMode.trim().toLowerCase();
         this.failFast = failFast;
+        this.assumeYes = assumeYes;
         this.scenarioLocation = scenarioLocation;
+        this.adminUsername = adminUsername;
+        this.datasourceUrl = datasourceUrl;
     }
 
     @Override
     public void run(ApplicationArguments args) {
-        switch (seedMode) {
-            case "off" -> log.info("seed.mode=off — scenario init skipped");
-            case "wipe" -> {
-                log.info("seed.mode=wipe — clearing in-memory repositories before init");
-                memoryRepoCleaner.clearAll();
-                devUserSeeder.run(null);   // a wipe nukes dev.member too
-                runScenario();
-            }
-            default -> runScenario();
+        if (seedMode.equals("ask")) {
+            runInteractive();
+        } else {
+            executeMode(seedMode, scenarioLocation);
         }
     }
 
-    private void runScenario() {
+    /** Runs one resolved mode against one scenario. Shared by the config-driven and interactive paths. */
+    private void executeMode(String mode, String scenario) {
+        switch (mode) {
+            case "off" -> log.info("seed.mode=off — no seeding");
+            case "reseed" -> {
+                log.info("seed.mode=reseed — seeding (idempotent)");
+                ensureMarketOpen();
+                runScenario(scenario);
+            }
+            case "wipe" -> {
+                if (destructiveAllowed("wipe")) {
+                    repoCleaner.clearAll();
+                    log.info("seed.mode=wipe — done; database cleared");
+                }
+            }
+            case "reset" -> {
+                if (destructiveAllowed("reset")) {
+                    repoCleaner.clearAll();
+                    ensureMarketOpen();
+                    devUserSeeder.ifAvailable(seeder -> seeder.run(null));
+                    runScenario(scenario);
+                    log.info("seed.mode=reset — done; database wiped and reseeded");
+                }
+            }
+            default -> log.warn("seed.mode='{}' not recognised ({} | ask) — skipping", mode, String.join(" | ", MODES));
+        }
+    }
+
+    /** Interactive startup menu ({@code seed.mode=ask}): pick the mode, then the scenario, then run it. */
+    private void runInteractive() {
+        System.out.println();
+        System.out.println("  === SEEDER — profiles: " + String.join(",", environment.getActiveProfiles())
+                + " — database: " + datasourceUrl + " ===");
+        String mode = askChoice("Mode", MODES, "off");
+        String scenario = scenarioLocation;
+        if (mode.equals("reseed") || mode.equals("reset")) {
+            scenario = "classpath:scenarios/" + askChoice("Scenario", SCENARIOS, "demo") + ".scenario";
+        }
+        executeMode(mode, scenario);
+    }
+
+    /** Prompts with a list of options and a default; returns the lowercased answer, or the default on empty/EOF. */
+    private String askChoice(String label, List<String> options, String dflt) {
+        System.out.println();
+        System.out.println("  " + label + "? " + options + "  [default: " + dflt + "]");
+        System.out.print("  > ");
+        System.out.flush();
+        try {
+            String line = readConsoleLine();
+            if (line == null) {
+                return dflt;
+            }
+            String value = line.trim().toLowerCase();
+            return value.isEmpty() ? dflt : value;
+        } catch (IOException e) {
+            return dflt;
+        }
+    }
+
+    /** Opens the trading market via the real admin path so the scenario's reserve/checkout steps work. */
+    private void ensureMarketOpen() {
+        try {
+            String adminToken = sessionManager.generateAdminToken(DEFAULT_ADMIN_ID, adminUsername);
+            systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "seed auto-open", adminToken));
+            log.info("seed: market opened so seeded purchases can run");
+        } catch (RuntimeException e) {
+            log.warn("seed: could not open the market ({}); the scenario's checkout steps may fail", e.getMessage());
+        }
+    }
+
+    /**
+     * Safety gate before a destructive wipe. The opt-in is an ENV FLAG ({@code seed.assume-yes=true}),
+     * NOT a console prompt — so the gate never depends on stdin reaching the app (which it may not under
+     * a forked {@code spring-boot:run}). Applies identically whether the mode came from {@code SEED_MODE}
+     * directly or from the {@code ask} menu: choosing {@code wipe}/{@code reset} is not enough on its own.
+     * When the flag is unset it logs exactly what would be deleted, the command to enable it, and refuses.
+     */
+    private boolean destructiveAllowed(String mode) {
+        if (assumeYes) {
+            log.warn("seed.mode={} — seed.assume-yes is set; wiping ALL business data (admin kept) from {} (profiles: {})",
+                    mode, datasourceUrl, String.join(",", environment.getActiveProfiles()));
+            return true;
+        }
+        log.warn("seed.mode={} REFUSED — a destructive wipe needs an explicit opt-in (it was not given).", mode);
+        log.warn("  Would DELETE ALL business data (events, users, companies, orders, tickets, messages),");
+        log.warn("  keeping only the platform admin, from:");
+        log.warn("    profiles : {}", String.join(",", environment.getActiveProfiles()));
+        log.warn("    database : {}", datasourceUrl);
+        log.warn("  To proceed, set the flag, e.g.:  SEED_MODE={} SEED_ASSUME_YES=true ./run-supabase.sh", mode);
+        return false;
+    }
+
+    private String readConsoleLine() throws IOException {
+        if (consoleReader == null) {
+            consoleReader = new BufferedReader(new InputStreamReader(System.in));
+        }
+        return consoleReader.readLine();
+    }
+
+    private void runScenario(String scenario) {
         String text;
         try {
-            Resource resource = resourceLoader.getResource(scenarioLocation);
+            Resource resource = resourceLoader.getResource(scenario);
             if (!resource.exists()) {
-                log.error("scenario file not found: {} — nothing seeded", scenarioLocation);
+                log.error("scenario file not found: {} — nothing seeded", scenario);
                 return;
             }
             try (var in = resource.getInputStream()) {
                 text = new String(in.readAllBytes(), StandardCharsets.UTF_8);
             }
         } catch (Exception e) {
-            log.error("could not read scenario file {}: {}", scenarioLocation, e.getMessage(), e);
+            log.error("could not read scenario file {}: {}", scenario, e.getMessage(), e);
             return;
         }
 
@@ -145,7 +277,7 @@ public class ScenarioRunner implements ApplicationRunner {
             reservationService, checkoutService, catalogService, messagingService,
             userRepository, new DemoClock(clock));
 
-        log.info("running scenario '{}' ({} operations)", scenarioLocation, commands.size());
+        log.info("running scenario '{}' ({} operations)", scenario, commands.size());
         try {
             for (ScenarioCommand cmd : commands) {
                 ops.execute(cmd, ctx, harness);
@@ -155,9 +287,9 @@ public class ScenarioRunner implements ApplicationRunner {
         } finally {
             String summary = report.render();
             if (report.hasFailures()) {
-                log.warn("scenario '{}' finished WITH FAILURES — see report below.{}", scenarioLocation, summary);
+                log.warn("scenario '{}' finished WITH FAILURES — see report below.{}", scenario, summary);
             } else {
-                log.info("scenario '{}' finished clean.{}", scenarioLocation, summary);
+                log.info("scenario '{}' finished clean.{}", scenario, summary);
             }
         }
     }

--- a/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
@@ -99,7 +99,12 @@ public final class Capabilities {
         Set<Capability> caps = EnumSet.copyOf(GUEST_BASE);
 
         if (AuthSession.isAdmin()) {
+            // Admins are a SEPARATE pool from members — the admin's id lives in the `admins` table,
+            // not `users`. Return here so we never resolve company memberships for an admin: falling
+            // through to listForUser(userId) -> getUserById(userId) throws UserNotFoundException
+            // whenever no member happens to share that id (always, on a clean DB).
             caps.addAll(ADMIN_BUNDLE);
+            return caps;
         }
 
         if (!AuthSession.isSignedIn()) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,9 +22,11 @@ spring:
 
 # Scenario init (ScenarioRunner) — boots the system from an editable command file.
 #   scenario:  the file to run (classpath:scenarios/*.scenario, or file:/abs/path/to/your.scenario)
-#   mode:      off | wipe (clear repos + re-seed dev personas, then run) | anything else runs it
+#   mode:      off (nothing) | reseed (idempotent) | wipe (clear data) | reset (wipe + reseed)
+#              | ask (interactive menu: pick mode + scenario at boot)
 #   fail-fast: true = stop at the first unexpected error (partial report still logged); false = run all
+# dev's H2 is create-drop (empty every boot), so reseed is the right default here — no wipe needed.
 seed:
   scenario: classpath:scenarios/demo.scenario
-  mode: idempotent
+  mode: reseed
   fail-fast: false

--- a/src/main/resources/application-supabase.yml
+++ b/src/main/resources/application-supabase.yml
@@ -1,0 +1,27 @@
+# Supabase (remote Postgres) run profile — V3 Lane J (#377).
+#
+# Activate with SPRING_PROFILES_ACTIVE=supabase — that auto-activates `jpa` too (see the
+# profiles.group in application.yml), so the Jpa* repositories are wired. Supply the connection
+# entirely via env vars; NEVER commit them:
+#
+#   DB_HOST=aws-1-eu-central-1.pooler.supabase.com   (your project's Session-pooler host)
+#   DB_PORT=5432                                      (Session pooler — NOT the 6543 txn pooler)
+#   DB_NAME=postgres
+#   DB_USER=postgres.<project-ref>
+#   DB_PASSWORD=<your database password>
+#
+# Uses the Supabase Session pooler (IPv4, supports the prepared statements Hibernate needs) over TLS.
+# Many app instances (local + deployed) can point here at once — they share all data, and @Version /
+# the refund FOR UPDATE coordinate across instances because they're enforced in Postgres.
+spring:
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT:5432}/${DB_NAME:postgres}?sslmode=require
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    hikari:
+      # Supabase caps connections (more so when several instances share the DB) — keep each pool small.
+      maximum-pool-size: ${DB_POOL_SIZE:5}
+  jpa:
+    hibernate:
+      # First boot builds the whole schema from the @Entity mappings; later boots only add what's new.
+      ddl-auto: update

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
   profiles:
     group:
       dev: jpa
+      # Running against Supabase: `supabase` activates the JPA stack + the SSL/pooler datasource
+      # (see application-supabase.yml). Run with SPRING_PROFILES_ACTIVE=supabase + the DB_* env vars.
+      supabase: jpa
 
 # JWT signing secret (consumed by Infrastructure/security/JwtSessionManager — UC-12).
 # In production the secret MUST be supplied via environment variable, never committed.

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -56,6 +56,19 @@
         <logger name="com.ticketing.system.Infrastructure.logging" level="DEBUG"/>
     </springProfile>
 
+    <!-- JPA run profiles (supabase / plain `jpa` deploy) — but NOT dev, which has its own block
+         above (dev activates jpa via profiles.group, so the `& !dev` avoids double-logging). Without
+         this, a supabase/jpa run matches no <springProfile> and gets NO appenders at all (silent). -->
+    <springProfile name="jpa &amp; !dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+        <logger name="com.ticketing.system" level="INFO"/>
+        <logger name="com.ticketing.system.Core.Domain" level="WARN"/>
+        <logger name="com.ticketing.system.Infrastructure.logging" level="INFO"/>
+    </springProfile>
+
     <!-- Test profile: DEBUG for our code, console only. -->
     <springProfile name="test">
         <root level="WARN">


### PR DESCRIPTION
Combines two V3 lanes so the seeder can actually populate the live Supabase database.

## #377 — V3-DEPLOY-01: provision Supabase, wire session pooler + SSL
- `application-supabase.yml`: Postgres via the Supabase **session pooler** (`:5432`, IPv4, prepared-statement capable), `sslmode=require`, small Hikari pool, `ddl-auto: update`.
- `supabase` profile group → `jpa`; console+file logging on the supabase/jpa run profile.
- Local `run-supabase.sh` (gitignored — holds DB creds) supplies the env.
- **Verified:** app boots against Supabase, connects over the pooler + TLS, reads/writes Postgres.

## #366 — V3-INIT-01: seeding & reset safety
- Backend-agnostic `RepoCleaner`: `JpaRepoCleaner` (`@Profile("jpa")`, `deleteAll()` per root, **keeps the bootstrap admin**) + `MemoryRepoCleaner` (`@Profile("!jpa")`).
- `ScenarioRunner` now runs on every non-`test` profile, **inert by default** (`seed.mode=off`), with modes:
  - `off` · `reseed` (idempotent) · `wipe` · `reset` (wipe+reseed) · `ask` (interactive boot menu: pick mode **and** scenario).
  - Destructive `wipe`/`reset` are gated by an **env flag** (`SEED_ASSUME_YES=true`), not a stdin prompt — it refuses with guidance when unset, so Supabase/prod data is never wiped by accident. Holds whether the mode came from `SEED_MODE` or the `ask` menu.
- dev defaults to `reseed` (its H2 is create-drop, so a wipe is pointless there).

## Validation
- `./mvnw -o -Pno-vaadin test` — **1397 tests, 0 failures**.
- Dev H2: `off` (clean wiring), `reseed` → **40/40 scenario ops**, `reset` without the flag → refuses (no wipe), `reset` + `SEED_ASSUME_YES=true` → wipes (no SQL error) + reseeds.
- **Supabase Postgres (the goal): reseed propagates real rows** — from an empty DB → users 5, companies 2, events 6, inventory_zones 10, tickets 15, receipts 5, sessions 13, conversations 7, notifications 19.

## Note on overlapping auth commits
This branch also carries two admin-login fixes so it runs standalone (admin login + seeding work on it without waiting on other lanes):
- `b356bf5` make `signInAsAdmin` writable (the admin `Session` write was silently dropped under a read-only tx) — **also addressed in #447**.
- `e9f80ad` skip company-membership resolution for admin principals — **also addressed in #448**.

Both are identical to those PRs' changes and will reconcile cleanly at merge regardless of order.

Closes #366, #377.
