### PR TITLE
infra(V3-ROB-01): HikariCP DB-reconnect recovery (SLR.6)

### DIFF
--- a/src/main/resources/application-supabase.yml
+++ b/src/main/resources/application-supabase.yml
@@ -21,6 +21,15 @@ spring:
     hikari:
       # Supabase caps connections (more so when several instances share the DB) — keep each pool small.
       maximum-pool-size: ${DB_POOL_SIZE:5}
+      # --- DB-reconnect / recovery resilience (SLR.6, #362), config-only: no health-poller, no retry lib ---
+      # The reconnect is HikariCP's own job: it validates a pooled connection before lending it (the default
+      # 30s connection-timeout / 5s validation-timeout bound a clean failure during an outage), so once
+      # Postgres is back the next borrow gets a fresh connection and the app resumes with NO restart.
+      # These three knobs make that recovery smooth and safe:
+      max-lifetime: 600000             # retire each connection after 10 min, before the Supabase pooler can
+                                       # silently drop an idle one — so a request is never lent a dead connection
+      keepalive-time: 300000           # ping idle connections every 5 min to keep them warm / detect dead ones
+      initialization-fail-timeout: 0   # let the pool start even if the DB is momentarily unreachable at boot
   jpa:
     hibernate:
       # First boot builds the whole schema from the @Entity mappings; later boots only add what's new.


### PR DESCRIPTION
Hardens the HikariCP connection pool so the app **auto-recovers when Postgres drops and returns, with no restart** (SLR.6) — the required V3-ROB-01 item.

## Approach — config-only (per the locked decision)
No custom health-poller, no retry library. Reconnect is already HikariCP's behavior: it **validates a pooled connection before lending it**, so once Postgres is back the next borrow gets a fresh connection and the app resumes. This PR just tunes the pool so that recovery is smooth and safe.

Added under `spring.datasource.hikari` in `application-supabase.yml`:
- **`max-lifetime: 600000`** — retire each connection after 10 min, *before* the Supabase session pooler can silently drop an idle one, so a request is never handed a dead connection.
- **`keepalive-time: 300000`** — ping idle connections every 5 min to keep them warm / detect dead ones early.
- **`initialization-fail-timeout: 0`** — let the pool start even if the DB is momentarily unreachable at boot (`PlatformInitializationRunner` already leaves the platform uninitialized + market closed until the DB returns).

The default `connection-timeout` (30s) / `validation-timeout` (5s) already bound a clean, fast failure during an outage, so they're left at their defaults.

## Verification
No Java changed; full suite green (**1441 tests, 0 failures**). The YAML parses and binds correctly under `spring.datasource.hikari`.

**Manual SLR.6 check (drop → resume, no restart):**
1. `./run-supabase.sh`, then use the app (e.g., browse events).
2. Simulate an outage — in the Supabase dashboard, pause the project (or restart the database / terminate its connections).
3. Trigger a DB action → it fails **cleanly** (clear error; the app does not crash).
4. Resume the project.
5. Trigger the same action again → it **succeeds**. The app recovered on its own, with no restart.

Per the V3 plan, recovery is config-only (HikariCP revalidation + `@Transactional` rollback); the optional `@Retryable`-on-reads and the WSEP retry/backoff (#365) are the lower-priority/exempt tier and are intentionally out of scope here.

Closes #362.
