### PR TITLE
fix(ux): clean up user-facing toasts (#451)

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/components/buyer/BzTicketDialog.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/buyer/BzTicketDialog.java
@@ -1,6 +1,5 @@
 package com.ticketing.system.Presentation.components.buyer;
 
-import com.ticketing.system.Presentation.components.Toasts;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -38,14 +37,10 @@ public final class BzTicketDialog {
         d.setMaxWidth("92vw");
         d.add(buildCard(ticket));
 
-        Button download = new Button("Download PDF",
-            e -> Toasts.success("Ticket PDF queued for download (mock)."));
-        download.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
-
         Button close = new Button("Close", e -> d.close());
         close.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
 
-        d.getFooter().add(download, close);
+        d.getFooter().add(close);
         d.open();
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
@@ -185,7 +185,7 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
                     signOutFlow.execute();
                     UI.getCurrent().navigate(LoginView.class);
                 }));
-        return new LkAccountMenu(initials(name), name, "Signed in member · V2-AUTH-02 stub", menu, null, null);
+        return new LkAccountMenu(initials(name), name, "Signed in member", menu, null, null);
     }
 
     private static String findActiveLabel(AfterNavigationEvent event) {

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyInvitationsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyInvitationsView.java
@@ -171,7 +171,7 @@ public class MyInvitationsView extends LkPage {
             case MyInvitationsPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case MyInvitationsPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not accept invitation: " + fail.reason());
+                Toasts.failure("Could not accept the invitation — please try again.");
         }
     }
 
