### PR TITLE
feat(V3-ROB-05): re-validate invariants vs loaded DB state at boot (#372)

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemIntegrityVerifier.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemIntegrityVerifier.java
@@ -1,15 +1,28 @@
 package com.ticketing.system.Core.Application.services;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.InventoryZone;
 import com.ticketing.system.Core.Domain.exceptions.SystemIntegrityViolationException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
+import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
+import com.ticketing.system.Core.Domain.users.User;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -67,16 +80,29 @@ public class SystemIntegrityVerifier {
 
     private final IUserRepository userRepository;
     private final IProductionCompanyRepository companyRepository;
+    private final IEventRepository eventRepository;
+    private final IActiveOrderRepository activeOrderRepository;
 
     public SystemIntegrityVerifier(IUserRepository userRepository,
-                                   IProductionCompanyRepository companyRepository) {
+                                   IProductionCompanyRepository companyRepository,
+                                   IEventRepository eventRepository,
+                                   IActiveOrderRepository activeOrderRepository) {
         this.userRepository = userRepository;
         this.companyRepository = companyRepository;
+        this.eventRepository = eventRepository;
+        this.activeOrderRepository = activeOrderRepository;
     }
 
+    // Read-only inside a transaction so the loaded JPA aggregates' lazy collections (event zones,
+    // cart items, show dates, …) stay reachable while the scans traverse them (#372).
+    @Transactional(readOnly = true)
     public void verify() {
-        verifyActiveCompaniesHaveOwner();   // constraint #6
-        verifyProducersAreUsers();          // constraint #4
+        verifyActiveCompaniesHaveOwner();      // constraint #6
+        verifyProducersAreUsers();             // constraint #4
+        revalidateLoadedAggregates();          // #372 — re-run each loaded aggregate's own invariants
+        verifyUniqueUsernames();               // constraint #1
+        verifyOneActiveOrderPerBuyerEvent();   // constraint #8
+        verifyInventoryWithinCapacity();       // constraint #12
         log.info("System integrity verified.");
     }
 
@@ -102,6 +128,93 @@ public class SystemIntegrityVerifier {
                     throw new SystemIntegrityViolationException(
                             "company '" + company.getName() + "' has producer " + userId
                                     + " that is not a registered user");
+                }
+            }
+        }
+    }
+
+    // ---- #372 V3 scans: re-validate the LOADED DB state (no-ops on the empty in-memory stack) ----
+
+    // Re-run every loaded aggregate's own invariant. A row persisted (or hand-edited) into a state
+    // that breaks its aggregate invariant blocks the market from opening.
+    private void revalidateLoadedAggregates() {
+        revalidateEach(userRepository.findAll(), "user");
+        revalidateEach(companyRepository.findAll(), "company");
+        revalidateEach(eventRepository.findAll(), "event");
+        revalidateEach(activeOrderRepository.findAll(), "active order");
+    }
+
+    private void revalidateEach(List<? extends InvariantChecked> aggregates, String type) {
+        for (InvariantChecked aggregate : aggregates) {
+            try {
+                aggregate.checkInvariants();
+            } catch (RuntimeException e) {
+                // checkInvariants throws a plain IllegalStateException; wrap it as a DomainException so
+                // PlatformInitializationRunner's catch leaves the platform uninitialized gracefully.
+                throw new SystemIntegrityViolationException(
+                        "loaded " + type + " violates its invariant: " + e.getMessage());
+            }
+        }
+    }
+
+    // #1 — usernames are system-wide unique. The column has no DB UNIQUE constraint (unlike email),
+    // so a duplicate can physically exist; flag it.
+    private void verifyUniqueUsernames() {
+        Set<String> seen = new HashSet<>();
+        for (User user : userRepository.findAll()) {
+            String username = user.getUsername();
+            if (username != null && !seen.add(username)) {
+                throw new SystemIntegrityViolationException(
+                        "duplicate username '" + username + "' in the member pool");
+            }
+        }
+    }
+
+    // #8 — at most one active order per buyer per event. A buyer is keyed by userId (member) or
+    // sessionId (guest); flag a buyer whose two distinct orders both hold the same event.
+    private void verifyOneActiveOrderPerBuyerEvent() {
+        Map<String, Map<Integer, String>> orderByBuyerEvent = new HashMap<>();
+        for (ActiveOrder order : activeOrderRepository.findAll()) {
+            String buyer = buyerKey(order);
+            if (buyer == null) {
+                continue; // an order with no identity is caught by the aggregate's own checkInvariants
+            }
+            Map<Integer, String> byEvent = orderByBuyerEvent.computeIfAbsent(buyer, b -> new HashMap<>());
+            Set<Integer> eventIds = new HashSet<>();
+            for (CartLineItem item : order.getItems()) {
+                eventIds.add(item.geteventId());
+            }
+            for (Integer eventId : eventIds) {
+                String previous = byEvent.put(eventId, order.getOrderKey());
+                if (previous != null && !previous.equals(order.getOrderKey())) {
+                    throw new SystemIntegrityViolationException(
+                            "buyer " + buyer + " has more than one active order for event " + eventId);
+                }
+            }
+        }
+    }
+
+    private static String buyerKey(ActiveOrder order) {
+        Integer userId = order.userIdOrNull();
+        if (userId != null) {
+            return "user:" + userId;
+        }
+        String sessionId = order.getSessionId();
+        return sessionId == null ? null : "sess:" + sessionId;
+    }
+
+    // #12 — a zone's committed tickets (sold + reserved) must not exceed its physical capacity.
+    private void verifyInventoryWithinCapacity() {
+        for (Event event : eventRepository.findAll()) {
+            if (event.getVenueMap() == null || event.getVenueMap().getInventoryZones() == null) {
+                continue;
+            }
+            for (InventoryZone zone : event.getVenueMap().getInventoryZones()) {
+                int committed = zone.getSoldAmount() + zone.getReservedAmount();
+                if (committed > zone.getCapacity()) {
+                    throw new SystemIntegrityViolationException(
+                            "event " + event.getId() + " has an oversold zone: sold+reserved="
+                                    + committed + " > capacity=" + zone.getCapacity());
                 }
             }
         }

--- a/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/IActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/ActiveOrder/IActiveOrderRepository.java
@@ -40,4 +40,7 @@ public interface IActiveOrderRepository extends IRepository<ActiveOrder, String>
 
     /** Sweep query for UC-2 / Phase 5: returns carts with any expired items. */
     List<ActiveOrder> findExpired();
+
+    // #372 — full enumeration for the boot-time integrity scan (<=1 active order per buyer/event).
+    List<ActiveOrder> findAll();
 }