@@ -184,7 +184,7 @@ public class MyInvitationsView extends LkPage {
             case MyInvitationsPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case MyInvitationsPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not decline invitation: " + fail.reason());
+                Toasts.failure("Could not decline the invitation — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
@@ -1,14 +1,11 @@
 package com.ticketing.system.Presentation.views.account;
 
-import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
-import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkCol;
 import com.ticketing.system.Presentation.components.kit.LkField;
 import com.ticketing.system.Presentation.components.kit.LkPage;
-import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.vaadin.flow.component.Component;
@@ -26,14 +23,7 @@ public class MyProfileView extends LkPage {
     public MyProfileView() {
         title("My Profile");
         subtitle("Your account details.");
-        add(buildSplit());
-    }
-
-    private Component buildSplit() {
-        Div split = new Div();
-        split.addClassName("prof-split");
-        split.add(buildProfileCard(), buildSideCol());
-        return split;
+        add(buildProfileCard());
     }
 
     private Component buildProfileCard() {
@@ -58,42 +48,8 @@ public class MyProfileView extends LkPage {
         fields.add(new LkField().label("Email").value("alex.morgan@email.com"));
         fields.add(new LkField().label("Member Since").value("15 Dec 2024"));
 
-        LkRow actions = new LkRow().gap(8);
-        actions.getStyle().set("margin-top", "16px");
-        actions.add(
-            new LkBtn("Edit Profile").variant(LkBtn.Variant.secondary)
-                .onClick(e -> Toasts.warn("Profile editing is exempt in Tier C (II.3.4).")),
-            new LkBtn("Change Password").variant(LkBtn.Variant.tertiary)
-                .onClick(e -> Toasts.warn("Password change wires with V2-AUTH-02."))
-        );
-
-        card.add(idRow, Lk.divider(), fields, actions);
+        card.add(idRow, Lk.divider(), fields);
         return card;
-    }
-
-    private Component buildSideCol() {
-        LkCol col = new LkCol().gap(14);
-
-        LkCard prefs = new LkCard("Preferences").pad(16);
-        LkCol p = new LkCol().gap(8);
-        Span pDesc = Lk.muted("Notifications, language, and privacy settings.");
-        pDesc.getStyle().set("font-size", "13.5px");
-        p.add(pDesc);
-        p.add(new LkBtn("Manage Preferences").variant(LkBtn.Variant.secondary).full()
-            .onClick(e -> Toasts.warn("Preferences screen — wired by V2-MEM-04.")));
-        prefs.add(p);
-
-        LkCard sessions = new LkCard("Sessions").pad(16);
-        LkCol s = new LkCol().gap(8);
-        Span sDesc = new Span("Signed in on 2 devices.");
-        sDesc.getStyle().set("font-size", "13.5px");
-        s.add(sDesc);
-        s.add(new LkBtn("Sign Out Everywhere").variant(LkBtn.Variant.tertiary).full()
-            .onClick(e -> Toasts.warn("Multi-device session control — V2-AUTH-02.")));
-        sessions.add(s);
-
-        col.add(prefs, sessions);
-        return col;
     }
 
     private static String initials(String name) {

--- a/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/ReceiptView.java
@@ -135,9 +135,7 @@ public class ReceiptView extends LkPage implements BeforeEnterObserver {
         actions.add(
                 new LkBtn("Print").variant(LkBtn.Variant.secondary)
                         .icon(new LkIcon("copy", 15))
-                        .onClick(e -> UI.getCurrent().getPage().executeJs("window.print()")),
-                new LkBtn("Email Receipt").variant(LkBtn.Variant.tertiary)
-                        .onClick(e -> Toasts.success("Receipt resent to your account email (mock).")));
+                        .onClick(e -> UI.getCurrent().getPage().executeJs("window.print()")));
         return actions;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
@@ -199,7 +199,7 @@ public class SupportInboxView extends LkPage implements BeforeEnterObserver {
             case SupportInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case SupportInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure("Could not send your reply — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintRespondView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintRespondView.java
@@ -116,7 +116,7 @@ public class AdminComplaintRespondView extends LkPage implements BeforeEnterObse
             case AdminComplaintQueuePresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminComplaintQueuePresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your response: " + fail.reason());
+                Toasts.failure("Could not send your response — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminInboxView.java
@@ -150,7 +150,7 @@ public class AdminInboxView extends LkPage {
             case AdminInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure("Could not send your reply — please try again.");
         }
     }
 
@@ -163,7 +163,7 @@ public class AdminInboxView extends LkPage {
             case AdminInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not close the conversation: " + fail.reason());
+                Toasts.failure("Could not close the conversation — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminSendMessagesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminSendMessagesView.java
@@ -141,7 +141,7 @@ public class AdminSendMessagesView extends LkPage {
             case AdminSendMessagesPresenter.SearchOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminSendMessagesPresenter.SearchOutcome.Failure fail ->
-                Toasts.failure("Could not search members: " + fail.reason());
+                Toasts.failure("Could not search members — please try again.");
         }
     }
 
@@ -198,7 +198,7 @@ public class AdminSendMessagesView extends LkPage {
             case AdminSendMessagesPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminSendMessagesPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send the message: " + fail.reason());
+                Toasts.failure("Could not send the message — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
@@ -3,13 +3,10 @@ package com.ticketing.system.Presentation.views.admin;
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Presentation.components.Money;
-import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
-import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkGrid;
-import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.components.kit.LkStat;
@@ -40,9 +37,6 @@ public class CompanySalesView extends LkPage {
 
     public CompanySalesView(CompanySalesPresenter presenter) {
         title("Company Sales History");
-        actions(new LkBtn("Export CSV").variant(LkBtn.Variant.secondary)
-            .icon(new LkIcon("chart", 15))
-            .onClick(e -> Toasts.success("Export CSV — no streaming endpoint yet.")));
 
         switch (presenter.load(AuthSession.token())) {
             case CompanySalesPresenter.Outcome.Success ok -> {

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/GlobalHistoryView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/GlobalHistoryView.java
@@ -2,14 +2,11 @@ package com.ticketing.system.Presentation.views.admin;
 
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
-import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBadge;
-import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkGrid;
-import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.components.kit.LkStat;
@@ -56,9 +53,6 @@ public class GlobalHistoryView extends LkPage {
 
         title("Global Purchase History");
         subtitle("Every order across the platform — filter by date, company, event, or status.");
-        actions(new LkBtn("Export CSV").variant(LkBtn.Variant.secondary)
-            .icon(new LkIcon("chart", 15))
-            .onClick(e -> Toasts.success("Global history exported (mock).")));
 
         add(buildFilters());
         statsSlot = new Div();

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/SystemAnalyticsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/SystemAnalyticsView.java
@@ -100,11 +100,11 @@ public class SystemAnalyticsView extends LkPage {
                 applyStatus(ok.market());
             }
             case SystemAnalyticsPresenter.MarketActionOutcome.NotAuthenticated ignored ->
-                Toasts.failure("Your admin session has expired — sign in again to control the market.");
+                Toasts.failure("Your session has expired — please sign in again.");
             case SystemAnalyticsPresenter.MarketActionOutcome.Rejected r ->
-                Toasts.failure("Cannot " + (open ? "open" : "close") + " the market: " + r.reason());
+                Toasts.failure("Couldn't " + (open ? "open" : "close") + " the market — please try again.");
             case SystemAnalyticsPresenter.MarketActionOutcome.Failure f ->
-                Toasts.failure("Market action failed: " + f.reason());
+                Toasts.failure("Market action failed — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
@@ -68,9 +68,9 @@ public class AdminLoginView extends LkAuthCard {
             case AdminLoginPresenter.Outcome.InvalidCredentials ignored ->
                 Toasts.failure("Invalid admin username or password.");
             case AdminLoginPresenter.Outcome.Locked locked ->
-                Toasts.failure(locked.reason());
+                Toasts.failure("Your account is temporarily locked after too many failed attempts. Please try again later.");
             case AdminLoginPresenter.Outcome.Failure fail ->
-                Toasts.failure("Sign-in failed: " + fail.reason());
+                Toasts.failure("Sign-in failed — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
@@ -110,10 +110,12 @@ public class LoginView extends LkAuthCard {
             case LoginPresenter.Outcome.Success ok -> onSuccess(ok.loginDTO());
             case LoginPresenter.Outcome.InvalidCredentials ignored ->
                 Toasts.failure("Invalid username or password.");
-            case LoginPresenter.Outcome.GuestSessionMissing miss ->
-                Toasts.failure("Session expired — please refresh the page. (" + miss.reason() + ")");
+            case LoginPresenter.Outcome.GuestSessionMissing miss -> {
+                Toasts.warn("Your session timed out — reloading…");
+                UI.getCurrent().getPage().reload();
+            }
             case LoginPresenter.Outcome.Failure fail ->
-                Toasts.failure("Sign-in failed: " + fail.reason());
+                Toasts.failure("Sign-in failed — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/RegisterView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/RegisterView.java
@@ -172,15 +172,17 @@ public class RegisterView extends LkAuthCard {
             case RegisterPresenter.Outcome.EmailTaken ignored ->
                 Toasts.failure("That email is already registered.");
             case RegisterPresenter.Outcome.WeakPassword weak ->
-                Toasts.failure("Weak password — " + weak.reason() + ".");
+                Toasts.failure("That password is too weak — please choose a stronger one.");
             case RegisterPresenter.Outcome.InvalidEmail ignored ->
                 Toasts.failure("That email address looks invalid.");
-            case RegisterPresenter.Outcome.GuestSessionMissing miss ->
-                Toasts.failure("Session expired — please refresh the page. (" + miss.reason() + ")");
+            case RegisterPresenter.Outcome.GuestSessionMissing miss -> {
+                Toasts.warn("Your session timed out — reloading…");
+                UI.getCurrent().getPage().reload();
+            }
             case RegisterPresenter.Outcome.InvalidInput bad ->
-                Toasts.failure("Invalid input: " + bad.reason());
+                Toasts.failure("Please check your details and try again.");
             case RegisterPresenter.Outcome.Failure fail ->
-                Toasts.failure("Registration failed: " + fail.reason());
+                Toasts.failure("Registration failed — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -228,7 +228,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure(f.message());
+                Toasts.failure("Couldn't reserve those tickets — please try again.");
         }
     }
 
@@ -283,7 +283,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure(f.message());
+                Toasts.failure("Couldn't reserve those tickets — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -47,8 +47,6 @@ public class CompanyEventListView extends LkPage {
         title("My Events");
         subtitle("All events under the selected company.");
         actions(
-            new LkBtn("Bulk Export").variant(LkBtn.Variant.secondary)
-                .onClick(e -> Toasts.success("Event list exported to CSV (mock).")),
             new LkBtn("New Event").variant(LkBtn.Variant.primary)
                 .icon(new LkIcon("plus", 15))
                 .onClick(e -> UI.getCurrent().navigate("owner/events/new"))
@@ -152,9 +150,9 @@ public class CompanyEventListView extends LkPage {
                     reload();
                 }
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
-                    Toasts.warn("Session expired — please sign in again.");
+                    Toasts.warn("Your session has expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure("Cancel failed: " + fail.reason());
+                    Toasts.failure("Could not cancel the event — please try again.");
             }
         });
         dialog.open();
@@ -175,9 +173,9 @@ public class CompanyEventListView extends LkPage {
                     reload();
                 }
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
-                    Toasts.warn("Session expired — please sign in again.");
+                    Toasts.warn("Your session has expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure(fail.reason() == null ? "Remove failed." : fail.reason());
+                    Toasts.failure("Could not remove the event — please try again.");
             }
         });
         dialog.open();
@@ -186,7 +184,7 @@ public class CompanyEventListView extends LkPage {
     private void openStatusDialog(EventDetailDTO ev) {
         List<EventStatus> allowed = allowedTransitions(ev.status());
         if (allowed.isEmpty()) {
-            Toasts.warn("No status transitions available for a " + ev.status().name() + " event.");
+            Toasts.warn("No further status changes are available for this event.");
             return;
         }
 
@@ -213,13 +211,13 @@ public class CompanyEventListView extends LkPage {
             }
             switch (presenter.changeEventStatus(AuthSession.token(), Integer.parseInt(ev.eventId()), target)) {
                 case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
-                    Toasts.success("Event status changed to " + target.name() + ".");
+                    Toasts.success("Event status updated.");
                     reload();
                 }
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
-                    Toasts.warn("Session expired — please sign in again.");
+                    Toasts.warn("Your session has expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure("Status change failed: " + fail.reason());
+                    Toasts.failure("Could not change the event status — please try again.");
             }
         });
         dialog.open();

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryRespondView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryRespondView.java
@@ -107,7 +107,7 @@ public class CompanyInquiryRespondView extends LkPage implements BeforeEnterObse
             case CompanyInquiryInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not send your reply: " + fail.reason());
+                Toasts.failure("Could not send your reply — please try again.");
         }
     }
 
@@ -120,7 +120,7 @@ public class CompanyInquiryRespondView extends LkPage implements BeforeEnterObse
             case CompanyInquiryInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not close the inquiry: " + fail.reason());
+                Toasts.failure("Could not close the inquiry — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyRegistrationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyRegistrationView.java
@@ -95,13 +95,13 @@ public class CompanyRegistrationView extends LkPage {
             case CompanyRegistrationPresenter.Outcome.Success success ->
                 Toasts.success("'" + success.company().name() + "' registered — welcome to the organizer workspace.");
             case CompanyRegistrationPresenter.Outcome.NotAuthenticated ignored ->
-                Toasts.failure("Sign in again to register a company.");
+                Toasts.failure("Your session has expired — please sign in again.");
             case CompanyRegistrationPresenter.Outcome.InvalidInput invalid ->
-                Toasts.failure(invalid.reason());
+                Toasts.failure("Please check the company details and try again.");
             case CompanyRegistrationPresenter.Outcome.NameTaken taken ->
-                Toasts.failure(taken.reason());
+                Toasts.failure("That company name is already taken — please choose another.");
             case CompanyRegistrationPresenter.Outcome.Failure fail ->
-                Toasts.failure("Registration failed: " + fail.reason());
+                Toasts.failure("Registration failed — please try again.");
         }
 
         if (outcome instanceof CompanyRegistrationPresenter.Outcome.Success) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -107,7 +107,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.LoadOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.LoadOutcome.Failure fail ->
-                Toasts.failure("Could not load event: " + fail.reason());
+                Toasts.failure("Could not load the event — please try again.");
         }
     }
 
@@ -165,7 +165,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.SaveOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.SaveOutcome.Failure fail ->
-                Toasts.failure("Could not save event: " + fail.reason());
+                Toasts.failure("Could not save the event — please try again.");
         }
     }
 
@@ -211,7 +211,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.CreateOutcome.InvalidInput bad ->
                 Toasts.failure(bad.reason());
             case EventManagementPresenter.CreateOutcome.Failure fail ->
-                Toasts.failure("Could not create event: " + fail.reason());
+                Toasts.failure("Could not create the event — please try again.");
         }
     }
 
@@ -370,7 +370,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
             case EventManagementPresenter.CancelOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case EventManagementPresenter.CancelOutcome.Failure fail ->
-                Toasts.failure("Could not cancel event: " + fail.reason());
+                Toasts.failure("Could not cancel the event — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/ManagerInvitationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/ManagerInvitationView.java
@@ -110,7 +110,7 @@ private final ManagerInvitationPresenter presenter;
             case ManagerInvitationPresenter.Outcome.UserNotFound u ->
                 Toasts.failure("User \"" + u.username() + "\" was not found.");
             case ManagerInvitationPresenter.Outcome.Failure fail ->
-                Toasts.failure("Could not send invitation: " + fail.reason());
+                Toasts.failure("Could not send the invitation — please try again.");
         }
     }
     

--- a/src/main/java/com/ticketing/system/Presentation/views/company/ManagerListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/ManagerListView.java
@@ -150,7 +150,7 @@ public class ManagerListView extends LkPage {
             case ManagerListPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case ManagerListPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not update permissions: " + fail.reason());
+                Toasts.failure("Could not update permissions — please try again.");
         }
     }
 
@@ -163,7 +163,7 @@ public class ManagerListView extends LkPage {
             case ManagerListPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case ManagerListPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not revoke manager: " + fail.reason());
+                Toasts.failure("Could not revoke the manager — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerAppointmentView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerAppointmentView.java
@@ -93,7 +93,7 @@ public class OwnerAppointmentView extends LkPage {
             case MyCompaniesPresenter.AppointOutcome.UserNotFound u ->
                 Toasts.failure("User \"" + u.username() + "\" was not found.");
             case MyCompaniesPresenter.AppointOutcome.Failure fail ->
-                Toasts.failure(fail.reason());
+                Toasts.failure("Could not complete the appointment — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -189,7 +189,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
             case LoadOutcome.Success s -> this.root = s.root();
             case LoadOutcome.NotAuthenticated na -> {
                 this.root = presenter.emptyPolicy();
-                Toasts.warn("Please sign in again to edit policies.");
+                Toasts.warn("Your session has expired — please sign in again.");
             }
             case LoadOutcome.Failure f -> {
                 this.root = presenter.emptyPolicy();
@@ -502,9 +502,9 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         if (isEventLevel && eventId <= 0) { Toasts.failure("Choose an event, or switch to Company-level."); return; }
         switch (presenter.save(memberToken, companyId, eventId, isEventLevel, root)) {
             case SaveOutcome.Success s           -> Toasts.success("Policy saved.");
-            case SaveOutcome.NotAuthenticated na  -> Toasts.failure("Please sign in again to save.");
+            case SaveOutcome.NotAuthenticated na  -> Toasts.failure("Your session has expired — please sign in again.");
             case SaveOutcome.Invalid inv         -> Toasts.warn(inv.reason());
-            case SaveOutcome.Failure f           -> Toasts.failure("Failed to save: " + f.reason());
+            case SaveOutcome.Failure f           -> Toasts.failure("Couldn't save the policy — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/VenueMapEditorView.java
@@ -121,7 +121,7 @@ public class VenueMapEditorView extends LkPage implements BeforeEnterObserver {
             case VenueMapPresenter.LoadOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case VenueMapPresenter.LoadOutcome.Failure fail ->
-                Toasts.failure("Could not load the venue map: " + fail.reason());
+                Toasts.failure("Could not load the venue map — please try again.");
         }
     }
 
@@ -450,7 +450,7 @@ public class VenueMapEditorView extends LkPage implements BeforeEnterObserver {
             case VenueMapPresenter.SaveOutcome.NoCompany ignored ->
                 Toasts.failure("You don't own a company — register one first.");
             case VenueMapPresenter.SaveOutcome.Failure fail ->
-                Toasts.failure("Could not save venue map: " + fail.reason());
+                Toasts.failure("Could not save the venue map — please try again.");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/messaging/NewInquiryView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/messaging/NewInquiryView.java
@@ -120,7 +120,7 @@ public class NewInquiryView extends LkPage implements BeforeEnterObserver {
         switch (presenter.searchCompanies(query)) {
             case NewInquiryPresenter.SearchOutcome.Success ok -> renderResults(ok.companies());
             case NewInquiryPresenter.SearchOutcome.Failure fail ->
-                Toasts.failure("Could not search companies: " + fail.reason());
+                Toasts.failure("Could not search companies — please try again.");
         }
     }
 
@@ -180,7 +180,7 @@ public class NewInquiryView extends LkPage implements BeforeEnterObserver {
             case NewInquiryPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case NewInquiryPresenter.ActionOutcome.Failure fail ->
-                Toasts.failure("Could not submit inquiry: " + fail.reason());
+                Toasts.failure("Could not submit the inquiry — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/messaging/SubmitComplaintView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/messaging/SubmitComplaintView.java
@@ -96,7 +96,7 @@ public class SubmitComplaintView extends LkPage {
             case SubmitComplaintPresenter.Outcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case SubmitComplaintPresenter.Outcome.Failure fail ->
-                Toasts.failure("Could not submit complaint: " + fail.reason());
+                Toasts.failure("Could not submit the complaint — please try again.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CartView.java
@@ -45,7 +45,7 @@ public class CartView extends LkPage {
             case CartPresenter.LoadOutcome.NotAuthenticated na -> clearCart();
             case CartPresenter.LoadOutcome.Failure f -> {
                 clearCart();
-                Toasts.failure("Could not load your cart: " + f.reason());
+                Toasts.failure("Could not load your cart — please try again.");
             }
         }
 
@@ -113,7 +113,7 @@ public class CartView extends LkPage {
                         Toasts.success("Removed from cart.");
                     }
                     case CartPresenter.RemoveOutcome.Failure f ->
-                        Toasts.failure("Failed to remove item: " + f.reason());
+                        Toasts.failure("Could not remove the item — please try again.");
                 }
             });
 

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -64,7 +64,6 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
     private final TextField    cardNumber  = new TextField("Card number");
     private final TextField    expiry      = new TextField("Expiry");
     private final TextField    cvc         = new TextField("CVC");
-    private final TextField    coupon      = new TextField();
     private final EmailField   guestEmail  = new EmailField("Your email");
     private final IntegerField guestAge    = new IntegerField("Your age");
 
@@ -283,18 +282,6 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
         Div foot = new Div();
         foot.addClassName("bz-order-foot");
 
-        coupon.setPlaceholder("Coupon code");
-        coupon.getStyle().set("flex", "1 1 auto");
-        LkBtn apply = new LkBtn("Apply")
-                .variant(LkBtn.Variant.tertiary)
-                .onClick(e -> {
-                    if (coupon.isEmpty()) Toasts.warn("Enter a coupon code first.");
-                    else Toasts.success("Coupon applied (no discount in placeholder).");
-                });
-        LkRow couponRow = new LkRow().gap(8);
-        couponRow.add(coupon, apply);
-        foot.add(couponRow);
-
         subtotalSpan = new Span(formatCents(subtotalCents));
         totalSpan    = new Span(formatCents(totalCents));
 
@@ -480,9 +467,9 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
                     return;
                 }
                 case CheckoutPresenter.PayOutcome.PolicyRejected p ->
-                    Toasts.failure("Cannot purchase: " + p.reason());
+                    Toasts.failure("This purchase isn't allowed under the event's purchase policy.");
                 case CheckoutPresenter.PayOutcome.PaymentDeclined d ->
-                    Toasts.failure("Payment declined: " + d.reason());
+                    Toasts.failure("Your payment was declined — please check your card details and try again.");
                 case CheckoutPresenter.PayOutcome.SoldOut s ->
                     Toasts.failure("Those seats just sold out. Please choose again.");
                 case CheckoutPresenter.PayOutcome.OrderExpired e ->


### PR DESCRIPTION
## Summary
A UX pass over every user-facing toast/notification (#451). Audited all ~197 `Toasts.*` call-sites across the Presentation layer and fixed the unfriendly ones — internal leaks, mock/placeholder success, dead exempt-feature affordances, and inconsistent session wording. Presentation-layer only; no domain/application changes.

## What changed
**Removed dead placeholder / exempt-feature affordances (button + toast, not just text):**
- Coupon field + "Apply" on Checkout (coupons/discounts are exempt).
- Mock buttons: "Download PDF" (ticket dialog), "Export CSV" (Global History, Company Sales), "Bulk Export" (Company Events), "Email Receipt".
- My Profile's exempt buttons (Edit Profile, Change Password, Manage Preferences, Sign Out Everywhere) — and the now-empty Preferences & Sessions cards they hosted.

**Standardized session/auth expiry copy:**
- Every member/admin token-expiry toast now reads `Your session has expired — please sign in again.`
- Guest-session expiry on Login/Register self-recovers via a quiet page reload (`Your session timed out — reloading…`) instead of exposing an internal reason code.

**Stopped leaking internal detail:**
- Replaced raw `Failure.reason()` / `.message()` / exception passthrough / enum `.name()` in toasts with curated, friendly messages.
- Each site was verified against its producing presenter; genuinely user-safe domain messages (refund eligibility, field validation) were preserved.
- Also dropped the `· V2-AUTH-02 stub` internal tag from the account-menu caption.

## Acceptance criteria (#451)
- [x] No user-facing toast contains internal identifiers, reason codes, exception text, or mock/placeholder/stub/TODO.
- [x] No toast claims success for an action that didn't actually happen.
- [x] Exempt features (coupons/discounts, mock exports) have no placeholder toast or dead affordance.
- [x] Session-expiry / auth messaging is consistent and actionable.

## Verification
- Clean `./mvnw compile` passes.
- Audit grep over toast call-sites returns only the intentionally-kept curated domain messages.
- Session-expiry phrasing confirmed uniform across the app.

Closes #451