--- a/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/IEventRepository.java
@@ -40,6 +40,9 @@ public interface IEventRepository extends IRepository<Event, Integer> {
     // UC-3 / UC-19 — events grouped by lifecycle state.
     List<Event> findByStatus(EventStatus status);
 
+    // #372 — full enumeration for the boot-time integrity scan (sellable <= inventory).
+    List<Event> findAll();
+
     // search across all events (filters from DTO).
     List<Event> searchAll(CatalogSearchFiltersDTO filters);
     // UC-7 — search across all events that are ON_SALE (filters from DTO).

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/JpaActiveOrderRepository.java
@@ -88,4 +88,9 @@ public class JpaActiveOrderRepository implements IActiveOrderRepository {
         LocalDateTime cutoff = LocalDateTime.now().minus(CartLineItem.getExpirationLimit());
         return data.findWithItemAddedBefore(cutoff);
     }
+
+    @Override
+    public List<ActiveOrder> findAll() {
+        return data.findAll();
+    }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/ActiveOrderPersistence/MemoryActiveOrderRepository.java
@@ -100,6 +100,11 @@ public class MemoryActiveOrderRepository implements IActiveOrderRepository {
         return result;
     }
 
+    @Override
+    public List<ActiveOrder> findAll() {
+        return new ArrayList<>(carts);
+    }
+
     private boolean sameIdentity(ActiveOrder a, ActiveOrder b) {
         // Member identity collapses on userId.
         if (a.userIdOrNull() != null && a.userIdOrNull().equals(b.userIdOrNull())) {

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/JpaEventRepository.java
@@ -119,6 +119,11 @@ public class JpaEventRepository implements IEventRepository {
     }
 
     @Override
+    public List<Event> findAll() {
+        return data.findAll();
+    }
+
+    @Override
     public List<Event> searchAll(CatalogSearchFiltersDTO filters) {
         return data.findAll(EventSearchSpecification.from(filters));
     }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -120,6 +120,11 @@ public class MemoryEventRepository implements IEventRepository {
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public List<Event> findAll() {
+        return events.values().stream().collect(Collectors.toList());
+    }
+
 
 
 

--- a/src/test/java/com/ticketing/system/unit/application/SystemIntegrityVerifierTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemIntegrityVerifierTest.java
@@ -2,30 +2,66 @@ package com.ticketing.system.unit.application;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.ticketing.system.Core.Application.services.SystemIntegrityVerifier;
+import com.ticketing.system.Core.Domain.ActiveOrder.ActiveOrder;
+import com.ticketing.system.Core.Domain.ActiveOrder.CartLineItem;
+import com.ticketing.system.Core.Domain.ActiveOrder.IActiveOrderRepository;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
+import com.ticketing.system.Core.Domain.events.DiscountPolicy;
+import com.ticketing.system.Core.Domain.events.Event;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.InventoryZone;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.events.StandingZone;
+import com.ticketing.system.Core.Domain.events.VenueMap;
 import com.ticketing.system.Core.Domain.exceptions.SystemIntegrityViolationException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
+import com.ticketing.system.Core.Domain.policies.purchase.NoPurchasePolicy;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
 import com.ticketing.system.Core.Domain.users.User;
 
 class SystemIntegrityVerifierTest {
 
+    private static final LocalDateTime FUTURE_START = LocalDateTime.of(2099, 6, 1, 18, 0);
+    private static final LocalDateTime FUTURE_END = LocalDateTime.of(2099, 6, 1, 22, 0);
+
     private final IUserRepository userRepository = mock(IUserRepository.class);
     private final IProductionCompanyRepository companyRepository = mock(IProductionCompanyRepository.class);
-    private final SystemIntegrityVerifier verifier = new SystemIntegrityVerifier(userRepository, companyRepository);
+    private final IEventRepository eventRepository = mock(IEventRepository.class);
+    private final IActiveOrderRepository activeOrderRepository = mock(IActiveOrderRepository.class);
+    private final SystemIntegrityVerifier verifier = new SystemIntegrityVerifier(
+            userRepository, companyRepository, eventRepository, activeOrderRepository);
+
+    // Default every enumeration to empty so a test only stubs the aggregate it exercises;
+    // the V3 scans iterate all four repos, so an unstubbed findAll() would otherwise NPE.
+    @BeforeEach
+    void emptyByDefault() {
+        when(companyRepository.findActive()).thenReturn(List.of());
+        when(userRepository.findAll()).thenReturn(List.of());
+        when(companyRepository.findAll()).thenReturn(List.of());
+        when(eventRepository.findAll()).thenReturn(List.of());
+        when(activeOrderRepository.findAll()).thenReturn(List.of());
+    }
+
+    // ---- existing structural scans (#4 / #6) ----
 
     @Test
     void givenEmptySystem_whenVerify_thenPasses() {
-        when(companyRepository.findActive()).thenReturn(List.of());
         assertDoesNotThrow(verifier::verify);
     }
 
@@ -61,5 +97,106 @@ class SystemIntegrityVerifierTest {
         when(userRepository.getUserById(5)).thenThrow(new UserNotFoundException(5));
 
         assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    // ---- #372 V3 scans against loaded state ----
+
+    @Test
+    void givenLoadedAggregateThatViolatesItsInvariant_whenVerify_thenThrows() {   // re-validation sweep
+        Event badEvent = mock(Event.class);
+        doThrow(new IllegalStateException("rating out of range")).when(badEvent).checkInvariants();
+        when(eventRepository.findAll()).thenReturn(List.of(badEvent));
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    @Test
+    void givenDuplicateUsernames_whenVerify_thenThrows() {   // constraint #1
+        User a = mock(User.class);
+        User b = mock(User.class);
+        when(a.getUsername()).thenReturn("alice");
+        when(b.getUsername()).thenReturn("alice");
+        when(userRepository.findAll()).thenReturn(List.of(a, b));
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    @Test
+    void givenDistinctUsernames_whenVerify_thenPasses() {   // constraint #1 — happy path
+        User a = mock(User.class);
+        User b = mock(User.class);
+        when(a.getUsername()).thenReturn("alice");
+        when(b.getUsername()).thenReturn("bob");
+        when(userRepository.findAll()).thenReturn(List.of(a, b));
+
+        assertDoesNotThrow(verifier::verify);
+    }
+
+    @Test
+    void givenBuyerWithTwoOrdersForSameEvent_whenVerify_thenThrows() {   // constraint #8
+        ActiveOrder order1 = orderFor(5, "ok-1", 7);
+        ActiveOrder order2 = orderFor(5, "ok-2", 7);
+        when(activeOrderRepository.findAll()).thenReturn(List.of(order1, order2));
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    @Test
+    void givenBuyerWithOrdersForDifferentEvents_whenVerify_thenPasses() {   // constraint #8 — happy path
+        ActiveOrder order1 = orderFor(5, "ok-1", 7);
+        ActiveOrder order2 = orderFor(5, "ok-2", 8);
+        when(activeOrderRepository.findAll()).thenReturn(List.of(order1, order2));
+
+        assertDoesNotThrow(verifier::verify);
+    }
+
+    @Test
+    void givenOversoldZone_whenVerify_thenThrows() {   // constraint #12
+        when(eventRepository.findAll()).thenReturn(List.of(eventWithSoldUnits(200))); // 200 > capacity 100
+
+        assertThrows(SystemIntegrityViolationException.class, verifier::verify);
+    }
+
+    @Test
+    void givenZoneWithinCapacity_whenVerify_thenPasses() {   // constraint #12 — happy path
+        when(eventRepository.findAll()).thenReturn(List.of(eventWithSoldUnits(0))); // sold 0 <= capacity 100
+
+        assertDoesNotThrow(verifier::verify);
+    }
+
+    // ---- helpers ----
+
+    private static ActiveOrder orderFor(int userId, String orderKey, int eventId) {
+        CartLineItem item = mock(CartLineItem.class);
+        when(item.geteventId()).thenReturn(eventId);
+        ActiveOrder order = mock(ActiveOrder.class);
+        when(order.userIdOrNull()).thenReturn(userId);
+        when(order.getOrderKey()).thenReturn(orderKey);
+        when(order.getItems()).thenReturn(List.of(item));
+        return order;
+    }
+
+    // Real Event with a real 100-capacity StandingZone. Inventory accessors are abstract/final so they
+    // resist mocking; instead the zone's soldAmount is corrupted directly to simulate an oversold DB row
+    // (the domain API never lets sold exceed capacity, which is the whole point of the boot scan).
+    private static Event eventWithSoldUnits(int sold) {
+        InventoryZone zone = new StandingZone(1, "Floor", 100, 50);
+        if (sold > 0) {
+            setPrivateInt(zone, "soldAmount", sold);
+        }
+        VenueMap venueMap = new VenueMap(1, new Location("Belgium", "Brussels"), List.of(zone));
+        return new Event(1, "Show", 4.5, List.of("Artist"), EventCategory.CONCERT, 10,
+                EventStatus.ON_SALE, venueMap, List.of(new ShowDate(FUTURE_START, FUTURE_END)),
+                new NoPurchasePolicy(), new DiscountPolicy(0));
+    }
+
+    private static void setPrivateInt(Object target, String fieldName, int value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.setInt(target, value);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("test could not corrupt " + fieldName, e);
+        }
     }
 }

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/IActiveOrderRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/ActiveOrderPersistence/IActiveOrderRepositoryContractTest.java
@@ -142,6 +142,20 @@ abstract class IActiveOrderRepositoryContractTest {
     }
 
     @Test
+    void findAll_returnsEveryCart() {
+        repo.save(ActiveOrder.forMember(5, "sid-M"));
+        repo.save(ActiveOrder.forGuest("sid-G"));
+
+        java.util.List<ActiveOrder> all = repo.findAll();
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    void findAll_emptyWhenNoCarts() {
+        assertTrue(repo.findAll().isEmpty());
+    }
+
+    @Test
     void save_persistsCartItems() {
         // A member cart with items survives save/reload (the "cart survives a restart" acceptance).
         ActiveOrder cart = ActiveOrder.forMember(5, "sid-A");

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
@@ -149,6 +149,25 @@ public abstract class IEventRepositoryContractTest {
         assertTrue(result.isEmpty());
     }
 
+    // === findAll (#372 boot-time integrity scan) ===
+
+    @Test
+    void givenEventsAcrossCompaniesAndStatuses_whenFindAll_thenReturnsEveryEvent() {
+        eventRepo.save(buildEvent(1, "Event A", 4.5, 10, EventStatus.ON_SALE, EventCategory.CONCERT));
+        eventRepo.save(buildEvent(2, "Event B", 3.8, 20, EventStatus.DRAFT, EventCategory.CONCERT));
+
+        List<Event> all = eventRepo.findAll();
+
+        assertEquals(2, all.size());
+        assertTrue(all.stream().anyMatch(e -> e.getId() == 1));
+        assertTrue(all.stream().anyMatch(e -> e.getId() == 2));
+    }
+
+    @Test
+    void givenNoEvents_whenFindAll_thenReturnsEmptyList() {
+        assertTrue(eventRepo.findAll().isEmpty());
+    }
+
     // === searchAll — eventName ===
 
     @Test


### PR DESCRIPTION
Re-validates the loaded database state at boot and refuses to open the market if any domain invariant is violated (V3-ROB-05). On the in-memory V1/V2 stack the integrity scan ran against empty repos (trivially passing); now that aggregates persist to Postgres, a populated DB can be loaded with state that breaks an invariant (a hand-edited row, a bug that persisted bad data, a partial restore).

## What it does
Extends `SystemIntegrityVerifier.verify()` — already called from `initializePlatform()` and re-checked in `openMarket()`, and already the gate that keeps the platform `UNINITIALIZED` (market closed) on a violation. After the existing #4/#6 structural scans it now:
- **Re-validates every loaded aggregate** — calls `checkInvariants()` on all users, companies, events, and active orders; a row persisted into a state that breaks its own aggregate invariant blocks the open.
- **#1 unique username** — flags a duplicate username (the column has no DB `UNIQUE` constraint, unlike email, so a dup can physically exist).
- **#8 ≤1 active order per buyer/event** — flags a buyer holding two distinct active orders for the same event.
- **#12 sellable ≤ inventory** — flags a zone whose `sold + reserved` exceeds its capacity (oversold).

`verify()` now runs `@Transactional(readOnly = true)` so the loaded JPA aggregates' lazy collections (event zones, cart items, …) stay reachable while the scans traverse them.

Scope is the **Core** set agreed for #372; the II.4.8.3 appointment-tree cycle check is deferred — cycles are already prevented at creation via `AppointmentCycleException`.

## Enabling change
Added `findAll()` to `IEventRepository` and `IActiveOrderRepository` (Memory + Jpa impls, mirroring the existing `User`/`ProductionCompany` `findAll()`), with contract-test coverage.

## Verification
- `./mvnw -o -Pno-vaadin test` — **1456 tests, 0 failures** (sweep + #1/#8/#12 happy + violation paths; two repo `findAll()` contract cases).
- **Real-data boot (no false positives):** started the `supabase` profile against the populated database (5 users, 6 events, 2 companies, orders) → `SystemIntegrityVerifier - System integrity verified.` → `Platform initialized — status READY`.

Closes #372.
