### PR TITLE
UI & workspace fixes for eval: manager permissions, catalog/My Events UX, informative messages

### DIFF
--- a/architecture-mermaid.html
+++ b/architecture-mermaid.html
@@ -227,9 +227,12 @@
   </p>
 
   <div class="callout">
-    Per <strong>Tier C</strong> there's no suspension view (II.6.7–9 exempt),
-    no real-time push (notification bell refreshes on view-load / login flush),
-    and no discount-policy editor — only the purchase-policy editor.
+    Per <strong>Tier C</strong> there's no suspension view (II.6.7–9 exempt) and
+    no discount-policy editor — only the purchase-policy editor. There's no
+    WebSocket/SSE push; instead the <strong>Client (browser)</strong> receives
+    delayed notifications over Vaadin <code>@Push</code> (<code>LONG_POLLING</code>):
+    a <code>NotificationPollingScheduler</code> flushes pending notifications to the
+    bell, plus an immediate flush on login / view-load.
   </div>
 
   <div class="mermaid-wrap">
@@ -238,6 +241,9 @@ flowchart LR
     classDef viewCluster fill:#dbeafe,stroke:#1e40af,color:#1e3a8a,stroke-width:2px
     classDef ctrl fill:#dbeafe,stroke:#1e40af,color:#1e3a8a,stroke-dasharray:5 3
     classDef svc fill:#e9d5ff,stroke:#6b21a8,color:#581c87,stroke-width:2px
+    classDef client fill:#dcfce7,stroke:#15803d,color:#14532d,stroke-width:2px
+
+    CLIENT["Client (browser)<br/>Vaadin @Push · long-polling"]:::client
 
     subgraph V["Vaadin Views (each + matching FooPresenter)"]
         direction TB
@@ -299,6 +305,10 @@ flowchart LR
     CmpC  --> CmpS
     AdmC  --> SysS
     AdmC  --> MsgS
+
+    %% communication channel: user actions in, delayed-notification push out
+    CLIENT --> V
+    NOT -. "@Push (LONG_POLLING)" .-> CLIENT
     </pre>
   </div>
 </section>
@@ -980,7 +990,10 @@ classDiagram
     The full picture in a single canvas: four layer boxes stacked top to bottom,
     every cross-layer arrow drawn. Each layer's contents are auto-laid-out
     horizontally inside its box, so the canvas is wide — scroll horizontally
-    inside the container if needed.
+    inside the container if needed. The <strong>Client (browser)</strong> sits on
+    top, and the communication / notification delivery path is drawn explicitly:
+    a scheduled long-poll pushes delayed notifications down to the bell via
+    Vaadin <code>@Push</code>.
   </p>
 
   <div class="callout warn">
@@ -1003,6 +1016,12 @@ flowchart TB
     classDef infra fill:#fed7aa,stroke:#9a3412,color:#7c2d12
     classDef adapter fill:#fed7aa,stroke:#9a3412,color:#7c2d12,stroke-width:2px
     classDef xcut fill:#fed7aa,stroke:#9a3412,color:#7c2d12,stroke-dasharray:5 3
+    classDef client fill:#dcfce7,stroke:#15803d,color:#14532d,stroke-width:2px
+
+    subgraph CLIENTL["CLIENT (browser)"]
+        direction LR
+        CLIENT["Browser UI · Vaadin<br/>@Push transport = LONG_POLLING"]:::client
+    end
 
     subgraph PRES["PRESENTATION LAYER (V2 NEW)"]
         direction LR
@@ -1069,6 +1088,8 @@ flowchart TB
         STI["StubTicketIssuer"]:::adapter
         INS["InMemoryNotificationService"]:::adapter
         VN["VaadinNotifier (V2)"]:::adapter
+        AUR["ActiveUiRegistry<br/><i>tracks live UIs</i>"]:::infra
+        NPS["NotificationPollingScheduler<br/><i>@Scheduled long-poll</i>"]:::xcut
         RL["RepositoryLocks"]:::xcut
         LA["LoggingAspect"]:::xcut
     end
@@ -1144,6 +1165,14 @@ flowchart TB
     STI -.implements.-> TI
     INS -.implements.-> NS
     VN  -.implements.-> NI
+
+    %% ====== COMMUNICATION / NOTIFICATION DELIVERY (long-poll push path) ======
+    CLIENT -->|"user actions"| BV
+    CLIENT -->|"user actions"| OV
+    NPS -->|reads live UIs| AUR
+    NPS -->|"deliverPending(userId)"| NotS
+    NPS -.->|"merge + refresh bell"| CC
+    CC  -.->|"@Push (LONG_POLLING)"| CLIENT
     </pre>
   </div>
 

--- a/src/main/java/com/ticketing/system/Core/Application/dto/EventDetailDTO.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dto/EventDetailDTO.java
@@ -20,6 +20,7 @@ public record EventDetailDTO(
         String companyName,
         EventStatus status, // event status
         List<ShowDate> showDates,
-        List<String> artistsNames // lineup (Event.getArtistsNames())
+        List<String> artistsNames, // lineup (Event.getArtistsNames())
+        double minPrice // cheapest ticket price across the event's zones (0 when it has no venue/zones)
 ) {
 }

--- a/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
+++ b/src/main/java/com/ticketing/system/Core/Application/dtoMappers/EventMapper.java
@@ -11,11 +11,16 @@ import com.ticketing.system.Core.Domain.events.Location;
 public class EventMapper {
 
 
-    // HELPER METHOD to convert Event --> EventSummaryDTO; used in both search methods above.
-    public EventSummaryDTO convertEventToEventSummaryDTO(Event event, IProductionCompanyRepository productionCompanyRepository) {
-        double minPrice = (event.getVenueMap() != null && !event.getVenueMap().getInventoryZones().isEmpty())
+    /** Cheapest ticket price across the event's zones, or 0 when it has no venue map / no zones. */
+    public static double minZonePrice(Event event) {
+        return (event.getVenueMap() != null && !event.getVenueMap().getInventoryZones().isEmpty())
                 ? event.getVenueMap().getInventoryZones().stream().mapToDouble(z -> z.getprice()).min().getAsDouble()
                 : 0;
+    }
+
+    // HELPER METHOD to convert Event --> EventSummaryDTO; used in both search methods above.
+    public EventSummaryDTO convertEventToEventSummaryDTO(Event event, IProductionCompanyRepository productionCompanyRepository) {
+        double minPrice = minZonePrice(event);
         double maxPrice = (event.getVenueMap() != null && !event.getVenueMap().getInventoryZones().isEmpty())
                 ? event.getVenueMap().getInventoryZones().stream().mapToDouble(z -> z.getprice()).max().getAsDouble()
                 : 0;
@@ -51,7 +56,8 @@ public class EventMapper {
                 companyName,
                 event.getStatus(),
                 event.getShowDates(),
-                event.getArtistsNames());
+                event.getArtistsNames(),
+                minZonePrice(event));
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/AuthenticationService.java
@@ -285,7 +285,7 @@ public class AuthenticationService {
         try {
             user = userRepository.findByUsername(request.username())
                     .orElseThrow(AuthenticationFailedException::new);
-            if (!user.verifyPassword(request.rawPassword(), passwordHasher)) {
+            if (!passwordHasher.matches(request.rawPassword(), user.getPasswordHash())) {
                 throw new AuthenticationFailedException();
             }
         } catch (AuthenticationFailedException e) {

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -91,6 +91,33 @@ public class CatalogService {
                 .toList();
     }
 
+    //* Browse filters: distinct countries that currently have publicly-visible ON_SALE events, sorted.
+    //* Visibility-gated exactly like searchGlobal so the dropdown never lists a country whose only ON_SALE
+    //* events belong to an inactive company (which Browse would then show zero results for). No credential —
+    //* the browse page is anonymous, like featured() above.
+    public List<String> onSaleCountries() {
+        return eventRepository.searchONSALE(CatalogSearchFiltersDTO.empty()).stream()
+                .filter(e -> isCompanyPubliclyVisible(activeCompanyOrNull(e.getCompanyId())))
+                .map(this::eventCountry)
+                .filter(c -> c != null && !c.isBlank())
+                .distinct()
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .toList();
+    }
+
+    //* Browse filters: distinct cities of publicly-visible ON_SALE events in the chosen country, sorted.
+    public List<String> onSaleCitiesInCountry(String country) {
+        if (country == null) return List.of();
+        return eventRepository.searchONSALE(CatalogSearchFiltersDTO.empty()).stream()
+                .filter(e -> isCompanyPubliclyVisible(activeCompanyOrNull(e.getCompanyId())))
+                .filter(e -> country.equalsIgnoreCase(eventCountry(e)))
+                .map(this::eventCity)
+                .filter(c -> c != null && !c.isBlank())
+                .distinct()
+                .sorted(String.CASE_INSENSITIVE_ORDER)
+                .toList();
+    }
+
 
 
 
@@ -316,6 +343,17 @@ public class CatalogService {
             return null;
         }
         return event.getVenueMap().getLocation().toString();
+    }
+
+    // *HELPER METHOD* — an event's country / city, or null when it has no bound venue/location.
+    private String eventCountry(Event event) {
+        return (event.getVenueMap() != null && event.getVenueMap().getLocation() != null)
+                ? event.getVenueMap().getLocation().country() : null;
+    }
+
+    private String eventCity(Event event) {
+        return (event.getVenueMap() != null && event.getVenueMap().getLocation() != null)
+                ? event.getVenueMap().getLocation().city() : null;
     }
 
     

--- a/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CatalogService.java
@@ -96,8 +96,9 @@ public class CatalogService {
     //* events belong to an inactive company (which Browse would then show zero results for). No credential —
     //* the browse page is anonymous, like featured() above.
     public List<String> onSaleCountries() {
+        Map<Integer, Boolean> visibleByCompany = new HashMap<>();
         return eventRepository.searchONSALE(CatalogSearchFiltersDTO.empty()).stream()
-                .filter(e -> isCompanyPubliclyVisible(activeCompanyOrNull(e.getCompanyId())))
+                .filter(e -> isCompanyPubliclyVisibleCached(e.getCompanyId(), visibleByCompany))
                 .map(this::eventCountry)
                 .filter(c -> c != null && !c.isBlank())
                 .distinct()
@@ -108,14 +109,22 @@ public class CatalogService {
     //* Browse filters: distinct cities of publicly-visible ON_SALE events in the chosen country, sorted.
     public List<String> onSaleCitiesInCountry(String country) {
         if (country == null) return List.of();
+        Map<Integer, Boolean> visibleByCompany = new HashMap<>();
         return eventRepository.searchONSALE(CatalogSearchFiltersDTO.empty()).stream()
-                .filter(e -> isCompanyPubliclyVisible(activeCompanyOrNull(e.getCompanyId())))
+                .filter(e -> isCompanyPubliclyVisibleCached(e.getCompanyId(), visibleByCompany))
                 .filter(e -> country.equalsIgnoreCase(eventCountry(e)))
                 .map(this::eventCity)
                 .filter(c -> c != null && !c.isBlank())
                 .distinct()
                 .sorted(String.CASE_INSENSITIVE_ORDER)
                 .toList();
+    }
+
+    // *HELPER METHOD* — per-call memoized company-visibility lookup. Many ON_SALE events share a
+    // company, so caching companyId→visibility avoids re-hitting the company repository once per
+    // event (an N+1 under the JPA backend) while keeping the same semantics as a direct lookup.
+    private boolean isCompanyPubliclyVisibleCached(int companyId, Map<Integer, Boolean> cache) {
+        return cache.computeIfAbsent(companyId, id -> isCompanyPubliclyVisible(activeCompanyOrNull(id)));
     }
 
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -132,7 +132,7 @@ public class EventManagementService {
         }
 
         User user = userRepository.getUserById(ownerId);
-        user.requirePermissionInCompany(request.companyId(), Permission.CONFIGURE_VENUE);
+        user.requirePermissionInCompany(request.companyId(), Permission.MANAGE_INVENTORY);
 
         int newEventId = eventRepository.nextId();
         VenueMap venueMap = new VenueMap(eventRepository.nextVenueMapId(), request.location(), List.of());
@@ -396,7 +396,7 @@ public class EventManagementService {
             Event event = eventRepository.findById(eventId);
 
             User user = userRepository.getUserById(userId);
-            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
 
             EventCategory newCategory = null;
             if (update.category() != null && !update.category().isBlank()) {
@@ -733,7 +733,10 @@ public class EventManagementService {
         ProductionCompany company = companyRepository.getCompanyById(event.getCompanyId());
 
         User user = userRepository.getUserById(userId);
-        user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+        // Read-only detail: any active member may load it. The pages that reach this (event-detail
+        // editor, venue editor) are each route-gated by their own capability, so this serves both a
+        // MANAGE_INVENTORY metadata editor and a CONFIGURE_VENUE venue editor.
+        user.requireMemberInCompany(event.getCompanyId());
 
         return new EventMapper().toEventDetailDTO(event, company.getName());
     }
@@ -755,7 +758,7 @@ public class EventManagementService {
             }
 
             User user = userRepository.getUserById(userId);
-            user.requirePermissionInCompany(companyId, Permission.CONFIGURE_VENUE);
+            user.requirePermissionInCompany(companyId, Permission.MANAGE_INVENTORY);
 
             event.transitionToOnSale(); // SCHEDULED -> ON_SALE (idempotent if already ON_SALE)
             eventRepository.save(event);
@@ -766,14 +769,14 @@ public class EventManagementService {
         }
     }
 
-    // Permanently removes a CANCELED event. Only callable by a user with CONFIGURE_VENUE.
+    // Permanently removes a CANCELED event. Only callable by a user with MANAGE_INVENTORY.
     public void deleteEvent(String token, int eventId) {
         int userId = validateTokenAndGetUserId(token);
         eventRepository.lockForUpdate(eventId);
         try {
             Event event = eventRepository.findById(eventId);
             User user = userRepository.getUserById(userId);
-            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
             if (event.getStatus() != EventStatus.CANCELED) {
                 throw new InvalidStateTransitionException("Only CANCELED events can be deleted");
             }
@@ -798,7 +801,7 @@ public class EventManagementService {
         try {
             Event event = eventRepository.findById(eventId);
             User user = userRepository.getUserById(userId);
-            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
             switch (targetStatus) {
                 case SCHEDULED -> event.transitionToScheduled();
                 case ON_SALE -> event.transitionToOnSale();
@@ -825,7 +828,7 @@ public class EventManagementService {
         try {
             Event event = eventRepository.findById(eventId); // throws if not found, which is what we want here.
             User user = userRepository.getUserById(ownerId);
-            user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
+            user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
 
             if (event.getStatus() == EventStatus.CANCELED) {
                 return;

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -193,7 +193,11 @@ public class EventManagementService {
             throw new CompanyNotFoundException("Company not found for ID: " + companyId);
         }
 
-        user.requirePermissionInCompany(companyId, Permission.MANAGE_INVENTORY);
+        // The events list is a read-only management hub. Any active member of the company may see
+        // it (so e.g. a venue/sales manager can reach the per-event venue editor); the per-event
+        // mutations (configure venue, edit details, policies, cancel) stay gated by their own
+        // permission at their own service entry points.
+        user.requireMemberInCompany(companyId);
 
         EventMapper mapper = new EventMapper();
         return eventRepository.searchByCompanyAll(companyId, filters.withoutCompanyRating()).stream()

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -229,7 +229,8 @@ public class EventManagementService {
             company.getName(),
             event.getStatus(),
             event.getShowDates(),
-            event.getArtistsNames()
+            event.getArtistsNames(),
+            EventMapper.minZonePrice(event)
             );
     }
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -784,7 +784,7 @@ public class EventManagementService {
             // permanently delete one that still has purchase history, which would orphan its
             // OrderReceipt/Ticket records (referenced by eventId, no cascade).
             if (!orderReceiptRepository.findByEventId(eventId).isEmpty()) {
-                throw new BusinessRuleViolationException("Can't delete event with purchase history");
+                throw new BusinessRuleViolationException("Can't delete an event with sales history");
             }
             eventRepository.delete(eventId);
             log.info("Event {} deleted by user {}", eventId, userId);

--- a/src/main/java/com/ticketing/system/Core/Application/services/MemberQueryService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/MemberQueryService.java
@@ -3,8 +3,10 @@ package com.ticketing.system.Core.Application.services;
 import java.util.Comparator;
 import java.util.List;
 
+import com.ticketing.system.Core.Application.dto.MemberDTO;
 import com.ticketing.system.Core.Application.dto.MemberSearchResultDTO;
 import com.ticketing.system.Core.Domain.users.IUserRepository;
+import com.ticketing.system.Core.Domain.users.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,17 @@ public class MemberQueryService {
     public boolean usernameExists(String username) {
         if (username == null || username.isBlank()) return false;
         return userRepository.existsByUsername(username.trim());
+    }
+
+    /**
+     * The member's profile projection (id, username, email) by id — backs {@code MyProfileView}.
+     * Returns a {@link MemberDTO}, never the domain object or anything sensitive (no passwordHash).
+     *
+     * @throws com.ticketing.system.Core.Domain.exceptions.UserNotFoundException if no user with that id exists
+     */
+    public MemberDTO getMemberProfile(int userId) {
+        User u = userRepository.getUserById(userId);
+        return new MemberDTO(u.getUserId(), u.getUsername(), u.getEmail());
     }
 
     /**

--- a/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/events/Event.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
+import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -654,7 +655,11 @@ public class Event implements InvariantChecked {
         PurchasePolicy company = companyPolicy == null ? new NoPurchasePolicy() : companyPolicy;
         PurchasePolicy effective = new AndPurchasePolicy(company, purchasePolicy);
         if (!effective.isSatisfiedBy(context)) {
-            throw new IllegalStateException(effective.getFailureMessage());
+            // Typed domain exception (not IllegalStateException): the Presentation layer maps
+            // PolicyViolationException -> PayOutcome.PolicyRejected so the buyer sees the clear,
+            // specific reason ("Cannot purchase: you can buy at most 4 tickets") rather than the
+            // generic failure toast. The merged failure message is unchanged.
+            throw new PolicyViolationException(effective.getFailureMessage());
         }
     }
 

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/PaymentGatewayUnreachableException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/PaymentGatewayUnreachableException.java
@@ -1,0 +1,20 @@
+package com.ticketing.system.Core.Domain.exceptions;
+
+// Thrown when the payment gateway could NOT be reached at all (transport timeout / no response /
+// connection error) — distinct from a real decline, which stays
+// PaymentGatewayException("payment declined by gateway") for the WSEP "-1" reply. Extends
+// PaymentGatewayException so the documented IPaymentGateway.charge contract still holds and every
+// existing catch(PaymentGatewayException) / instanceof check keeps working; the Presentation layer
+// maps THIS subtype to a GENERIC error so no gateway/WSEP wording leaks to the buyer. The #409
+// rollback is unchanged: when this is thrown the charge never returned, so no money moved, no
+// inventory changed, and no receipt/ticket was created.
+public class PaymentGatewayUnreachableException extends PaymentGatewayException {
+
+    public PaymentGatewayUnreachableException(String reason) {
+        super(reason);
+    }
+
+    public PaymentGatewayUnreachableException(String reason, Throwable cause) {
+        super(reason, cause);
+    }
+}

--- a/src/main/java/com/ticketing/system/Core/Domain/users/User.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/User.java
@@ -251,6 +251,23 @@ public class User implements InvariantChecked {
         }
     }
 
+    // True when the user holds any ACTIVE appointment (owner or manager) in the company.
+    public boolean isMemberInCompany(int companyId) {
+        return getActiveCompanyAppointment(companyId) != null;
+    }
+
+    /**
+     * Will throw if the user is not an active member (owner or manager) of the company.
+     * Used to gate read-only company-management views that any member may see — e.g. the
+     * events hub a venue/sales manager opens to reach the per-event venue editor — while the
+     * per-action mutations stay gated by their specific {@link Permission}.
+     */
+    public void requireMemberInCompany(int companyId) {
+        if (!isMemberInCompany(companyId)) {
+            throw new RuntimeException("User is not a member of this company");
+        }
+    }
+
 
 
     /**

--- a/src/main/java/com/ticketing/system/Core/Domain/users/User.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/users/User.java
@@ -4,7 +4,6 @@ import java.util.EnumSet;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.ticketing.system.Core.Application.interfaces.IPasswordHasher;
 import com.ticketing.system.Core.Domain.shared.InvariantChecked;
 
 import org.hibernate.annotations.Fetch;
@@ -297,15 +296,12 @@ public int getAge() {
 }
 
     /**
-     * Verifies a candidate raw password against the stored hash. UC-12.
-     *
-     * <p>
-     * The hash never leaves this entity — the hasher does the comparison
-     * in place. The {@link IPasswordHasher} collaborator is passed in rather
-     * than held as a field so the entity stays a pure domain object.
+     * The stored password hash. UC-12. The Application layer owns the password hasher and does the
+     * raw-vs-hash comparison (mirrors {@code Admin.getPasswordHash()}), keeping this entity free of
+     * any Application/Infrastructure dependency.
      */
-    public boolean verifyPassword(String rawPassword, IPasswordHasher hasher) {
-        return hasher.matches(rawPassword, this.password);
+    public String getPasswordHash() {
+        return password;
     }
 
     public List<CompanyAppointment> getAllCompanyAppointments() {

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
@@ -32,10 +32,14 @@ import org.springframework.stereotype.Component;
 public class WsepHttpClient {
 
     private final String baseUrl;
+    private final long requestTimeoutSeconds;
     private final HttpClient http;
 
-    public WsepHttpClient(@Value("${wsep.base-url:https://damp-lynna-wsep-1984852e.koyeb.app/}") String baseUrl) {
+    public WsepHttpClient(
+            @Value("${wsep.base-url:https://damp-lynna-wsep-1984852e.koyeb.app/}") String baseUrl,
+            @Value("${wsep.request-timeout-seconds:20}") long requestTimeoutSeconds) {
         this.baseUrl = baseUrl;
+        this.requestTimeoutSeconds = requestTimeoutSeconds;
         this.http = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -79,7 +83,7 @@ public class WsepHttpClient {
     public String post(Form form) {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(baseUrl))
-                .timeout(Duration.ofSeconds(20))
+                .timeout(Duration.ofSeconds(requestTimeoutSeconds))
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .POST(HttpRequest.BodyPublishers.ofString(form.encoded(), StandardCharsets.UTF_8))
                 .build();

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
@@ -12,6 +12,7 @@ import com.ticketing.system.Core.Application.dto.PaymentResultDTO;
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Application.interfaces.IPaymentGateway;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayUnreachableException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -84,10 +85,14 @@ public class WsepPaymentGateway implements IPaymentGateway {
         try {
             body = http.post(form);
         } catch (WsepCommunicationException e) {
-            throw new PaymentGatewayException("payment gateway unreachable: " + e.getMessage());
+            // No answer from WSEP (timeout / connection error). This is NOT a decline — the charge
+            // never reached a verdict — so it gets the unreachable subtype, which the Presentation
+            // layer surfaces as a generic error (no gateway wording leaked).
+            throw new PaymentGatewayUnreachableException("payment gateway unreachable: " + e.getMessage(), e);
         }
 
         if (FAILURE.equals(body)) {
+            // The ONLY real decline: WSEP explicitly replied "-1".
             log.debug("wsep pay declined ({} ms)", msSince(start));
             throw new PaymentGatewayException("payment declined by gateway");
         }
@@ -134,15 +139,18 @@ public class WsepPaymentGateway implements IPaymentGateway {
                 List.of());
     }
 
+    // Only "-1" is a real decline (handled by the caller). Any other non-positive or unparseable
+    // body is a malformed/unexpected response, not a verdict — treat it as unreachable/generic so
+    // it never masquerades as "Payment declined".
     private int parsePositiveInt(String body, String action) {
         try {
             int value = Integer.parseInt(body == null ? "" : body.trim());
             if (value <= 0) {
-                throw new PaymentGatewayException("wsep " + action + " returned non-positive value: " + value);
+                throw new PaymentGatewayUnreachableException("wsep " + action + " returned non-positive value: " + value);
             }
             return value;
         } catch (NumberFormatException e) {
-            throw new PaymentGatewayException("wsep " + action + " returned an unparseable response");
+            throw new PaymentGatewayUnreachableException("wsep " + action + " returned an unparseable response");
         }
     }
 

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/EventSearchSpecification.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/EventSearchSpecification.java
@@ -21,8 +21,9 @@ import jakarta.persistence.criteria.Subquery;
  * Translates {@link CatalogSearchFiltersDTO} into a Criteria {@link Specification} for the catalogue
  * search (UC-7), mirroring {@code MemoryEventRepository.matchesSearch}. Simple predicates (name,
  * category, rating, location) sit on the Event root; the "at least one matching element" filters
- * (artist, keyword-in-artist, show-date range, zone-price range) are correlated {@code EXISTS}
- * subqueries so the outer query never multiplies rows (no {@code distinct} needed).
+ * (artist, keyword-in-artist, show-date range) are correlated {@code EXISTS} subqueries, and the
+ * price range compares against a correlated {@code min(zone price)} subquery (the event's cheapest
+ * ticket) so the outer query never multiplies rows (no {@code distinct} needed).
  */
 final class EventSearchSpecification {
 
@@ -53,8 +54,13 @@ final class EventSearchSpecification {
             if (filters.fromDate() != null || filters.toDate() != null) {
                 predicates.add(cb.exists(showDateInRange(query, cb, root, filters)));
             }
-            if (filters.minPrice() != null || filters.maxPrice() != null) {
-                predicates.add(cb.exists(zonePriceInRange(query, cb, root, filters)));
+            // The event's CHEAPEST ticket price (min zone price) must fall within the range; a
+            // correlated min() subquery returns null for an event with no zones, so it never matches.
+            if (filters.minPrice() != null) {
+                predicates.add(cb.greaterThanOrEqualTo(cheapestZonePrice(query, cb, root), filters.minPrice()));
+            }
+            if (filters.maxPrice() != null) {
+                predicates.add(cb.lessThanOrEqualTo(cheapestZonePrice(query, cb, root), filters.maxPrice()));
             }
             if (filters.minEventRating() != null) {
                 predicates.add(cb.greaterThanOrEqualTo(root.get("rating"), filters.minEventRating()));
@@ -110,20 +116,12 @@ final class EventSearchSpecification {
         return sub;
     }
 
-    private static Subquery<Integer> zonePriceInRange(CriteriaQuery<?> query, CriteriaBuilder cb, Root<Event> root,
-            CatalogSearchFiltersDTO filters) {
-        Subquery<Integer> sub = query.subquery(Integer.class);
+    /** Correlated scalar subquery: the cheapest (min) zone price for the outer event; null if it has no zones. */
+    private static Subquery<Double> cheapestZonePrice(CriteriaQuery<?> query, CriteriaBuilder cb, Root<Event> root) {
+        Subquery<Double> sub = query.subquery(Double.class);
         Root<Event> subRoot = sub.from(Event.class);
         Join<Object, Object> zone = subRoot.join("venueMap").join("inventoryZones");
-        List<Predicate> predicates = new ArrayList<>();
-        predicates.add(cb.equal(subRoot, root));
-        if (filters.minPrice() != null) {
-            predicates.add(cb.greaterThanOrEqualTo(zone.get("price"), filters.minPrice()));
-        }
-        if (filters.maxPrice() != null) {
-            predicates.add(cb.lessThanOrEqualTo(zone.get("price"), filters.maxPrice()));
-        }
-        sub.select(cb.literal(1)).where(predicates.toArray(new Predicate[0]));
+        sub.select(cb.min(zone.<Double>get("price"))).where(cb.equal(subRoot, root));
         return sub;
     }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/persistence/EventPersistence/MemoryEventRepository.java
@@ -209,19 +209,17 @@ public class MemoryEventRepository implements IEventRepository {
                 return false;
         }
 
-        // minPrice / maxPrice — at least one zone must be priced within the range.
+        // minPrice / maxPrice — the event's CHEAPEST ticket price (its lowest zone price) must fall
+        // within the range. An event with no venue/zones has no price and never matches a price filter.
         if (filters.minPrice() != null || filters.maxPrice() != null) {
-            if (event.getVenueMap() == null || event.getVenueMap().getInventoryZones() == null)
+            if (event.getVenueMap() == null || event.getVenueMap().getInventoryZones() == null
+                    || event.getVenueMap().getInventoryZones().isEmpty())
                 return false;
-            boolean hasMatchingZone = event.getVenueMap().getInventoryZones().stream().anyMatch(z -> {
-                double price = z.getprice();
-                if (filters.minPrice() != null && price < filters.minPrice())
-                    return false;
-                if (filters.maxPrice() != null && price > filters.maxPrice())
-                    return false;
-                return true;
-            });
-            if (!hasMatchingZone)
+            double cheapest = event.getVenueMap().getInventoryZones().stream()
+                    .mapToDouble(z -> z.getprice()).min().getAsDouble();
+            if (filters.minPrice() != null && cheapest < filters.minPrice())
+                return false;
+            if (filters.maxPrice() != null && cheapest > filters.maxPrice())
                 return false;
         }
 

--- a/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/MainLayout.java
@@ -1,9 +1,8 @@
 package com.ticketing.system.Presentation.layouts;
 
-import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
-import com.ticketing.system.Core.Application.interfaces.INotificationService;
-import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Presentation.components.NotificationBellComponent;
+import com.ticketing.system.Presentation.presenters.notifications.NotificationBellPresenter;
+import com.ticketing.system.Presentation.presenters.order.CartBadgePresenter;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
 import com.ticketing.system.Presentation.components.kit.LkTopBar;
@@ -33,7 +32,6 @@ import com.vaadin.flow.component.applayout.AppLayout;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
 import com.vaadin.flow.server.VaadinSession;
-import com.ticketing.system.Presentation.session.SessionIdentity;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,18 +60,16 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
             CheckoutView.class, "My Tickets",
             OrderConfirmationView.class, "My Tickets");
 
-    private final ReservationService reservationService;
+    private final CartBadgePresenter cartBadgePresenter;
     private LkTopBar topBar;
     private final SignOutFlow signOutFlow;
-    private final SessionIdentity identity;
-    private final INotificationService notificationService;
+    private final NotificationBellPresenter bellPresenter;
 
-    public MainLayout(ReservationService reservationService, SignOutFlow signOutFlow,
-            SessionIdentity identity, INotificationService notificationService) {
-        this.reservationService = reservationService;
+    public MainLayout(CartBadgePresenter cartBadgePresenter, SignOutFlow signOutFlow,
+            NotificationBellPresenter bellPresenter) {
+        this.cartBadgePresenter = cartBadgePresenter;
         this.signOutFlow = signOutFlow;
-        this.identity = identity;
-        this.notificationService = notificationService;
+        this.bellPresenter = bellPresenter;
         rebuildTopBar(null);
     }
 
@@ -105,20 +101,17 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
                     cartSize = cachedSize;
                     cartDeadlineMs = cachedDeadlineMs;
                 } else {
-                    try {
-                        String credential = identity.credential();
-                        ActiveOrderDTO order = (credential != null)
-                                ? reservationService.viewMyActiveOrder(credential)
-                                : null;
-                        if (order != null && !order.lines().isEmpty()) {
-                            cartSize = order.lines().size();
-                            long remSec = order.remainingSecondsBeforeExpiry();
-                            if (remSec > 0) {
-                                cartDeadlineMs = now + remSec * 1000L;
+                    // The presenter owns the service call + error handling; the shell only
+                    // reads the typed Outcome and keeps caching the result in the Vaadin session.
+                    switch (cartBadgePresenter.loadBadge()) {
+                        case CartBadgePresenter.Outcome.Cart c -> {
+                            cartSize = c.count();
+                            if (c.remainingSeconds() > 0) {
+                                cartDeadlineMs = now + c.remainingSeconds() * 1000L;
                             }
                         }
-                    } catch (Exception e) {
-                        // Log but don't fail topbar render
+                        case CartBadgePresenter.Outcome.Empty ignored -> { /* no cart — leave 0 */ }
+                        case CartBadgePresenter.Outcome.Failure ignored -> { /* don't fail topbar render */ }
                     }
                     session.setAttribute("cart.size", cartSize);
                     session.setAttribute("cart.deadline", cartDeadlineMs);
@@ -141,10 +134,7 @@ public class MainLayout extends AppLayout implements AfterNavigationObserver {
                 .brand("TicketHub", LandingView.class)
                 .nav(nav, activeLabel)
                 .cart(CartView.class, cartSize, cartDeadlineMs)
-                .bell(new NotificationBellComponent(notifId -> {
-                    Integer userId = AuthSession.userId();
-                    if (userId != null) notificationService.markRead(userId, notifId);
-                }));
+                .bell(new NotificationBellComponent(bellPresenter::markRead));
 
         if (signedIn) {
             bar.account(initials(name), name, buildMemberMenu(name));

--- a/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/PlatformAdminLayout.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.Presentation.layouts;
 
-import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Presentation.components.NotificationBellComponent;
+import com.ticketing.system.Presentation.presenters.notifications.NotificationBellPresenter;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
 import com.ticketing.system.Presentation.components.kit.LkSideNav;
@@ -50,11 +50,11 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
     private LkTopBar topBar;
     private LkSideNav adminNav;
     private final SignOutFlow signOutFlow;
-    private final INotificationService notificationService;
+    private final NotificationBellPresenter bellPresenter;
 
-    public PlatformAdminLayout(SignOutFlow signOutFlow, INotificationService notificationService) {
+    public PlatformAdminLayout(SignOutFlow signOutFlow, NotificationBellPresenter bellPresenter) {
         this.signOutFlow = signOutFlow;
-        this.notificationService = notificationService;
+        this.bellPresenter = bellPresenter;
         rebuildTopBar();
         buildDrawerOnce();
     }
@@ -72,10 +72,7 @@ public class PlatformAdminLayout extends AppLayout implements AfterNavigationObs
             // No navigation target — the brand is inert; "Back to Site" (right) is the way out.
             .brand("Event Ticket Platform", " · Admin")
             .rightLink("Back to Site", "arrowLeft", LandingView.class)
-            .bell(new NotificationBellComponent(notifId -> {
-                Integer userId = AuthSession.userId();
-                if (userId != null) notificationService.markRead(userId, notifId);
-            }))
+            .bell(new NotificationBellComponent(bellPresenter::markRead))
             .account(initials(name), name, buildAdminMenu(name), "#fff", "#c2410c");
         addToNavbar(topBar);
     }

--- a/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
+++ b/src/main/java/com/ticketing/system/Presentation/layouts/WorkspaceLayout.java
@@ -1,7 +1,7 @@
 package com.ticketing.system.Presentation.layouts;
 
-import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Presentation.components.NotificationBellComponent;
+import com.ticketing.system.Presentation.presenters.notifications.NotificationBellPresenter;
 import com.ticketing.system.Presentation.components.kit.LkAccountMenu;
 import com.ticketing.system.Presentation.components.kit.LkMenu;
 import com.ticketing.system.Presentation.components.kit.LkSideNav;
@@ -82,11 +82,11 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
     private LkSideNav ownerNav;
     private final Div drawerWrap = new Div();
     private final SignOutFlow signOutFlow;
-    private final INotificationService notificationService;
+    private final NotificationBellPresenter bellPresenter;
 
-    public WorkspaceLayout(SignOutFlow signOutFlow, INotificationService notificationService) {
+    public WorkspaceLayout(SignOutFlow signOutFlow, NotificationBellPresenter bellPresenter) {
         this.signOutFlow = signOutFlow;
-        this.notificationService = notificationService;
+        this.bellPresenter = bellPresenter;
         rebuildTopBar();
         addToDrawer(drawerWrap);
         rebuildDrawer(null);
@@ -107,10 +107,7 @@ public class WorkspaceLayout extends AppLayout implements AfterNavigationObserve
                 new LkTopBar.NavItem("Browse",     BrowseEventsView.class),
                 new LkTopBar.NavItem("My Tickets", MyAccountView.class)
             ), null)
-            .bell(new NotificationBellComponent(notifId -> {
-                Integer userId = AuthSession.userId();
-                if (userId != null) notificationService.markRead(userId, notifId);
-            }))
+            .bell(new NotificationBellComponent(bellPresenter::markRead))
             .account(initials(name), name, buildOwnerMenu(name));
         addToNavbar(topBar);
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/account/MyProfilePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/account/MyProfilePresenter.java
@@ -1,0 +1,50 @@
+package com.ticketing.system.Presentation.presenters.account;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.MemberDTO;
+import com.ticketing.system.Core.Application.services.MemberQueryService;
+import com.ticketing.system.Presentation.session.AuthSession;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Read-only presenter for {@code MyProfileView}. Loads the signed-in member's
+ * profile projection (id, username, email) so the view can show the real email
+ * instead of a placeholder.
+ *
+ * <p>Vaadin-free POJO that returns a sealed {@link Outcome} the view switches on
+ * (never try/catch). Resolves the member by the session userId; degrades to
+ * {@link Outcome.NotAuthenticated} when signed out and {@link Outcome.Failure}
+ * on any service error.
+ */
+@Slf4j
+@Component
+public class MyProfilePresenter {
+
+    private final MemberQueryService memberQueryService;
+
+    public MyProfilePresenter(MemberQueryService memberQueryService) {
+        this.memberQueryService = memberQueryService;
+    }
+
+    public sealed interface Outcome {
+        record Success(MemberDTO member) implements Outcome { }
+        record NotAuthenticated() implements Outcome { }
+        record Failure(String reason) implements Outcome { }
+    }
+
+    /** The signed-in member's profile; NotAuthenticated when signed out, Failure on error. */
+    public Outcome load() {
+        Integer userId = AuthSession.userId();
+        if (userId == null) {
+            return new Outcome.NotAuthenticated();
+        }
+        try {
+            return new Outcome.Success(memberQueryService.getMemberProfile(userId));
+        } catch (RuntimeException e) {
+            log.warn("Failed to load profile for user {}: {}", userId, e.getMessage());
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/BrowseEventsPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/BrowseEventsPresenter.java
@@ -39,4 +39,24 @@ public class BrowseEventsPresenter {
             return List.of();
         }
     }
+
+    /** Distinct countries that currently have on-sale events; empty list on failure. */
+    public List<String> countries() {
+        try {
+            return catalogService.onSaleCountries();
+        } catch (RuntimeException e) {
+            log.warn("Browse countries failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    /** Distinct cities of on-sale events in {@code country}; empty list on failure. */
+    public List<String> cities(String country) {
+        try {
+            return catalogService.onSaleCitiesInCountry(country);
+        } catch (RuntimeException e) {
+            log.warn("Browse cities failed: {}", e.getMessage());
+            return List.of();
+        }
+    }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
@@ -8,6 +8,8 @@ import java.util.TreeMap;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
 import com.ticketing.system.Core.Application.dto.InventoryZoneDTO;
 import com.ticketing.system.Core.Application.dto.SeatDTO;
@@ -20,6 +22,7 @@ import com.ticketing.system.Presentation.components.venue.VkSeatedZonePicker;
 import com.ticketing.system.Presentation.session.SessionIdentity;
 
 @Component
+@Slf4j
 public class SeatPickerPresenter {
 
     private final CatalogService catalogService;
@@ -64,6 +67,8 @@ public class SeatPickerPresenter {
             }
             return new ReserveOutcome.Success(selection.getSeatNumbers().size());
         } catch (RuntimeException e) {
+            log.warn("seated reserve failed (eventId={}, zoneId={}, seats={}): {}",
+                    eventId, zoneId, selection.getSeatNumbers(), e.getMessage(), e);
             return new ReserveOutcome.Failure(e.getMessage());
         }
     }
@@ -78,6 +83,8 @@ public class SeatPickerPresenter {
             }
             return new ReserveOutcome.Success(quantity);
         } catch (RuntimeException e) {
+            log.warn("standing reserve failed (eventId={}, zoneId={}, qty={}): {}",
+                    eventId, zoneId, quantity, e.getMessage(), e);
             return new ReserveOutcome.Failure(e.getMessage());
         }
     }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/catalog/SeatPickerPresenter.java
@@ -17,6 +17,7 @@ import com.ticketing.system.Core.Application.dto.VenueMapDTO;
 import com.ticketing.system.Core.Application.services.CatalogService;
 import com.ticketing.system.Core.Application.services.ReservationService;
 import com.ticketing.system.Core.Domain.events.ZoneType;
+import com.ticketing.system.Core.Domain.exceptions.DomainException;
 import com.ticketing.system.Presentation.components.venue.VkSeat;
 import com.ticketing.system.Presentation.components.venue.VkSeatedZonePicker;
 import com.ticketing.system.Presentation.session.SessionIdentity;
@@ -66,10 +67,17 @@ public class SeatPickerPresenter {
                 reservationService.reserveForGuest(identity.guestSessionId(), eventId, zoneId, selection);
             }
             return new ReserveOutcome.Success(selection.getSeatNumbers().size());
-        } catch (RuntimeException e) {
-            log.warn("seated reserve failed (eventId={}, zoneId={}, seats={}): {}",
-                    eventId, zoneId, selection.getSeatNumbers(), e.getMessage(), e);
+        } catch (DomainException e) {
+            // Domain rejections (sold out, not on sale, market closed, …) carry buyer-facing messages.
+            log.warn("seated reserve rejected (eventId={}, zoneId={}, seats={}): {}",
+                    eventId, zoneId, selection.getSeatNumbers(), e.getMessage());
             return new ReserveOutcome.Failure(e.getMessage());
+        } catch (RuntimeException e) {
+            // Infrastructure errors (e.g. optimistic-lock contention) have technical messages — log the
+            // full trace but hand the view a null so it shows its friendly fallback, never the raw text.
+            log.warn("seated reserve errored (eventId={}, zoneId={}, seats={})",
+                    eventId, zoneId, selection.getSeatNumbers(), e);
+            return new ReserveOutcome.Failure(null);
         }
     }
 
@@ -82,10 +90,17 @@ public class SeatPickerPresenter {
                 reservationService.reserveForGuest(identity.guestSessionId(), eventId, zoneId, selection);
             }
             return new ReserveOutcome.Success(quantity);
-        } catch (RuntimeException e) {
-            log.warn("standing reserve failed (eventId={}, zoneId={}, qty={}): {}",
-                    eventId, zoneId, quantity, e.getMessage(), e);
+        } catch (DomainException e) {
+            // Domain rejections (sold out, not on sale, market closed, …) carry buyer-facing messages.
+            log.warn("standing reserve rejected (eventId={}, zoneId={}, qty={}): {}",
+                    eventId, zoneId, quantity, e.getMessage());
             return new ReserveOutcome.Failure(e.getMessage());
+        } catch (RuntimeException e) {
+            // Infrastructure errors (e.g. optimistic-lock contention) have technical messages — log the
+            // full trace but hand the view a null so it shows its friendly fallback, never the raw text.
+            log.warn("standing reserve errored (eventId={}, zoneId={}, qty={})",
+                    eventId, zoneId, quantity, e);
+            return new ReserveOutcome.Failure(null);
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventStatus;
@@ -26,16 +26,15 @@ public class CompanyEventListPresenter {
         this.companyManagementService = companyManagementService;
     }
 
-    public Outcome load(String token, CatalogSearchFiltersDTO filters) {
+    public Outcome load(String token, Integer companyId, CatalogSearchFiltersDTO filters) {
         if (token == null) return new Outcome.NotAuthenticated();
         try {
-            List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
-            if (owned.isEmpty()) return new Outcome.NoCompany();
-            int companyId = owned.get(0).companyId();
+            Integer resolved = resolveCompanyId(token, companyId);
+            if (resolved == null) return new Outcome.NoCompany();
             // Null filters means "unfiltered" — substitute an empty filter set so the service's
             // filters.withoutCompanyRating() call can't NPE into a generic Failure.
             CatalogSearchFiltersDTO effectiveFilters = filters == null ? CatalogSearchFiltersDTO.empty() : filters;
-            List<EventDetailDTO> events = eventService.listEventsForCompany(token, companyId, effectiveFilters);
+            List<EventDetailDTO> events = eventService.listEventsForCompany(token, resolved, effectiveFilters);
             return new Outcome.Success(events);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
@@ -44,21 +43,38 @@ public class CompanyEventListPresenter {
         }
     }
 
-    // ---- filter options (owner scope): distinct country/city of THIS company's own events ----
+    /**
+     * Resolve which of the caller's companies to scope to. Uses {@code findMyCompanies}
+     * (manager-inclusive, unlike {@code findOwnedCompanies}) so a manager granted
+     * {@code MANAGE_INVENTORY} sees their company's events; honors the workspace's selected company
+     * ({@code preferredCompanyId}) when it is one of theirs, else falls back to the first — the same
+     * select-or-first idiom as {@code CompanyInquiryInboxPresenter}. {@code null} when the caller
+     * belongs to no company.
+     */
+    private Integer resolveCompanyId(String token, Integer preferredCompanyId) {
+        List<MyCompanyDTO> companies = companyManagementService.findMyCompanies(token);
+        if (companies.isEmpty()) return null;
+        return companies.stream()
+                .filter(c -> preferredCompanyId != null && c.companyId() == preferredCompanyId)
+                .findFirst()
+                .orElse(companies.get(0))
+                .companyId();
+    }
 
-    /** This company's events (all statuses), unfiltered; empty when there's no token / no owned company. */
-    private List<EventDetailDTO> ownedCompanyEvents(String token) {
+    // ---- filter options (company scope): distinct country/city of THIS company's own events ----
+
+    /** This company's events (all statuses), unfiltered; empty when there's no token / no company. */
+    private List<EventDetailDTO> companyEvents(String token, Integer companyId) {
         if (token == null) return List.of();
-        List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
-        if (owned.isEmpty()) return List.of();
-        int companyId = owned.get(0).companyId();
-        return eventService.listEventsForCompany(token, companyId, CatalogSearchFiltersDTO.empty());
+        Integer resolved = resolveCompanyId(token, companyId);
+        if (resolved == null) return List.of();
+        return eventService.listEventsForCompany(token, resolved, CatalogSearchFiltersDTO.empty());
     }
 
     /** Distinct countries this company has events in, sorted; empty list on any failure. */
-    public List<String> countries(String token) {
+    public List<String> countries(String token, Integer companyId) {
         try {
-            return ownedCompanyEvents(token).stream()
+            return companyEvents(token, companyId).stream()
                     .map(ev -> ev.location() == null ? null : ev.location().country())
                     .filter(c -> c != null && !c.isBlank())
                     .distinct()
@@ -70,10 +86,10 @@ public class CompanyEventListPresenter {
     }
 
     /** Distinct cities this company has events in for {@code country}, sorted; empty list on any failure. */
-    public List<String> cities(String token, String country) {
+    public List<String> cities(String token, Integer companyId, String country) {
         if (country == null) return List.of();
         try {
-            return ownedCompanyEvents(token).stream()
+            return companyEvents(token, companyId).stream()
                     .filter(ev -> ev.location() != null && country.equalsIgnoreCase(ev.location().country()))
                     .map(ev -> ev.location().city())
                     .filter(c -> c != null && !c.isBlank())

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanyEventListPresenter.java
@@ -44,6 +44,47 @@ public class CompanyEventListPresenter {
         }
     }
 
+    // ---- filter options (owner scope): distinct country/city of THIS company's own events ----
+
+    /** This company's events (all statuses), unfiltered; empty when there's no token / no owned company. */
+    private List<EventDetailDTO> ownedCompanyEvents(String token) {
+        if (token == null) return List.of();
+        List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
+        if (owned.isEmpty()) return List.of();
+        int companyId = owned.get(0).companyId();
+        return eventService.listEventsForCompany(token, companyId, CatalogSearchFiltersDTO.empty());
+    }
+
+    /** Distinct countries this company has events in, sorted; empty list on any failure. */
+    public List<String> countries(String token) {
+        try {
+            return ownedCompanyEvents(token).stream()
+                    .map(ev -> ev.location() == null ? null : ev.location().country())
+                    .filter(c -> c != null && !c.isBlank())
+                    .distinct()
+                    .sorted(String.CASE_INSENSITIVE_ORDER)
+                    .toList();
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
+    /** Distinct cities this company has events in for {@code country}, sorted; empty list on any failure. */
+    public List<String> cities(String token, String country) {
+        if (country == null) return List.of();
+        try {
+            return ownedCompanyEvents(token).stream()
+                    .filter(ev -> ev.location() != null && country.equalsIgnoreCase(ev.location().country()))
+                    .map(ev -> ev.location().city())
+                    .filter(c -> c != null && !c.isBlank())
+                    .distinct()
+                    .sorted(String.CASE_INSENSITIVE_ORDER)
+                    .toList();
+        } catch (RuntimeException e) {
+            return List.of();
+        }
+    }
+
     public ActionOutcome cancelEvent(String token, int eventId) {
         if (token == null) return new ActionOutcome.NotAuthenticated();
         try {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanySalesPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanySalesPresenter.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
 import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.services.CompanyAnalyticsService;
@@ -36,9 +35,10 @@ public class CompanySalesPresenter {
                     .filter(c -> companyId != null && c.companyId() == companyId)
                     .findFirst()
                     .orElse(companies.get(0));
-            CompanyDashboardDTO stats = companyAnalyticsService.dashboard(selected.companyId());
+            // The view derives all headline figures from the order records (refund-aware, honoring
+            // the date filter), so the fixed 30-day dashboard() snapshot is no longer fetched here.
             PurchaseHistoryDTO sales = companyAnalyticsService.salesHistory(selected.companyId());
-            return new Outcome.Success(selected.name(), stats, sales);
+            return new Outcome.Success(selected.name(), sales);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
@@ -47,8 +47,7 @@ public class CompanySalesPresenter {
     }
 
     public sealed interface Outcome {
-        record Success(String companyName, CompanyDashboardDTO stats,
-                       PurchaseHistoryDTO sales) implements Outcome {}
+        record Success(String companyName, PurchaseHistoryDTO sales) implements Outcome {}
         record NotAuthenticated() implements Outcome {}
         record NoCompany() implements Outcome {}
         record Failure(String reason) implements Outcome {}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanySalesPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/CompanySalesPresenter.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Core.Application.services.CompanyAnalyticsService;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
@@ -25,15 +25,20 @@ public class CompanySalesPresenter {
         this.companyAnalyticsService = companyAnalyticsService;
     }
 
-    public Outcome load(String token) {
+    public Outcome load(String token, Integer companyId) {
         if (token == null) return new Outcome.NotAuthenticated();
         try {
-            List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
-            if (owned.isEmpty()) return new Outcome.NoCompany();
-            int companyId = owned.get(0).companyId();
-            CompanyDashboardDTO stats = companyAnalyticsService.dashboard(companyId);
-            PurchaseHistoryDTO sales = companyAnalyticsService.salesHistory(companyId);
-            return new Outcome.Success(owned.get(0).name(), stats, sales);
+            // findMyCompanies (manager-inclusive) so a manager granted VIEW_SALES sees their
+            // company's sales — not just owners; honor the workspace's selected company, else first.
+            List<MyCompanyDTO> companies = companyManagementService.findMyCompanies(token);
+            if (companies.isEmpty()) return new Outcome.NoCompany();
+            MyCompanyDTO selected = companies.stream()
+                    .filter(c -> companyId != null && c.companyId() == companyId)
+                    .findFirst()
+                    .orElse(companies.get(0));
+            CompanyDashboardDTO stats = companyAnalyticsService.dashboard(selected.companyId());
+            PurchaseHistoryDTO sales = companyAnalyticsService.salesHistory(selected.companyId());
+            return new Outcome.Success(selected.name(), stats, sales);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/EventManagementPresenter.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import com.ticketing.system.Core.Application.dto.EventCreationDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventCategory;
@@ -59,8 +59,8 @@ public class EventManagementPresenter {
 
     /**
      * Creates a new event in DRAFT state under the caller's company. The company is resolved from
-     * the caller's owned companies — {@code preferredCompanyId} (the workspace's currently selected
-     * company) when it is one of them, otherwise the first owned company (matching how
+     * the caller's companies — {@code preferredCompanyId} (the workspace's currently selected
+     * company) when it is one of them, otherwise the first (matching how
      * {@code CompanyEventListPresenter} picks the company for the event list the user came from).
      * Domain value objects ({@link Location}, {@link ShowDate}) are assembled here so the view stays
      * free of domain construction.
@@ -113,22 +113,23 @@ public class EventManagementPresenter {
     }
 
     /**
-     * Resolve the company to create under from the caller's <em>owned</em> companies. When a company
-     * is selected ({@code preferredCompanyId} non-null) it must be one the caller owns — otherwise we
-     * return {@code null} ({@code → NoCompany}) rather than silently retargeting to a different
-     * company (e.g. a manager viewing a company they don't own). With no selection, use the first
-     * owned company. {@code null} when the caller owns none.
+     * Resolve the company to create under from the caller's companies (manager-inclusive via
+     * {@code findMyCompanies}, so a MANAGE_INVENTORY manager can create under their company). When a
+     * company is selected ({@code preferredCompanyId} non-null) it must be one of the caller's —
+     * otherwise we return {@code null} ({@code → NoCompany}) rather than silently retargeting to a
+     * different company. With no selection, use the first. {@code null} when the caller has none.
+     * The {@code addEvent} service still enforces the MANAGE_INVENTORY permission.
      */
     private Integer resolveCompanyId(String token, Integer preferredCompanyId) {
-        List<ProductionCompanyDTO> owned = companyService.findOwnedCompanies(token);
-        if (owned.isEmpty()) return null;
+        List<MyCompanyDTO> companies = companyService.findMyCompanies(token);
+        if (companies.isEmpty()) return null;
         if (preferredCompanyId != null) {
-            for (ProductionCompanyDTO c : owned) {
+            for (MyCompanyDTO c : companies) {
                 if (c.companyId() == preferredCompanyId) return preferredCompanyId;
             }
-            return null;   // selected company isn't owned — don't create under a different one
+            return null;   // selected company isn't one of the caller's — don't create elsewhere
         }
-        return owned.get(0).companyId();
+        return companies.get(0).companyId();
     }
 
     private static boolean isBlank(String s) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/PurchasePolicyEditorPresenter.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import com.ticketing.system.Core.Application.dto.CompanyPolicyConfigDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
 import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
@@ -55,7 +55,8 @@ public class PurchasePolicyEditorPresenter {
     public ContextOutcome resolveContext(String token) {
         if (token == null) return new ContextOutcome.NotAuthenticated();
         try {
-            List<ProductionCompanyDTO> companies = companyManagementService.findOwnedCompanies(token);
+            // Manager-inclusive: an EDIT_POLICIES manager (not just owners) must reach the editor.
+            List<MyCompanyDTO> companies = companyManagementService.findMyCompanies(token);
             if (companies.isEmpty()) return new ContextOutcome.NoCompany();
             return new ContextOutcome.Ready(companies);
         } catch (InvalidTokenException e) {
@@ -76,7 +77,7 @@ public class PurchasePolicyEditorPresenter {
     }
 
     public sealed interface ContextOutcome {
-        record Ready(List<ProductionCompanyDTO> companies) implements ContextOutcome { }
+        record Ready(List<MyCompanyDTO> companies) implements ContextOutcome { }
         record NotAuthenticated() implements ContextOutcome { }
         record NoCompany() implements ContextOutcome { }
         record Failure(String reason) implements ContextOutcome { }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/company/VenueMapPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/company/VenueMapPresenter.java
@@ -1,15 +1,11 @@
 package com.ticketing.system.Presentation.presenters.company;
 
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.dto.VenueLayoutDTO;
 import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
-import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 
@@ -17,13 +13,10 @@ import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 public class VenueMapPresenter {
 
     private final EventManagementService eventService;
-    private final CompanyManagementService companyManagementService;
 
     @Autowired
-    public VenueMapPresenter(EventManagementService eventService,
-                             CompanyManagementService companyManagementService) {
+    public VenueMapPresenter(EventManagementService eventService) {
         this.eventService = eventService;
-        this.companyManagementService = companyManagementService;
     }
 
     public LoadOutcome loadZones(String token, int eventId) {
@@ -41,9 +34,12 @@ public class VenueMapPresenter {
     public SaveOutcome saveMap(String token, String eventId, VenueMapConfigDTO config) {
         if (token == null) return new SaveOutcome.NotAuthenticated();
         try {
-            List<ProductionCompanyDTO> owned = companyManagementService.findOwnedCompanies(token);
-            if (owned.isEmpty()) return new SaveOutcome.NoCompany();
-            int companyId = owned.get(0).companyId();
+            // The venue map must be saved to the EVENT's own company — not "the caller's first
+            // company". Resolving from the event (a) targets the correct company for a multi-company
+            // owner and (b) works for a manager granted CONFIGURE_VENUE, who has no Owner appointment
+            // for an owner-only lookup to return. getEventDetail itself requires CONFIGURE_VENUE.
+            int companyId = Integer.parseInt(
+                    eventService.getEventDetail(token, Integer.parseInt(eventId)).companyId());
             eventService.configureVenueMap(token, companyId, config);
             return new SaveOutcome.Success();
         } catch (InvalidTokenException e) {

--- a/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminComplaintQueuePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/messaging/AdminComplaintQueuePresenter.java
@@ -26,6 +26,8 @@ import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
 public class AdminComplaintQueuePresenter {
 
     private static final String ALL = "All";
+    private static final String GROUP_OPEN = "Open";
+    private static final String GROUP_RESOLVED = "Resolved";
     private static final String RESOLVED = "RESOLVED";
 
     private final MessagingService messagingService;
@@ -35,22 +37,40 @@ public class AdminComplaintQueuePresenter {
         this.messagingService = messagingService;
     }
 
-    /** Loads the complaint queue, optionally filtered to a single status ("All"/blank → no filter). */
-    public Outcome load(String token, String statusFilter) {
+    /**
+     * Loads the complaint queue grouped by the UI status filter: "All" → everything, "Open" →
+     * OPEN+RESPONDED (not yet resolved), "Resolved" → RESOLVED+CLOSED (terminal). A single
+     * server-side status can't express those groups, so the whole queue is fetched and grouped
+     * in-memory ("All"/blank → no grouping).
+     */
+    public Outcome load(String token, String group) {
         if (token == null) {
             return new Outcome.NotAuthenticated();
         }
         try {
-            String status = (statusFilter == null || statusFilter.isBlank() || ALL.equals(statusFilter))
-                ? null : statusFilter;
-            List<ConversationDTO> complaints = messagingService.viewAllComplaints(
-                token, new ComplaintFilterDTO(status, null, null, null));
-            return new Outcome.Success(complaints);
+            List<ConversationDTO> all = messagingService.viewAllComplaints(
+                token, new ComplaintFilterDTO(null, null, null, null));
+            List<ConversationDTO> filtered = all.stream()
+                .filter(c -> inGroup(c.status(), group))
+                .toList();
+            return new Outcome.Success(filtered);
         } catch (InvalidTokenException e) {
             return new Outcome.NotAuthenticated();
         } catch (RuntimeException e) {
             return new Outcome.Failure(e.getMessage());
         }
+    }
+
+    /** UI status group → which raw ConversationStatus values it includes. "All"/blank → everything. */
+    private static boolean inGroup(String status, String group) {
+        if (group == null || group.isBlank() || ALL.equals(group)) {
+            return true;
+        }
+        return switch (group) {
+            case GROUP_OPEN     -> "OPEN".equals(status) || "RESPONDED".equals(status);
+            case GROUP_RESOLVED -> "RESOLVED".equals(status) || "CLOSED".equals(status);
+            default             -> true;
+        };
     }
 
     /** Loads a single complaint thread for the dedicated respond page. */

--- a/src/main/java/com/ticketing/system/Presentation/presenters/notifications/NotificationBellPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/notifications/NotificationBellPresenter.java
@@ -1,0 +1,34 @@
+package com.ticketing.system.Presentation.presenters.notifications;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.interfaces.INotificationService;
+import com.ticketing.system.Presentation.session.AuthSession;
+
+/**
+ * Presenter for the top-bar notification bell's mark-read action. A Vaadin-free
+ * POJO wrapping the one fire-and-forget {@link INotificationService} call, so the
+ * three layout shells ({@code MainLayout}, {@code WorkspaceLayout},
+ * {@code PlatformAdminLayout}) don't reach into the application layer directly.
+ *
+ * <p>The bell's data is read from {@code NotificationSession} by
+ * {@code NotificationBellComponent}; this presenter only handles the write
+ * (mark-read) side, resolving the user from {@link AuthSession}.
+ */
+@Component
+public class NotificationBellPresenter {
+
+    private final INotificationService notificationService;
+
+    public NotificationBellPresenter(INotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    /** Mark one notification read for the signed-in member; no-op when signed out. */
+    public void markRead(String notificationId) {
+        Integer userId = AuthSession.userId();
+        if (userId != null) {
+            notificationService.markRead(userId, notificationId);
+        }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/order/CartBadgePresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/order/CartBadgePresenter.java
@@ -1,0 +1,57 @@
+package com.ticketing.system.Presentation.presenters.order;
+
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.dto.ActiveOrderDTO;
+import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Presentation.session.SessionIdentity;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Read-only presenter for the buyer top-bar cart-count badge. A Vaadin-free POJO
+ * that owns the {@link ReservationService} call and the error handling and returns
+ * a sealed {@link Outcome} the layout switches on — so the shell never calls a
+ * service or catches an exception itself.
+ *
+ * <p>Resolves the caller's credential (member token or guest sessionId) via
+ * {@link SessionIdentity} — the same resolution {@code CheckoutPresenter} uses —
+ * and degrades to {@link Outcome.Failure} so a backend hiccup can't break the
+ * top-bar render.
+ */
+@Slf4j
+@Component
+public class CartBadgePresenter {
+
+    private final ReservationService reservationService;
+    private final SessionIdentity    identity;
+
+    public CartBadgePresenter(ReservationService reservationService, SessionIdentity identity) {
+        this.reservationService = reservationService;
+        this.identity           = identity;
+    }
+
+    /** Cart size + remaining hold time for the current member/guest; Empty when none, Failure on error. */
+    public Outcome loadBadge() {
+        try {
+            String credential = identity.credential();
+            if (credential == null) {
+                return new Outcome.Empty();
+            }
+            ActiveOrderDTO order = reservationService.viewMyActiveOrder(credential);
+            if (order == null || order.lines().isEmpty()) {
+                return new Outcome.Empty();
+            }
+            return new Outcome.Cart(order.lines().size(), order.remainingSecondsBeforeExpiry());
+        } catch (RuntimeException e) {
+            log.warn("Failed to load cart badge: {}", e.getMessage());
+            return new Outcome.Failure(e.getMessage());
+        }
+    }
+
+    public sealed interface Outcome {
+        record Cart(int count, long remainingSeconds) implements Outcome { }
+        record Empty()                                implements Outcome { }
+        record Failure(String reason)                 implements Outcome { }
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/order/CheckoutPresenter.java
@@ -19,10 +19,10 @@ import com.ticketing.system.Core.Domain.exceptions.IdempotencyConflictException;
 import com.ticketing.system.Core.Domain.exceptions.InsufficientInventoryException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayUnreachableException;
 import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
 import com.ticketing.system.Presentation.components.Money;
 import com.ticketing.system.Presentation.session.SessionIdentity;
-import com.vaadin.flow.server.VaadinSession;
 
 @Component
 @Slf4j
@@ -108,6 +108,13 @@ public class CheckoutPresenter {
         } catch (RuntimeException e) {
             Throwable cause = (e.getCause() != null) ? e.getCause() : e;
             if (cause instanceof PolicyViolationException)       return new PayOutcome.PolicyRejected(cause.getMessage());
+            // MUST precede the PaymentGatewayException arm: unreachable is a subtype of it. A timeout
+            // is expected transport noise, not a bug -> warn (not error), and a GENERIC outcome that
+            // carries no reason so no gateway/WSEP wording can leak to the buyer.
+            if (cause instanceof PaymentGatewayUnreachableException) {
+                log.warn("Checkout aborted: payment gateway unreachable", e);
+                return new PayOutcome.GatewayUnavailable();
+            }
             if (cause instanceof PaymentGatewayException)        return new PayOutcome.PaymentDeclined(cause.getMessage());
             if (cause instanceof InsufficientInventoryException) return new PayOutcome.SoldOut(cause.getMessage());
             if (cause instanceof InvalidStateTransitionException) return new PayOutcome.OrderExpired("Order expired during checkout");
@@ -143,15 +150,6 @@ public class CheckoutPresenter {
             return Integer.parseInt(value);
         } catch (NumberFormatException e) {
             return 0;
-        }
-    }
-
-    // ---- session --------------------------------------------------------
-
-    public void setOrderSession(CheckoutResultDTO result) {
-        VaadinSession s = VaadinSession.getCurrent();
-        if (s != null) {
-            s.setAttribute("checkout.result", result);
         }
     }
 
@@ -195,6 +193,7 @@ public class CheckoutPresenter {
         record SoldOut(String reason)                implements PayOutcome { }
         record OrderExpired(String reason)           implements PayOutcome { }
         record DuplicateSubmission()                 implements PayOutcome { }
+        record GatewayUnavailable()                  implements PayOutcome { }
         record Failure(String reason)                implements PayOutcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/security/AuthBootstrap.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/AuthBootstrap.java
@@ -1,5 +1,6 @@
 package com.ticketing.system.Presentation.security;
 
+import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.views.auth.LoginView;
 import com.ticketing.system.Presentation.views.company.CompanyRegistrationView;
@@ -95,6 +96,13 @@ public class AuthBootstrap implements VaadinServiceInitListener {
 
         // 2. Capability gate.
         if (cap != null && !Capabilities.has(cap.value())) {
+            // A signed-in company member who reached a workspace action they lack the permission
+            // for — e.g. a manager clicking "Policies" without EDIT_PURCHASE_POLICIES — gets a clear
+            // toast instead of a silent redirect. The admin-shell and "no company yet" forwards keep
+            // their existing (silent) behavior; those aren't a missing-permission situation.
+            if (WORKSPACE_CAPS.contains(cap.value()) && Capabilities.has(Capability.OWNER_WORKSPACE)) {
+                Toasts.warn("Action not in your permissions - Contact Owner");
+            }
             event.forwardTo(fallbackFor(cap.value()));
         }
     }

--- a/src/main/java/com/ticketing/system/Presentation/security/AuthBootstrap.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/AuthBootstrap.java
@@ -9,6 +9,7 @@ import com.ticketing.system.Presentation.views.company.OwnerDashboardView;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import org.springframework.stereotype.Component;
 
@@ -74,10 +75,16 @@ public class AuthBootstrap implements VaadinServiceInitListener {
         Capability.TRANSFER_FOUNDERSHIP
     );
 
+    /** Session attribute holding a permission-denied message to flash after the redirect lands. */
+    private static final String PENDING_DENIAL_KEY = "authBootstrap.pendingDenialToast";
+
     @Override
     public void serviceInit(ServiceInitEvent event) {
-        event.getSource().addUIInitListener(uiInit ->
-            uiInit.getUI().addBeforeEnterListener(this::guard));
+        event.getSource().addUIInitListener(uiInit -> {
+            uiInit.getUI().addBeforeEnterListener(this::guard);
+            // Flash the deferred permission-denied toast once the forwarded navigation has landed.
+            uiInit.getUI().addAfterNavigationListener(e -> flushPendingDenialToast());
+        });
     }
 
     private void guard(BeforeEnterEvent event) {
@@ -100,10 +107,32 @@ public class AuthBootstrap implements VaadinServiceInitListener {
             // for — e.g. a manager clicking "Policies" without EDIT_PURCHASE_POLICIES — gets a clear
             // toast instead of a silent redirect. The admin-shell and "no company yet" forwards keep
             // their existing (silent) behavior; those aren't a missing-permission situation.
+            //
+            // The toast is DEFERRED (stored, then shown by the after-navigation listener): opening a
+            // Notification here and immediately forwardTo()-ing reroutes in the same navigation cycle,
+            // so the toast wouldn't reliably render on the destination. Flashing it after the redirect
+            // lands makes it dependable.
             if (WORKSPACE_CAPS.contains(cap.value()) && Capabilities.has(Capability.OWNER_WORKSPACE)) {
-                Toasts.warn("Action not in your permissions - Contact Owner");
+                VaadinSession session = VaadinSession.getCurrent();
+                if (session != null) {
+                    session.setAttribute(PENDING_DENIAL_KEY,
+                        "You don't have that action in your permissions - contact an owner");
+                }
             }
             event.forwardTo(fallbackFor(cap.value()));
+        }
+    }
+
+    /** Shows (once) any permission-denied message queued by {@link #guard} on the previous redirect. */
+    private void flushPendingDenialToast() {
+        VaadinSession session = VaadinSession.getCurrent();
+        if (session == null) {
+            return;
+        }
+        Object pending = session.getAttribute(PENDING_DENIAL_KEY);
+        if (pending instanceof String message) {
+            session.setAttribute(PENDING_DENIAL_KEY, null);
+            Toasts.warn(message);
         }
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
@@ -163,7 +163,13 @@ public final class Capabilities {
                 case VIEW_SALES -> caps.add(Capability.VIEW_COMPANY_SALES);
                 case EDIT_POLICIES -> caps.add(Capability.EDIT_PURCHASE_POLICIES);
                 case RESPOND_TO_INQUIRIES -> caps.add(Capability.RESPOND_INQUIRIES);
-                case CONFIGURE_VENUE -> caps.add(Capability.MANAGE_VENUE_MAPS);
+                case CONFIGURE_VENUE -> {
+                    caps.add(Capability.MANAGE_VENUE_MAPS);
+                    // Reach the "My Events" hub (read-only) to open an event's venue editor —
+                    // the only path to it. EDIT_COMPANY_EVENTS is NOT granted, so event-detail
+                    // editing/creation/cancellation stay hidden for a venue-only manager.
+                    caps.add(Capability.VIEW_COMPANY_EVENTS);
+                }
                 case MANAGE_INVENTORY -> {
                     caps.add(Capability.VIEW_COMPANY_EVENTS);
                     caps.add(Capability.EDIT_COMPANY_EVENTS);

--- a/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capabilities.java
@@ -158,21 +158,21 @@ public final class Capabilities {
         if (permissions == null) {
             return caps;
         }
+        // Every manager permission grants VIEW_COMPANY_EVENTS: "My Events" is the read-only hub
+        // every manager lands on, and the per-row actions there are each gated by the specific
+        // capability below, so a manager only sees the buttons for what their permissions allow.
         for (Permission permission : permissions) {
+            caps.add(Capability.VIEW_COMPANY_EVENTS);
             switch (permission) {
                 case VIEW_SALES -> caps.add(Capability.VIEW_COMPANY_SALES);
                 case EDIT_POLICIES -> caps.add(Capability.EDIT_PURCHASE_POLICIES);
                 case RESPOND_TO_INQUIRIES -> caps.add(Capability.RESPOND_INQUIRIES);
-                case CONFIGURE_VENUE -> {
-                    caps.add(Capability.MANAGE_VENUE_MAPS);
-                    // Reach the "My Events" hub (read-only) to open an event's venue editor —
-                    // the only path to it. EDIT_COMPANY_EVENTS is NOT granted, so event-detail
-                    // editing/creation/cancellation stay hidden for a venue-only manager.
-                    caps.add(Capability.VIEW_COMPANY_EVENTS);
-                }
+                case CONFIGURE_VENUE -> caps.add(Capability.MANAGE_VENUE_MAPS);
                 case MANAGE_INVENTORY -> {
-                    caps.add(Capability.VIEW_COMPANY_EVENTS);
+                    // Full event lifecycle: edit metadata, create, change status, remove
+                    // (EDIT_COMPANY_EVENTS) and cancel + refund (CANCEL_EVENT).
                     caps.add(Capability.EDIT_COMPANY_EVENTS);
+                    caps.add(Capability.CANCEL_EVENT);
                 }
             }
         }

--- a/src/main/java/com/ticketing/system/Presentation/security/Capability.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/Capability.java
@@ -42,13 +42,16 @@ public enum Capability {
     EDIT_PURCHASE_POLICIES,
     RESPOND_INQUIRIES,
     MANAGE_VENUE_MAPS,
+    // Rides with MANAGE_INVENTORY as part of the full event lifecycle. Cancelling an event refunds
+    // every buyer, so it is a weighty action — but it belongs to whoever manages the event, not to a
+    // separate owner-only tier. Owners hold it unconditionally via OWNER_BUNDLE.
+    CANCEL_EVENT,
 
     // ---- Owner-only (Founder + Co-owner; NOT manager-grantable) ----
     APPOINT_MANAGER,
     APPOINT_CO_OWNER,
     EDIT_MANAGER_PERMISSIONS,
     REVOKE_MANAGER,
-    CANCEL_EVENT,
     VIEW_COMPANY_ORG_TREE,
 
     // ---- Founder-only ----

--- a/src/main/java/com/ticketing/system/Presentation/session/OrderSession.java
+++ b/src/main/java/com/ticketing/system/Presentation/session/OrderSession.java
@@ -1,0 +1,38 @@
+package com.ticketing.system.Presentation.session;
+
+import com.ticketing.system.Core.Application.dto.CheckoutResultDTO;
+import com.vaadin.flow.server.VaadinSession;
+
+/**
+ * Session-scoped holder for the just-completed checkout result, handed from
+ * {@code CheckoutView} to {@code OrderConfirmationView} across the
+ * {@code navigate("order-confirmed")} hop. Keeping the {@link VaadinSession}
+ * read/write here (mirroring {@link AuthSession} / {@link GuestSession}) lets
+ * {@code CheckoutPresenter} stay a Vaadin-free POJO.
+ *
+ * <p>Read-once: the confirmation view calls {@link #result()} then {@link #clear()},
+ * so a refresh / re-navigation reroutes to Browse instead of re-showing a stale receipt.
+ */
+public final class OrderSession {
+
+    private static final String RESULT_KEY = "checkout.result";
+
+    private OrderSession() { }
+
+    /** The last checkout result, or {@code null} when none / no Vaadin session. */
+    public static CheckoutResultDTO result() {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s == null) return null;
+        return (CheckoutResultDTO) s.getAttribute(RESULT_KEY);
+    }
+
+    public static void setResult(CheckoutResultDTO result) {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s != null) s.setAttribute(RESULT_KEY, result);
+    }
+
+    public static void clear() {
+        VaadinSession s = VaadinSession.getCurrent();
+        if (s != null) s.setAttribute(RESULT_KEY, null);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
@@ -32,12 +32,12 @@ public class MyProfileView extends LkPage {
 
     private Component buildProfileCard() {
         String name = AuthSession.displayName();
-        if (name == null || name.isBlank()) name = "Alex Morgan";
+        if (name == null || name.isBlank()) name = "Guest";
 
-        // Real username + email come from the User aggregate via the presenter;
-        // fall back to the display name / a derived handle when signed out or on error.
-        String username = name;
-        String email = name + "@gmail.com";
+        // Username + email come from the User aggregate via the presenter. When signed out or on a load
+        // error we show a neutral placeholder rather than fabricating a plausible-looking address.
+        String username = "—";
+        String email = "—";
         switch (presenter.load()) {
             case MyProfilePresenter.Outcome.Success ok -> {
                 username = ok.member().username();

--- a/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/MyProfileView.java
@@ -10,6 +10,7 @@ import com.ticketing.system.Presentation.components.kit.LkField;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Presentation.presenters.account.MyProfilePresenter;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
@@ -23,22 +24,33 @@ import jakarta.annotation.security.PermitAll;
 @PermitAll
 public class MyProfileView extends LkPage {
 
-    public MyProfileView() {
+    private final MyProfilePresenter presenter;
+
+    public MyProfileView(MyProfilePresenter presenter) {
+        this.presenter = presenter;
         title("My Profile");
         subtitle("Your account details.");
-        add(buildSplit());
-    }
-
-    private Component buildSplit() {
-        Div split = new Div();
-        split.addClassName("prof-split");
-        split.add(buildProfileCard(), buildSideCol());
-        return split;
+        add(buildProfileCard());
     }
 
     private Component buildProfileCard() {
         String name = AuthSession.displayName();
         if (name == null || name.isBlank()) name = "Alex Morgan";
+
+        // Real username + email come from the User aggregate via the presenter;
+        // fall back to the display name / a derived handle when signed out or on error.
+        String username = name;
+        String email = name + "@gmail.com";
+        switch (presenter.load()) {
+            case MyProfilePresenter.Outcome.Success ok -> {
+                username = ok.member().username();
+                if (ok.member().email() != null && !ok.member().email().isBlank()) {
+                    email = ok.member().email();
+                }
+            }
+            case MyProfilePresenter.Outcome.NotAuthenticated ignored -> { /* keep placeholder */ }
+            case MyProfilePresenter.Outcome.Failure ignored -> { /* keep placeholder */ }
+        }
 
         LkCard card = new LkCard("Profile").pad(20);
 
@@ -54,9 +66,8 @@ public class MyProfileView extends LkPage {
         idRow.add(avatar, info);
 
         LkCol fields = new LkCol().gap(14);
-        fields.add(new LkField().label("Username").value("alex.morgan"));
-        fields.add(new LkField().label("Email").value("alex.morgan@email.com"));
-        fields.add(new LkField().label("Member Since").value("15 Dec 2024"));
+        fields.add(new LkField().label("Username").value(username));
+        fields.add(new LkField().label("Email").value(email));
 
         LkRow actions = new LkRow().gap(8);
         actions.getStyle().set("margin-top", "16px");
@@ -69,31 +80,6 @@ public class MyProfileView extends LkPage {
 
         card.add(idRow, Lk.divider(), fields, actions);
         return card;
-    }
-
-    private Component buildSideCol() {
-        LkCol col = new LkCol().gap(14);
-
-        LkCard prefs = new LkCard("Preferences").pad(16);
-        LkCol p = new LkCol().gap(8);
-        Span pDesc = Lk.muted("Notifications, language, and privacy settings.");
-        pDesc.getStyle().set("font-size", "13.5px");
-        p.add(pDesc);
-        p.add(new LkBtn("Manage Preferences").variant(LkBtn.Variant.secondary).full()
-            .onClick(e -> Toasts.warn("Preferences screen — wired by V2-MEM-04.")));
-        prefs.add(p);
-
-        LkCard sessions = new LkCard("Sessions").pad(16);
-        LkCol s = new LkCol().gap(8);
-        Span sDesc = new Span("Signed in on 2 devices.");
-        sDesc.getStyle().set("font-size", "13.5px");
-        s.add(sDesc);
-        s.add(new LkBtn("Sign Out Everywhere").variant(LkBtn.Variant.tertiary).full()
-            .onClick(e -> Toasts.warn("Multi-device session control — V2-AUTH-02.")));
-        sessions.add(s);
-
-        col.add(prefs, sessions);
-        return col;
     }
 
     private static String initials(String name) {

--- a/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/account/SupportInboxView.java
@@ -194,8 +194,10 @@ public class SupportInboxView extends LkPage implements BeforeEnterObserver {
 
     private void handleReply(String text) {
         switch (presenter.reply(AuthSession.token(), selectedId, text)) {
-            case SupportInboxPresenter.ActionOutcome.Success ignored ->
+            case SupportInboxPresenter.ActionOutcome.Success ignored -> {
+                Toasts.success("Reply sent.");
                 reload(); // refresh thread, ordering, and unread badges; keeps selection
+            }
             case SupportInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case SupportInboxPresenter.ActionOutcome.Failure fail ->

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintQueueView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminComplaintQueueView.java
@@ -6,10 +6,10 @@ import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
-import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
+import com.ticketing.system.Presentation.components.kit.LkSelect;
 import com.ticketing.system.Presentation.components.messaging.MdConvRow;
 import com.ticketing.system.Presentation.components.messaging.MdThread;
 import com.ticketing.system.Presentation.layouts.PlatformAdminLayout;
@@ -29,7 +29,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 /**
  * System-admin complaint queue (#269): lists the platform-wide member complaints, lets an admin
@@ -50,6 +49,7 @@ import java.util.Set;
 public class AdminComplaintQueueView extends LkPage {
 
     private static final String ALL = "All";
+    private static final List<String> STATUS_OPTIONS = List.of(ALL, "Open", "Resolved");
 
     private final AdminComplaintQueuePresenter presenter;
 
@@ -60,7 +60,7 @@ public class AdminComplaintQueueView extends LkPage {
     private List<ConversationDTO> complaints = List.of();
     private final List<MdConvRow> convRows = new ArrayList<>();
     private String selectedId;
-    private String statusFilter = ALL;   // server-side filter, re-queried on change
+    private String statusFilter = ALL;   // status group (All/Open/Resolved); re-queried on change
     private LkCard detailCard;
 
     public AdminComplaintQueueView(AdminComplaintQueuePresenter presenter) {
@@ -109,13 +109,13 @@ public class AdminComplaintQueueView extends LkPage {
 
     private Component buildFilters() {
         LkRow row = new LkRow().gap(8);
-        List<String> applied = ALL.equals(statusFilter) ? List.of() : List.of(statusFilter);
-        LkFilterChip status = new LkFilterChip("Status",
-            List.of("Open", "Responded", "Resolved", "Closed"), true, applied);
-        status.onApply(() -> {
-            Set<String> selected = status.getSelected();
-            statusFilter = selected.isEmpty() ? ALL : selected.iterator().next();
-            reload();   // server-side re-query
+        // Three coarse groups: All / Open (OPEN+RESPONDED) / Resolved (RESOLVED+CLOSED). The presenter
+        // fetches the whole queue and groups in-memory, so each option shows only its complaints.
+        LkSelect status = new LkSelect(statusFilter, STATUS_OPTIONS).label("Status");
+        status.onChange(v -> {
+            if (statusFilter.equals(v)) return;
+            statusFilter = v;
+            reload();
         });
         row.add(status);
         return row;

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/AdminInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/AdminInboxView.java
@@ -146,7 +146,10 @@ public class AdminInboxView extends LkPage {
 
     private void handleReply(String text) {
         switch (presenter.reply(AuthSession.token(), selectedId, text)) {
-            case AdminInboxPresenter.ActionOutcome.Success ignored -> reload();
+            case AdminInboxPresenter.ActionOutcome.Success ignored -> {
+                Toasts.success("Reply sent.");
+                reload();
+            }
             case AdminInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case AdminInboxPresenter.ActionOutcome.Failure fail ->

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
@@ -3,13 +3,11 @@ package com.ticketing.system.Presentation.views.admin;
 import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Presentation.components.Money;
-import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.Lk;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
 import com.ticketing.system.Presentation.components.kit.LkGrid;
-import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.components.kit.LkStat;
@@ -38,25 +36,47 @@ public class CompanySalesView extends LkPage {
 
     private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("d MMM yyyy");
 
-    public CompanySalesView(CompanySalesPresenter presenter) {
-        title("Company Sales History");
-        actions(new LkBtn("Export CSV").variant(LkBtn.Variant.secondary)
-            .icon(new LkIcon("chart", 15))
-            .onClick(e -> Toasts.success("Export CSV — no streaming endpoint yet.")));
+    private final CompanySalesPresenter presenter;
+    // Single body slot, rebuilt on every (re)load so the Refresh button can surface a
+    // freshly-completed sale without a full page reload. Styled like the kit's .lk-page
+    // body (flex column, 20px gap) because it replaces what used to be direct page children.
+    private final Div content = new Div();
 
+    public CompanySalesView(CompanySalesPresenter presenter) {
+        this.presenter = presenter;
+
+        title("Company Sales History");
+        actions(new LkBtn("Refresh").variant(LkBtn.Variant.secondary)
+            .onClick(e -> reload()));
+
+        content.getStyle().set("display", "flex").set("flex-direction", "column").set("gap", "20px");
+        add(content);
+
+        reload();
+    }
+
+    /** (Re)builds the report into the content slot — on open and on every Refresh click. */
+    private void reload() {
+        content.removeAll();
         switch (presenter.load(AuthSession.token())) {
             case CompanySalesPresenter.Outcome.Success ok -> {
                 subtitle(ok.companyName() + "  ·  immutable order receipts.");
-                add(buildFilters());
-                add(buildStats(ok.stats(), ok.sales()));
-                add(buildGridCard(ok.sales()));
+                content.add(buildFilters());
+                content.add(buildStats(ok.stats(), ok.sales()));
+                content.add(buildGridCard(ok.sales()));
             }
-            case CompanySalesPresenter.Outcome.NotAuthenticated ignored ->
-                add(Lk.muted("Your session has expired — please sign in again."));
-            case CompanySalesPresenter.Outcome.NoCompany ignored ->
-                add(Lk.muted("You don't own a company yet."));
-            case CompanySalesPresenter.Outcome.Failure fail ->
-                add(Lk.muted("Could not load sales: " + fail.reason()));
+            case CompanySalesPresenter.Outcome.NotAuthenticated ignored -> {
+                subtitle("");
+                content.add(Lk.muted("Your session has expired — please sign in again."));
+            }
+            case CompanySalesPresenter.Outcome.NoCompany ignored -> {
+                subtitle("");
+                content.add(Lk.muted("You don't own a company yet."));
+            }
+            case CompanySalesPresenter.Outcome.Failure fail -> {
+                subtitle("");
+                content.add(Lk.muted("Could not load sales: " + fail.reason()));
+            }
         }
     }
 
@@ -65,9 +85,7 @@ public class CompanySalesView extends LkPage {
         row.add(
             new LkFilterChip("Date range",
                 List.of("Last 7 days", "Last 30 days", "This quarter", "This year", "All time"),
-                true, List.of("Last 30 days")),
-            new LkFilterChip("Event",
-                List.of("All events"), false, List.of())
+                true, List.of("Last 30 days"))
         );
         return row;
     }

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
@@ -16,6 +16,7 @@ import com.ticketing.system.Presentation.presenters.company.CompanySalesPresente
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.session.CurrentCompanies;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Span;
@@ -58,7 +59,7 @@ public class CompanySalesView extends LkPage {
     /** (Re)builds the report into the content slot — on open and on every Refresh click. */
     private void reload() {
         content.removeAll();
-        switch (presenter.load(AuthSession.token())) {
+        switch (presenter.load(AuthSession.token(), CurrentCompanies.currentCompanyId())) {
             case CompanySalesPresenter.Outcome.Success ok -> {
                 subtitle(ok.companyName() + "  ·  immutable order receipts.");
                 content.add(buildFilters());

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/CompanySalesView.java
@@ -1,9 +1,9 @@
 package com.ticketing.system.Presentation.views.admin;
 
-import com.ticketing.system.Core.Application.dto.CompanyDashboardDTO;
 import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO;
 import com.ticketing.system.Presentation.components.Money;
 import com.ticketing.system.Presentation.components.kit.Lk;
+import com.ticketing.system.Presentation.components.kit.LkBadge;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
 import com.ticketing.system.Presentation.components.kit.LkCard;
 import com.ticketing.system.Presentation.components.kit.LkFilterChip;
@@ -24,6 +24,8 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -42,6 +44,18 @@ public class CompanySalesView extends LkPage {
     // freshly-completed sale without a full page reload. Styled like the kit's .lk-page
     // body (flex column, 20px gap) because it replaces what used to be direct page children.
     private final Div content = new Div();
+
+    // Stats + grid are rendered into these slots so the date filter can re-render from the
+    // already-loaded records without re-querying the service.
+    private final Div statsSlot = new Div();
+    private final Div gridSlot = new Div();
+
+    // The orders for the current company, loaded once per (re)load; the date filter narrows a copy.
+    private List<PurchaseHistoryDTO.PurchaseRecordDTO> allRecords = List.of();
+    // Default "All time" so every order (including refunded ones, which carry a tag) is visible by
+    // default; the headline figures still count only non-refunded orders.
+    private String selectedRange = SalesDateRange.ALL_TIME;
+    private LkFilterChip dateChip;
 
     public CompanySalesView(CompanySalesPresenter presenter) {
         this.presenter = presenter;
@@ -62,9 +76,11 @@ public class CompanySalesView extends LkPage {
         switch (presenter.load(AuthSession.token(), CurrentCompanies.currentCompanyId())) {
             case CompanySalesPresenter.Outcome.Success ok -> {
                 subtitle(ok.companyName() + "  ·  immutable order receipts.");
+                this.allRecords = ok.sales().records();
                 content.add(buildFilters());
-                content.add(buildStats(ok.stats(), ok.sales()));
-                content.add(buildGridCard(ok.sales()));
+                content.add(statsSlot);
+                content.add(gridSlot);
+                renderReport();
             }
             case CompanySalesPresenter.Outcome.NotAuthenticated ignored -> {
                 subtitle("");
@@ -72,7 +88,7 @@ public class CompanySalesView extends LkPage {
             }
             case CompanySalesPresenter.Outcome.NoCompany ignored -> {
                 subtitle("");
-                content.add(Lk.muted("You don't own a company yet."));
+                content.add(Lk.muted("You're not part of a company workspace yet."));
             }
             case CompanySalesPresenter.Outcome.Failure fail -> {
                 subtitle("");
@@ -81,51 +97,52 @@ public class CompanySalesView extends LkPage {
         }
     }
 
+    /** Filters the loaded records by the selected range and rebuilds the stats + grid slots. */
+    private void renderReport() {
+        List<PurchaseHistoryDTO.PurchaseRecordDTO> filtered = filterByDate(allRecords, selectedRange);
+        statsSlot.removeAll();
+        statsSlot.add(buildStats(filtered));
+        gridSlot.removeAll();
+        gridSlot.add(buildGridCard(filtered));
+    }
+
+    private static List<PurchaseHistoryDTO.PurchaseRecordDTO> filterByDate(
+            List<PurchaseHistoryDTO.PurchaseRecordDTO> records, String range) {
+        LocalDateTime from = SalesDateRange.startOf(range, LocalDate.now());
+        if (from == null) {
+            return records;
+        }
+        return records.stream()
+                .filter(r -> r.purchasedAt() != null && !r.purchasedAt().isBefore(from))
+                .toList();
+    }
+
     private Component buildFilters() {
+        dateChip = new LkFilterChip("Date range", SalesDateRange.OPTIONS, true, List.of(selectedRange));
+        dateChip.onApply(() -> {
+            selectedRange = dateChip.getSelected().stream().findFirst().orElse(SalesDateRange.ALL_TIME);
+            renderReport();
+        });
         LkRow row = new LkRow().gap(8);
-        row.add(
-            new LkFilterChip("Date range",
-                List.of("Last 7 days", "Last 30 days", "This quarter", "This year", "All time"),
-                true, List.of("Last 30 days"))
-        );
+        row.add(dateChip);
         return row;
     }
 
-    private Component buildStats(CompanyDashboardDTO stats,
-                                  PurchaseHistoryDTO sales) {
-        List<PurchaseHistoryDTO.PurchaseRecordDTO> records = sales.records();
-
-        String revenue = Money.format(Money.toCents(stats.revenue30d()));
-        String tickets = String.valueOf(stats.ticketsSold30d());
-
-        double aov = records.isEmpty() ? 0
-                : records.stream().mapToDouble(PurchaseHistoryDTO.PurchaseRecordDTO::totalPaid).sum()
-                  / records.size();
-
-        String topEvent = records.stream()
-                .flatMap(r -> r.tickets().stream())
-                .filter(t -> t.eventName() != null)
-                .collect(java.util.stream.Collectors.groupingBy(
-                        PurchaseHistoryDTO.TicketRecordDTO::eventName,
-                        java.util.stream.Collectors.summingDouble(
-                                PurchaseHistoryDTO.TicketRecordDTO::pricePaid)))
-                .entrySet().stream()
-                .max(Map.Entry.comparingByValue())
-                .map(Map.Entry::getKey)
-                .orElse("—");
+    private Component buildStats(List<PurchaseHistoryDTO.PurchaseRecordDTO> records) {
+        SalesSummary s = SalesSummary.of(records);
 
         Div statsDiv = new Div();
         statsDiv.addClassName("ow-stats");
         statsDiv.add(
-            new LkStat("Total revenue · 30d", revenue),
-            new LkStat("Tickets sold · 30d",  tickets),
-            new LkStat("Avg order value",      Money.format(Money.toCents(aov))),
-            new LkStat("Top event",            topEvent)
+            new LkStat("Total revenue",   Money.format(Money.toCents(s.revenue()))),
+            new LkStat("Tickets sold",     String.valueOf(s.ticketsSold())),
+            new LkStat("Avg order value",  Money.format(Money.toCents(s.avgOrderValue()))),
+            new LkStat("Top event",        s.topEvent())
         );
         return statsDiv;
     }
 
-    private Component buildGridCard(PurchaseHistoryDTO sales) {
+    private Component buildGridCard(List<PurchaseHistoryDTO.PurchaseRecordDTO> records) {
         LkCard card = new LkCard().pad(0);
         LkGrid grid = new LkGrid()
             .col("Date",    "date")
@@ -134,12 +151,12 @@ public class CompanySalesView extends LkPage {
             .col("Tickets", "tickets", LkGrid.Align.RIGHT)
             .col("Total",   "total",   LkGrid.Align.RIGHT);
 
-        if (sales.records().isEmpty()) {
+        if (records.isEmpty()) {
             card.add(Lk.muted("No sales yet."));
             return card;
         }
 
-        for (PurchaseHistoryDTO.PurchaseRecordDTO r : sales.records()) {
+        for (PurchaseHistoryDTO.PurchaseRecordDTO r : records) {
             Map<String, Object> row = new LinkedHashMap<>();
 
             String date = r.purchasedAt() != null
@@ -160,10 +177,7 @@ public class CompanySalesView extends LkPage {
 
             row.put("tickets", String.valueOf(r.tickets().size()));
 
-            Span total = new Span();
-            total.getElement().setProperty("innerHTML",
-                                        "<b>" + Money.format(Money.toCents(r.totalPaid())) + "</b>");
-            row.put("total", total);
+            row.put("total", totalCell(r));
 
             grid.row(row);
         }
@@ -171,6 +185,25 @@ public class CompanySalesView extends LkPage {
         grid.build();
         card.add(grid);
         return card;
+    }
+
+    /**
+     * Total amount for an order. A refunded order is shown struck-through with a "Refunded" tag so
+     * it's clear it does not contribute to the headline revenue (see {@link SalesSummary}).
+     */
+    private static Component totalCell(PurchaseHistoryDTO.PurchaseRecordDTO r) {
+        String amount = Money.format(Money.toCents(r.totalPaid()));
+        Span amountSpan = new Span();
+        LkRow cell = new LkRow().gap(8).noWrap().justify("flex-end");
+        if (r.refunded()) {
+            amountSpan.getElement().setProperty("innerHTML",
+                    "<span style=\"text-decoration:line-through;color:var(--muted);\">" + amount + "</span>");
+            cell.add(amountSpan, new LkBadge("Refunded", LkBadge.Tone.error).small());
+        } else {
+            amountSpan.getElement().setProperty("innerHTML", "<b>" + amount + "</b>");
+            cell.add(amountSpan);
+        }
+        return cell;
     }
 
     private static String escape(String s) {

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/GlobalHistoryView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/GlobalHistoryView.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -99,15 +100,9 @@ public class GlobalHistoryView extends LkPage {
         Set<String> sel = dateChip.getSelected();
         if (sel.isEmpty() || sel.contains(DATE_ALL)) return true;
         if (r.purchasedAt() == null) return false;
-        LocalDateTime now = LocalDateTime.now();
-        String pick = sel.iterator().next();
-        LocalDateTime from = switch (pick) {
-            case "Last 7 days" -> now.minusDays(7);
-            case "Last 30 days" -> now.minusDays(30);
-            case "This quarter" -> now.minusMonths(3);
-            case "This year" -> now.minusYears(1);
-            default -> null;
-        };
+        // Calendar-correct windows ("This quarter"/"This year" start on the quarter/year boundary),
+        // shared with the Company Sales page filter.
+        LocalDateTime from = SalesDateRange.startOf(sel.iterator().next(), LocalDate.now());
         return from == null || !r.purchasedAt().isBefore(from);
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/SalesDateRange.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/SalesDateRange.java
@@ -1,0 +1,42 @@
+package com.ticketing.system.Presentation.views.admin;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Date-range presets for the Company Sales History filter. The filter narrows orders by their
+ * purchase date. Pure (no Vaadin) so the window math is unit-testable.
+ */
+public final class SalesDateRange {
+
+    public static final String ALL_TIME = "All time";
+
+    public static final List<String> OPTIONS = List.of(
+            "Last 7 days", "Last 30 days", "This quarter", "This year", ALL_TIME);
+
+    private SalesDateRange() { }
+
+    /**
+     * Inclusive lower bound for {@code range} relative to {@code today}; {@code null} for
+     * "All time" (and any unknown value), meaning no lower bound. An order is in range when its
+     * purchase time is not before the returned bound.
+     */
+    public static LocalDateTime startOf(String range, LocalDate today) {
+        if (range == null) {
+            return null;
+        }
+        return switch (range) {
+            case "Last 7 days"  -> today.minusDays(7).atStartOfDay();
+            case "Last 30 days" -> today.minusDays(30).atStartOfDay();
+            case "This quarter" -> firstDayOfQuarter(today).atStartOfDay();
+            case "This year"    -> today.withDayOfYear(1).atStartOfDay();
+            default              -> null; // All time / unknown → unbounded
+        };
+    }
+
+    private static LocalDate firstDayOfQuarter(LocalDate today) {
+        int firstMonthOfQuarter = ((today.getMonthValue() - 1) / 3) * 3 + 1;
+        return LocalDate.of(today.getYear(), firstMonthOfQuarter, 1);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/SalesSummary.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/SalesSummary.java
@@ -11,6 +11,13 @@ import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecord
  * Refund-aware headline figures for the Company Sales History page, derived from the order
  * records the grid shows. Refunded orders are excluded from every figure (they remain listed and
  * tagged in the grid). Pure (no Vaadin) so it is unit-testable.
+ *
+ * <p><b>Known limitation (see issue #457):</b> {@code refunded()} reflects the order-level
+ * {@code OrderReceipt.isRefunded} flag, which an event cancellation flips for the whole receipt even
+ * when only that one event's lines were refunded. So an order mixing multiple events or companies that
+ * then has one event cancelled is excluded in full — understating revenue for its still-valid tickets.
+ * Single-event orders and full-order member refunds are unaffected; a proper fix needs per-line refund
+ * granularity rather than this whole-order boolean.
  */
 public record SalesSummary(double revenue, int ticketsSold, double avgOrderValue, String topEvent) {
 

--- a/src/main/java/com/ticketing/system/Presentation/views/admin/SalesSummary.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/admin/SalesSummary.java
@@ -1,0 +1,39 @@
+package com.ticketing.system.Presentation.views.admin;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
+
+/**
+ * Refund-aware headline figures for the Company Sales History page, derived from the order
+ * records the grid shows. Refunded orders are excluded from every figure (they remain listed and
+ * tagged in the grid). Pure (no Vaadin) so it is unit-testable.
+ */
+public record SalesSummary(double revenue, int ticketsSold, double avgOrderValue, String topEvent) {
+
+    public static final String NO_TOP_EVENT = "—";
+
+    public static SalesSummary of(List<PurchaseRecordDTO> records) {
+        List<PurchaseRecordDTO> paid = records.stream().filter(r -> !r.refunded()).toList();
+
+        double revenue = paid.stream().mapToDouble(PurchaseRecordDTO::totalPaid).sum();
+        int ticketsSold = paid.stream().mapToInt(r -> r.tickets().size()).sum();
+        double avgOrderValue = paid.isEmpty() ? 0.0 : revenue / paid.size();
+
+        String topEvent = paid.stream()
+                .flatMap(r -> r.tickets().stream())
+                .filter(t -> t.eventName() != null)
+                .collect(Collectors.groupingBy(
+                        TicketRecordDTO::eventName,
+                        Collectors.summingDouble(TicketRecordDTO::pricePaid)))
+                .entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(NO_TOP_EVENT);
+
+        return new SalesSummary(revenue, ticketsSold, avgOrderValue, topEvent);
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -64,10 +64,10 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private static final String DATE_ANY    = CatalogFilterSupport.DATE_ANY;
 
     private static final List<String> CATEGORIES = CatalogFilterSupport.CATEGORIES;
-    private static final List<String> COUNTRIES  = CatalogFilterSupport.COUNTRIES;
 
     private static final List<String> SORTS = List.of(
-            "Date · soonest", "Date · latest", "Price · low to high", "Price · high to low", "Popularity");
+            "Date · soonest", "Price · low to high", "Price · high to low",
+            "Rating · high to low", "Rating · low to high");
 
     // ---- filter state ----
 
@@ -261,13 +261,16 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         customRangeRow.add(customFromPicker, customToPicker);
         customRangeRow.setVisible(false);
 
-        // Country → City (dependent selects)
-        countrySelect = new LkSelect(COUNTRY_ALL, COUNTRIES).label("Country");
+        // Country → City (dependent selects), both populated from events that actually exist.
+        countrySelect = new LkSelect(COUNTRY_ALL,
+                CatalogFilterSupport.countryOptions(presenter.countries())).label("Country");
         countrySelect.onChange(v -> {
             if (Objects.equals(filterCountry, v)) return;
             filterCountry = v;
             filterCity = CITY_ALL;
-            citySelect.setOptions(CatalogFilterSupport.cityOptionsFor(v));
+            citySelect.setOptions(COUNTRY_ALL.equals(v)
+                    ? List.of(CITY_ALL)
+                    : CatalogFilterSupport.cityOptions(presenter.cities(v)));
             citySelect.enabled(!COUNTRY_ALL.equals(v));
             runSearch();
         });
@@ -289,9 +292,9 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         });
 
         LkCol col = new LkCol().gap(16);
-        col.add(categorySelect, eventNameWrap, keywordsWrap, artistWrap, dateRangeField, customRangeRow,
+        col.add(sortSelect, categorySelect, eventNameWrap, keywordsWrap, artistWrap, dateRangeField, customRangeRow,
                 buildPriceRange(), buildEventRatingRange(), buildCompanyRatingRange(),
-                countrySelect, citySelect, sortSelect);
+                countrySelect, citySelect);
         card.add(col);
         return card;
     }
@@ -596,14 +599,14 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
     private static Comparator<EventRow> comparatorFor(String sort) {
         Comparator<EventRow> bySoonest = Comparator.comparing(EventRow::startsAt,
                 Comparator.nullsLast(Comparator.naturalOrder()));
-        Comparator<EventRow> byLatest = Comparator.comparing(EventRow::startsAt,
-                Comparator.nullsLast(Comparator.reverseOrder()));
         return switch (sort) {
-            case "Date · latest"       -> byLatest;
-            case "Price · low to high" -> Comparator.comparingInt(EventRow::priceCents);
-            case "Price · high to low" -> Comparator.comparingInt(EventRow::priceCents).reversed();
-            case "Popularity"          -> Comparator.comparing(EventRow::id);
-            default                    -> bySoonest;
+            case "Price · low to high"  -> Comparator.comparingInt(EventRow::priceCents);
+            case "Price · high to low"  -> Comparator.comparingInt(EventRow::priceCents).reversed();
+            case "Rating · high to low" -> Comparator.comparing(EventRow::rating,
+                    Comparator.nullsLast(Comparator.reverseOrder()));
+            case "Rating · low to high" -> Comparator.comparing(EventRow::rating,
+                    Comparator.nullsLast(Comparator.naturalOrder()));
+            default                     -> bySoonest;
         };
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsView.java
@@ -551,7 +551,7 @@ public class BrowseEventsView extends LkPage implements BeforeEnterObserver {
         row.put("cat", ev.category);
         row.put("venue", ev.venue);
         row.put("date", ev.date);
-        row.put("from", "$" + (ev.priceCents / 100));
+        row.put("from", ev.priceCents > 0 ? String.format("$%,.2f", ev.priceCents / 100.0) : "—");
         row.put("rating", ev.rating == null ? "—" : "★ " + ratingText(ev.rating));
         row.put("status", new LkStatusDot(ev.tone, ev.status));
         LkBtn reserve = new LkBtn("Reserve")

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/CatalogFilterSupport.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/CatalogFilterSupport.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Shared, layout-independent options and pure helpers for the catalogue event filters — the single
@@ -24,13 +23,6 @@ public final class CatalogFilterSupport {
 
     public static final List<String> CATEGORIES = List.of(
             CAT_ALL, "Concerts", "Sports", "Theatre", "Festivals", "Comedy");
-
-    public static final Map<String, List<String>> CITIES_BY_COUNTRY = Map.of(
-            "Israel", List.of("Tel Aviv", "Jerusalem", "Haifa", "Caesarea", "Be'er Sheva"),
-            "USA",    List.of("New York", "Los Angeles", "Chicago"),
-            "UK",     List.of("London", "Manchester", "Birmingham"));
-
-    public static final List<String> COUNTRIES = List.of(COUNTRY_ALL, "Israel", "USA", "UK");
 
     /** A resolved from/to date range for a date-range preset; either bound may be null (unbounded). */
     public record DateWindow(LocalDate from, LocalDate to) { }
@@ -72,13 +64,19 @@ public final class CatalogFilterSupport {
         return null;
     }
 
-    /** City options for a country: "All cities" first, then the country's cities (or just "All cities"). */
-    public static List<String> cityOptionsFor(String country) {
-        List<String> cities = CITIES_BY_COUNTRY.get(country);
-        if (cities == null) return List.of(CITY_ALL);
-        List<String> opts = new ArrayList<>(cities.size() + 1);
+    /** Country select options: COUNTRY_ALL first, then the supplied countries (caller supplies them distinct/sorted). */
+    public static List<String> countryOptions(List<String> countries) {
+        List<String> opts = new ArrayList<>();
+        opts.add(COUNTRY_ALL);
+        if (countries != null) opts.addAll(countries);
+        return opts;
+    }
+
+    /** City select options: CITY_ALL first, then the supplied cities (caller supplies them distinct/sorted). */
+    public static List<String> cityOptions(List<String> cities) {
+        List<String> opts = new ArrayList<>();
         opts.add(CITY_ALL);
-        opts.addAll(cities);
+        if (cities != null) opts.addAll(cities);
         return opts;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -228,7 +228,7 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure("Couldn't reserve those tickets — please try again.");
+                Toasts.failure(reserveFailureMessage(f.message()));
         }
     }
 
@@ -283,8 +283,15 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
                 UI.getCurrent().navigate(CartView.class);
             }
             case SeatPickerPresenter.ReserveOutcome.Failure f ->
-                Toasts.failure("Couldn't reserve those tickets — please try again.");
+                Toasts.failure(reserveFailureMessage(f.message()));
         }
+    }
+
+    /** Surface the real reserve-failure reason when present, else a friendly fallback. */
+    private static String reserveFailureMessage(String raw) {
+        return (raw == null || raw.isBlank())
+            ? "Couldn't reserve those tickets — please try again."
+            : raw;
     }
 
     private Component buildBreadcrumb(String trailText) {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -178,12 +178,15 @@ public class CompanyEventListView extends LkPage {
         eventRatingMin = ratingField("Min", v -> { filterMinEventRating = v; reload(); });
         eventRatingMax = ratingField("Max", v -> { filterMaxEventRating = v; reload(); });
 
-        countrySelect = new LkSelect(CatalogFilterSupport.COUNTRY_ALL, CatalogFilterSupport.COUNTRIES).label("Country");
+        countrySelect = new LkSelect(CatalogFilterSupport.COUNTRY_ALL,
+                CatalogFilterSupport.countryOptions(presenter.countries(AuthSession.token()))).label("Country");
         countrySelect.onChange(v -> {
             if (Objects.equals(filterCountry, v)) return;
             filterCountry = v;
             filterCity = CatalogFilterSupport.CITY_ALL;
-            citySelect.setOptions(CatalogFilterSupport.cityOptionsFor(v));
+            citySelect.setOptions(CatalogFilterSupport.COUNTRY_ALL.equals(v)
+                    ? List.of(CatalogFilterSupport.CITY_ALL)
+                    : CatalogFilterSupport.cityOptions(presenter.cities(AuthSession.token(), v)));
             citySelect.enabled(!CatalogFilterSupport.COUNTRY_ALL.equals(v));
             reload();
         });

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -113,6 +113,7 @@ public class CompanyEventListView extends LkPage {
             .col("Event",   "name")
             .col("Date",    "date")
             .col("Venue",   "venue")
+            .col("From",    "from", LkGrid.Align.RIGHT)
             .col("Rating",  "rating", LkGrid.Align.RIGHT)
             .col("Status",  "status")
             .col("Actions", "act", LkGrid.Align.RIGHT);
@@ -347,6 +348,10 @@ public class CompanyEventListView extends LkPage {
 
         String venue = ev.location() != null ? ev.location().toString() : "—";
         row.put("venue", venue);
+
+        // Cheapest ticket price (the same value the catalog's price-range filter matches on); "—"
+        // for events with no venue/zones yet (e.g. drafts).
+        row.put("from", ev.minPrice() > 0 ? "$" + (long) ev.minPrice() : "—");
 
         row.put("rating", ev.rating() == null ? "—" : "★ " + ratingText(ev.rating()));
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -450,7 +450,7 @@ public class CompanyEventListView extends LkPage {
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
                     Toasts.warn("Your session has expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure("Could not remove the event — please try again.");
+                    Toasts.failure(actionFailureMessage(fail.reason(), "Could not remove the event — please try again."));
             }
         });
         dialog.open();
@@ -486,13 +486,13 @@ public class CompanyEventListView extends LkPage {
             }
             switch (presenter.changeEventStatus(AuthSession.token(), Integer.parseInt(ev.eventId()), target)) {
                 case CompanyEventListPresenter.ActionOutcome.Success ignored2 -> {
-                    Toasts.success("Event status updated.");
+                    Toasts.success(statusChangeSuccessMessage(target));
                     reload();
                 }
                 case CompanyEventListPresenter.ActionOutcome.NotAuthenticated ignored2 ->
                     Toasts.warn("Your session has expired — please sign in again.");
                 case CompanyEventListPresenter.ActionOutcome.Failure fail ->
-                    Toasts.failure("Could not change the event status — please try again.");
+                    Toasts.failure(actionFailureMessage(fail.reason(), "Could not change the event status — please try again."));
             }
         });
         dialog.open();
@@ -503,6 +503,25 @@ public class CompanyEventListView extends LkPage {
             case DRAFT -> List.of(EventStatus.SCHEDULED);
             case SCHEDULED -> List.of(EventStatus.ON_SALE);
             default -> List.of();
+        };
+    }
+
+    /**
+     * Surface the real reason the service refused an action (e.g. "Can't delete an event with sales
+     * history", or "Event cannot be scheduled without a venue map and at least one inventory zone")
+     * instead of a generic toast — so the owner understands why. Falls back to {@code fallback} only
+     * when the service gave no message.
+     */
+    private static String actionFailureMessage(String reason, String fallback) {
+        return (reason == null || reason.isBlank()) ? fallback : reason;
+    }
+
+    /** Informative, status-specific confirmation for a successful status change. */
+    private static String statusChangeSuccessMessage(EventStatus target) {
+        return switch (target) {
+            case SCHEDULED -> "Event scheduled — you can publish it (put it On Sale) when ready.";
+            case ON_SALE   -> "Event is now On Sale — tickets are available to buyers.";
+            default        -> "Event status updated.";
         };
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -363,8 +363,9 @@ public class CompanyEventListView extends LkPage {
         row.put("venue", venue);
 
         // Cheapest ticket price (the same value the catalog's price-range filter matches on); "—"
-        // for events with no venue/zones yet (e.g. drafts).
-        row.put("from", ev.minPrice() > 0 ? "$" + (long) ev.minPrice() : "—");
+        // for events with no venue/zones yet (e.g. drafts). Format with cents so it matches the
+        // actual ticket price (e.g. $49.99, not a truncated $49).
+        row.put("from", ev.minPrice() > 0 ? String.format("$%,.2f", ev.minPrice()) : "—");
 
         row.put("rating", ev.rating() == null ? "—" : "★ " + ratingText(ev.rating()));
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -384,7 +384,9 @@ public class CompanyEventListView extends LkPage {
             actions.add(iconBtn("map", "Venue map", () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())));
         }
         if (Capabilities.has(Capability.EDIT_PURCHASE_POLICIES)) {
-            actions.add(iconBtn("policy", "Policies", () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)));
+            // Deep-link to THIS event's purchase policy (route owner/policies/:companyId?/:eventId?).
+            actions.add(iconBtn("policy", "Policies",
+                    () -> UI.getCurrent().navigate("owner/policies/" + ev.companyId() + "/" + ev.eventId())));
         }
         if (Capabilities.has(Capability.VIEW_COMPANY_SALES)) {
             actions.add(iconBtn("chart", "Sales", () -> UI.getCurrent().navigate(CompanySalesView.class)));

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.router.Route;
 import jakarta.annotation.security.PermitAll;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +54,9 @@ public class CompanyEventListView extends LkPage {
     private static final String STATUS_ALL = "All statuses";
     private static final List<String> STATUS_OPTIONS = List.of(
             STATUS_ALL, "Draft", "Scheduled", "On sale", "Sold out", "Cancelled", "Completed");
+
+    /** Human-readable start date + time, e.g. "Jul 19, 2026 · 5:41 PM" (no ISO "T"/seconds gibberish). */
+    private static final DateTimeFormatter DATE_TIME_FMT = DateTimeFormatter.ofPattern("MMM d, yyyy · h:mm a");
 
     private final CompanyEventListPresenter presenter;
     private final LkCard eventsCard = new LkCard().pad(0);
@@ -343,7 +347,7 @@ public class CompanyEventListView extends LkPage {
         row.put("name", name);
 
         String date = ev.showDates() != null && !ev.showDates().isEmpty()
-            ? ev.showDates().get(0).getStartTime().toString() : "—";
+            ? ev.showDates().get(0).getStartTime().format(DATE_TIME_FMT) : "—";
         row.put("date", date);
 
         String venue = ev.location() != null ? ev.location().toString() : "—";

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -17,9 +17,11 @@ import com.ticketing.system.Presentation.components.kit.LkSelect;
 import com.ticketing.system.Presentation.components.kit.LkStatusDot;
 import com.ticketing.system.Presentation.layouts.WorkspaceLayout;
 import com.ticketing.system.Presentation.presenters.company.CompanyEventListPresenter;
+import com.ticketing.system.Presentation.security.Capabilities;
 import com.ticketing.system.Presentation.security.Capability;
 import com.ticketing.system.Presentation.security.RequireCapability;
 import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.session.CurrentCompanies;
 import com.ticketing.system.Presentation.views.admin.CompanySalesView;
 import com.ticketing.system.Presentation.views.catalog.CatalogFilterSupport;
 import com.vaadin.flow.component.Component;
@@ -96,13 +98,18 @@ public class CompanyEventListView extends LkPage {
         this.presenter = presenter;
         title("My Events");
         subtitle("All events under the selected company.");
-        actions(
-            new LkBtn("Bulk Export").variant(LkBtn.Variant.secondary)
-                .onClick(e -> Toasts.success("Event list exported to CSV (mock).")),
-            new LkBtn("New Event").variant(LkBtn.Variant.primary)
-                .icon(new LkIcon("plus", 15))
-                .onClick(e -> UI.getCurrent().navigate("owner/events/new"))
-        );
+        LkBtn bulkExport = new LkBtn("Bulk Export").variant(LkBtn.Variant.secondary)
+            .onClick(e -> Toasts.success("Event list exported to CSV (mock)."));
+        // "New Event" is an event-management action — hidden for a member who can't edit events
+        // (e.g. a venue-only manager), so the page is browse + per-event venue/sales for them.
+        if (Capabilities.has(Capability.EDIT_COMPANY_EVENTS)) {
+            actions(bulkExport,
+                new LkBtn("New Event").variant(LkBtn.Variant.primary)
+                    .icon(new LkIcon("plus", 15))
+                    .onClick(e -> UI.getCurrent().navigate("owner/events/new")));
+        } else {
+            actions(bulkExport);
+        }
         add(buildFilters());
         add(eventsCard);
         Span hint = Lk.muted("Row actions → Edit metadata · Venue map · Policies · Sales · Status · Cancel.");
@@ -121,7 +128,7 @@ public class CompanyEventListView extends LkPage {
             .col("Rating",  "rating", LkGrid.Align.RIGHT)
             .col("Status",  "status")
             .col("Actions", "act", LkGrid.Align.RIGHT);
-        switch (presenter.load(AuthSession.token(), currentFilters())) {
+        switch (presenter.load(AuthSession.token(), CurrentCompanies.currentCompanyId(), currentFilters())) {
             case CompanyEventListPresenter.Outcome.Success ok -> {
                 // Status isn't a CatalogSearchFiltersDTO field — apply it client-side on the result.
                 EventStatus wanted = statusValue(filterStatus);
@@ -139,7 +146,7 @@ public class CompanyEventListView extends LkPage {
                 }
             }
             case CompanyEventListPresenter.Outcome.NoCompany ignored ->
-                eventsCard.add(Lk.muted("You don't own a company yet."));
+                eventsCard.add(Lk.muted("You're not part of a company workspace yet."));
             case CompanyEventListPresenter.Outcome.NotAuthenticated ignored ->
                 eventsCard.add(Lk.muted("Your session has expired — please sign in again."));
             case CompanyEventListPresenter.Outcome.Failure fail ->
@@ -184,14 +191,16 @@ public class CompanyEventListView extends LkPage {
         eventRatingMax = ratingField("Max", v -> { filterMaxEventRating = v; reload(); });
 
         countrySelect = new LkSelect(CatalogFilterSupport.COUNTRY_ALL,
-                CatalogFilterSupport.countryOptions(presenter.countries(AuthSession.token()))).label("Country");
+                CatalogFilterSupport.countryOptions(
+                        presenter.countries(AuthSession.token(), CurrentCompanies.currentCompanyId()))).label("Country");
         countrySelect.onChange(v -> {
             if (Objects.equals(filterCountry, v)) return;
             filterCountry = v;
             filterCity = CatalogFilterSupport.CITY_ALL;
             citySelect.setOptions(CatalogFilterSupport.COUNTRY_ALL.equals(v)
                     ? List.of(CatalogFilterSupport.CITY_ALL)
-                    : CatalogFilterSupport.cityOptions(presenter.cities(AuthSession.token(), v)));
+                    : CatalogFilterSupport.cityOptions(
+                            presenter.cities(AuthSession.token(), CurrentCompanies.currentCompanyId(), v)));
             citySelect.enabled(!CatalogFilterSupport.COUNTRY_ALL.equals(v));
             reload();
         });
@@ -364,20 +373,35 @@ public class CompanyEventListView extends LkPage {
             : LkStatusDot.Tone.warn;
         row.put("status", new LkStatusDot(tone, ev.status().name()));
 
+        // Each action is gated by the capability it actually needs, so a member only sees the
+        // actions they can perform — e.g. a venue-only manager (CONFIGURE_VENUE) sees just "Venue
+        // map", a sales manager just "Sales", an owner the full set.
         LkRow actions = new LkRow().gap(4).noWrap();
-        actions.add(
-            iconBtn("edit",    "Edit metadata", () -> UI.getCurrent().navigate("owner/events/" + ev.eventId())),
-            iconBtn("map",     "Venue map",     () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())),
-            iconBtn("policy",  "Policies",      () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)),
-            iconBtn("chart",   "Sales",         () -> UI.getCurrent().navigate(CompanySalesView.class))
-        );
+        if (Capabilities.has(Capability.EDIT_COMPANY_EVENTS)) {
+            actions.add(iconBtn("edit", "Edit metadata", () -> UI.getCurrent().navigate("owner/events/" + ev.eventId())));
+        }
+        if (Capabilities.has(Capability.MANAGE_VENUE_MAPS)) {
+            actions.add(iconBtn("map", "Venue map", () -> UI.getCurrent().navigate("owner/venue/" + ev.eventId())));
+        }
+        if (Capabilities.has(Capability.EDIT_PURCHASE_POLICIES)) {
+            actions.add(iconBtn("policy", "Policies", () -> UI.getCurrent().navigate(PurchasePolicyEditorView.class)));
+        }
+        if (Capabilities.has(Capability.VIEW_COMPANY_SALES)) {
+            actions.add(iconBtn("chart", "Sales", () -> UI.getCurrent().navigate(CompanySalesView.class)));
+        }
         if (ev.status() == EventStatus.CANCELED) {
             // A canceled event has no further transitions and can't be canceled again —
             // the only action is to permanently remove it.
-            actions.add(iconBtn("trash", "Remove event", () -> openDeleteDialog(ev)));
+            if (Capabilities.has(Capability.EDIT_COMPANY_EVENTS)) {
+                actions.add(iconBtn("trash", "Remove event", () -> openDeleteDialog(ev)));
+            }
         } else {
-            actions.add(iconBtn("gear",    "Change status", () -> openStatusDialog(ev)));
-            actions.add(iconBtn("warning", "Cancel event",  () -> openCancelDialog(ev)));
+            if (Capabilities.has(Capability.EDIT_COMPANY_EVENTS)) {
+                actions.add(iconBtn("gear", "Change status", () -> openStatusDialog(ev)));
+            }
+            if (Capabilities.has(Capability.CANCEL_EVENT)) {
+                actions.add(iconBtn("warning", "Cancel event", () -> openCancelDialog(ev)));
+            }
         }
         row.put("act", actions);
         grid.row(row);

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryInboxView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryInboxView.java
@@ -131,7 +131,7 @@ public class CompanyInquiryInboxView extends LkPage {
         LkRow row = new LkRow().gap(8);
         List<String> applied = ALL.equals(statusFilter) ? List.of() : List.of(statusFilter);
         LkFilterChip status = new LkFilterChip("Status",
-            List.of("Open", "Responded", "Closed"), true, applied);
+            List.of("Open", "Closed"), true, applied);
         status.onApply(() -> {
             Set<String> selected = status.getSelected();
             statusFilter = selected.isEmpty() ? ALL : selected.iterator().next();
@@ -143,8 +143,11 @@ public class CompanyInquiryInboxView extends LkPage {
 
     private List<ConversationDTO> applyStatusFilter(List<ConversationDTO> all) {
         if (ALL.equals(statusFilter)) return all;
+        // "Closed" = terminal (CLOSED/RESOLVED); "Open" = active (OPEN/RESPONDED — i.e. an inquiry
+        // the company has replied to is still "Open", not hidden).
+        boolean wantClosed = "Closed".equals(statusFilter);
         return all.stream()
-            .filter(c -> statusFilter.equals(humanizeStatus(c.status())))
+            .filter(c -> isTerminal(c.status()) == wantClosed)
             .toList();
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryRespondView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyInquiryRespondView.java
@@ -102,8 +102,10 @@ public class CompanyInquiryRespondView extends LkPage implements BeforeEnterObse
 
     private void handleReply(String text) {
         switch (presenter.reply(AuthSession.token(), conversationId, text)) {
-            case CompanyInquiryInboxPresenter.ActionOutcome.Success ignored ->
+            case CompanyInquiryInboxPresenter.ActionOutcome.Success ignored -> {
+                Toasts.success("Reply sent.");
                 reload(); // refresh thread + status
+            }
             case CompanyInquiryInboxPresenter.ActionOutcome.NotAuthenticated ignored ->
                 Toasts.failure("Your session has expired — please sign in again.");
             case CompanyInquiryInboxPresenter.ActionOutcome.Failure fail ->

--- a/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/EventManagementView.java
@@ -283,7 +283,7 @@ public class EventManagementView extends LkPage implements BeforeEnterObserver {
 
         rating.setMin(0);
         rating.setMax(5);
-        rating.setStep(0.5);
+        // No step constraint: accept any decimal (e.g. 4.1); only out-of-range [0,5] is flagged invalid.
         rating.setRequiredIndicatorVisible(true);
         rating.setWidthFull();
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
@@ -117,11 +117,6 @@ public class OwnerDashboardView extends LkPage {
         Div row = new Div();
         row.addClassName("ow-stats");
 
-        LkStat inquiries = new LkStat("Open inquiries", String.valueOf(stats.openInquiries()));
-        if (stats.openInquiries() > 0) {
-            inquiries.delta("needs reply", LkStat.Tone.warn);
-        }
-
         // Company rating is derived from the average of this company's events' ratings.
         LkStat rating = new LkStat("Rating",
             stats.rating() == null ? "—" : "★ " + ratingText(stats.rating()));
@@ -136,7 +131,15 @@ public class OwnerDashboardView extends LkPage {
         if (Capabilities.has(Capability.VIEW_COMPANY_SALES)) {
             row.add(new LkStat("Revenue · 30d", "$" + String.format("%,.0f", stats.revenue30d())));
         }
-        row.add(inquiries);
+        // Open inquiries is inquiry-handling data — only members with RESPOND_TO_INQUIRIES
+        // (RESPOND_INQUIRIES) see it, matching the "Customer Inquiries" tile gate below.
+        if (Capabilities.has(Capability.RESPOND_INQUIRIES)) {
+            LkStat inquiries = new LkStat("Open inquiries", String.valueOf(stats.openInquiries()));
+            if (stats.openInquiries() > 0) {
+                inquiries.delta("needs reply", LkStat.Tone.warn);
+            }
+            row.add(inquiries);
+        }
         return row;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
@@ -129,10 +129,14 @@ public class OwnerDashboardView extends LkPage {
         row.add(
             rating,
             new LkStat("Live events",        String.valueOf(stats.activeEvents())),
-            new LkStat("Tickets sold · 30d",  String.format("%,d", stats.ticketsSold30d())),
-            new LkStat("Revenue · 30d",       "$" + String.format("%,.0f", stats.revenue30d())),
-            inquiries
+            new LkStat("Tickets sold · 30d",  String.format("%,d", stats.ticketsSold30d()))
         );
+        // Revenue is sales data — only members with VIEW_SALES (VIEW_COMPANY_SALES) see it, matching
+        // the "Sales History" tile gate below and the VIEW_COMPANY_SALES-gated sales page.
+        if (Capabilities.has(Capability.VIEW_COMPANY_SALES)) {
+            row.add(new LkStat("Revenue · 30d", "$" + String.format("%,.0f", stats.revenue30d())));
+        }
+        row.add(inquiries);
         return row;
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/OwnerDashboardView.java
@@ -176,6 +176,11 @@ public class OwnerDashboardView extends LkPage {
                 "Invite another member as co-owner. Cycle-prevention enforced.",
                 OwnerAppointmentView.class));
 
+        if (Capabilities.has(Capability.VIEW_COMPANY_ORG_TREE))
+            tiles.add(tile("org", "Organizational Tree",
+                "View your company's founder → owners → managers appointment hierarchy.",
+                CompanyOrgTreeView.class));
+
         if (Capabilities.has(Capability.EDIT_PURCHASE_POLICIES))
             tiles.add(tile("policy", "Purchase Policies",
                 "Visual AND/OR builder for company- or event-level rules.",

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -3,7 +3,7 @@ package com.ticketing.system.Presentation.views.company;
 import java.util.List;
 
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Presentation.components.Toasts;
 import com.ticketing.system.Presentation.components.kit.LkBanner;
 import com.ticketing.system.Presentation.components.kit.LkBtn;
@@ -63,7 +63,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     private Span                          validityBadge;
     private Span                          scopeContextLabel;
     private final Div                     loadErrorSlot = new Div();
-    private Select<ProductionCompanyDTO>  companySelect;
+    private Select<MyCompanyDTO>          companySelect;
     private Select<EventDetailDTO>        eventSelect;
     private NativeButton                  companyBtn;
     private NativeButton                  eventBtn;
@@ -106,7 +106,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
             case ContextOutcome.NotAuthenticated na ->
                 disableEditing("Please sign in again to edit policies.");
             case ContextOutcome.NoCompany nc ->
-                disableEditing("You don't own a company yet — register one to set purchase policies.");
+                disableEditing("You're not part of a company workspace yet — join or register one to set purchase policies.");
             case ContextOutcome.Failure f ->
                 showLoadError("Could not load your companies: " + f.reason(), this::initContext);
             case ContextOutcome.Ready ready ->
@@ -114,20 +114,20 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
         }
     }
 
-    private void populateCompanies(List<ProductionCompanyDTO> companies) {
+    private void populateCompanies(List<MyCompanyDTO> companies) {
         companySelect.setEnabled(true);
         companySelect.setItems(companies);
 
-        ProductionCompanyDTO chosen = companies.get(0);
+        MyCompanyDTO chosen = companies.get(0);
         if (routeCompanyId != null) {
-            for (ProductionCompanyDTO c : companies) {
+            for (MyCompanyDTO c : companies) {
                 if (c.companyId() == routeCompanyId) { chosen = c; break; }
             }
         }
         companySelect.setValue(chosen);   // fires onCompanyChosen()
     }
 
-    private void onCompanyChosen(ProductionCompanyDTO c) {
+    private void onCompanyChosen(MyCompanyDTO c) {
         if (c == null) return;
         this.companyId = c.companyId();
 
@@ -218,7 +218,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
 
         companySelect = new Select<>();
         companySelect.setLabel("Company");
-        companySelect.setItemLabelGenerator(ProductionCompanyDTO::name);
+        companySelect.setItemLabelGenerator(MyCompanyDTO::name);
         companySelect.setWidth("220px");
         companySelect.setEnabled(false);
         companySelect.addValueChangeListener(e -> onCompanyChosen(e.getValue()));
@@ -295,7 +295,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     }
 
     private String currentCompanyName() {
-        ProductionCompanyDTO c = companySelect.getValue();
+        MyCompanyDTO c = companySelect.getValue();
         return c != null ? c.name() : ("#" + companyId);
     }
 

--- a/src/main/java/com/ticketing/system/Presentation/views/landing/LandingView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/landing/LandingView.java
@@ -144,7 +144,7 @@ public class LandingView extends LkPage {
     }
 
     private static String priceLabel(EventSummaryDTO e) {
-        return e.minPrice() > 0 ? "From $" + (long) e.minPrice() : "—";
+        return e.minPrice() > 0 ? String.format("From $%,.2f", e.minPrice()) : "—";
     }
 
     // ---- category quick-pick grid ----

--- a/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/CheckoutView.java
@@ -16,6 +16,7 @@ import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.presenters.order.CheckoutPresenter;
+import com.ticketing.system.Presentation.session.OrderSession;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.DetachEvent;
@@ -471,7 +472,7 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
 
             switch (outcome) {
                 case CheckoutPresenter.PayOutcome.Success ok -> {
-                    presenter.setOrderSession(ok.result());
+                    OrderSession.setResult(ok.result());
                     clearIdempotencyKey();
                     Toasts.success("Payment successful — "
                             + formatCents(Money.toCents(ok.result().totalCharged()))
@@ -482,7 +483,9 @@ public class CheckoutView extends LkPage implements BeforeEnterObserver, AfterNa
                 case CheckoutPresenter.PayOutcome.PolicyRejected p ->
                     Toasts.failure("Cannot purchase: " + p.reason());
                 case CheckoutPresenter.PayOutcome.PaymentDeclined d ->
-                    Toasts.failure("Payment declined: " + d.reason());
+                    Toasts.failure("Payment declined. Please check your card details or use a different card.");
+                case CheckoutPresenter.PayOutcome.GatewayUnavailable g ->
+                    Toasts.failure("An unexpected error occurred. Please try again in a moment.");
                 case CheckoutPresenter.PayOutcome.SoldOut s ->
                     Toasts.failure("Those seats just sold out. Please choose again.");
                 case CheckoutPresenter.PayOutcome.OrderExpired e ->

--- a/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/order/OrderConfirmationView.java
@@ -10,6 +10,7 @@ import com.ticketing.system.Presentation.components.kit.LkIcon;
 import com.ticketing.system.Presentation.components.kit.LkPage;
 import com.ticketing.system.Presentation.components.kit.LkRow;
 import com.ticketing.system.Presentation.layouts.MainLayout;
+import com.ticketing.system.Presentation.session.OrderSession;
 import com.ticketing.system.Presentation.views.account.MyAccountView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.vaadin.flow.component.Component;
@@ -21,7 +22,6 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 import java.util.LinkedHashMap;
@@ -36,13 +36,10 @@ public class OrderConfirmationView extends LkPage implements BeforeEnterObserver
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
-        VaadinSession s = VaadinSession.getCurrent();
-        if (s == null) {
-            result = null;
-        } else {
-            result = (CheckoutResultDTO) s.getAttribute("checkout.result");
-            s.setAttribute("checkout.result", null);
-        }
+        // Read-once: grab the result handed over by CheckoutView, then clear it so a
+        // refresh / re-navigation reroutes to Browse instead of re-showing the receipt.
+        result = OrderSession.result();
+        OrderSession.clear();
         if (result == null) {
             event.rerouteTo(BrowseEventsView.class);
             return;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -28,3 +28,9 @@ seed:
   scenario: classpath:scenarios/demo.scenario
   mode: idempotent
   fail-fast: false
+
+# WSEP external-systems client. Prod/eval keep the 20s default (application.yml is
+# untouched); dev shortens the per-request timeout so the "gateway unreachable" demo
+# (e.g. CVV 986, which never answers) surfaces the generic error in ~8s instead of ~20s.
+wsep:
+  request-timeout-seconds: 8

--- a/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/views/catalog/BrowseEventsFilterTest.java
@@ -97,25 +97,31 @@ class BrowseEventsFilterTest {
         assertNull(CatalogFilterSupport.locationFilter("All cities", "All countries"));
     }
 
-    // ── cityOptionsFor ────────────────────────────────────────────────────────
+    // ── countryOptions / cityOptions ──────────────────────────────────────────
+    // Pure prepend helpers — the data source supplies the (already distinct/sorted) values.
 
     @Test
-    void cityOptionsFor_knownCountry_prependsAllCities() {
-        List<String> opts = CatalogFilterSupport.cityOptionsFor("Israel");
-        assertEquals("All cities", opts.get(0));
-        assertTrue(opts.contains("Tel Aviv"));
-        assertTrue(opts.contains("Jerusalem"));
-        assertTrue(opts.contains("Haifa"));
+    void countryOptions_prependsAllCountries() {
+        assertEquals(List.of("All countries", "Israel", "USA"),
+                CatalogFilterSupport.countryOptions(List.of("Israel", "USA")));
     }
 
     @Test
-    void cityOptionsFor_unknownCountry_returnsOnlyAllCities() {
-        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptionsFor("Mars"));
+    void countryOptions_emptyOrNull_isJustSentinel() {
+        assertEquals(List.of("All countries"), CatalogFilterSupport.countryOptions(List.of()));
+        assertEquals(List.of("All countries"), CatalogFilterSupport.countryOptions(null));
     }
 
     @Test
-    void cityOptionsFor_allCountries_returnsOnlyAllCities() {
-        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptionsFor("All countries"));
+    void cityOptions_prependsAllCities() {
+        assertEquals(List.of("All cities", "Tel Aviv", "Haifa"),
+                CatalogFilterSupport.cityOptions(List.of("Tel Aviv", "Haifa")));
+    }
+
+    @Test
+    void cityOptions_emptyOrNull_isJustSentinel() {
+        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptions(List.of()));
+        assertEquals(List.of("All cities"), CatalogFilterSupport.cityOptions(null));
     }
 
     // ── isValidCustomRange ────────────────────────────────────────────────────

--- a/src/test/java/com/ticketing/system/acceptance/CompanySalesReportAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CompanySalesReportAcceptanceTest.java
@@ -1,0 +1,120 @@
+package com.ticketing.system.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.orders.IOrderReceiptRepository;
+import com.ticketing.system.Core.Domain.orders.OrderReceipt;
+import com.ticketing.system.Core.Domain.orders.ReceiptLine;
+import com.ticketing.system.Presentation.presenters.company.CompanySalesPresenter;
+
+/**
+ * Issue #430 [Eval 9] — after a successful purchase the sale must appear in the owner's
+ * sales report (real receipt data, not mocked). These tests drive the exact path the
+ * {@code owner/sales} view uses ({@link CompanySalesPresenter#load}) and assert that a
+ * freshly-persisted purchase shows up on a subsequent {@code load()} — which is precisely
+ * what the new Refresh button does at runtime. Existing suites hit the service directly;
+ * this closes the gap by exercising the presenter and the reload (refresh) contract.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class CompanySalesReportAcceptanceTest {
+
+    @Autowired
+    private AuthenticationService authService;
+    @Autowired
+    private CompanyManagementService companyService;
+    @Autowired
+    private EventManagementService eventManagementService;
+    @Autowired
+    private IOrderReceiptRepository orderReceiptRepository;
+    @Autowired
+    private CompanySalesPresenter presenter;
+
+    private AuthTokenDTO registerAndLoginMember(String name) {
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 20));
+        return authService.login(new LoginRequestDTO(name, "Password1", sid)).authToken();
+    }
+
+    private int addEventForCompany(AuthTokenDTO owner, int companyId, String eventName) {
+        EventDetailDTO event = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                companyId, eventName, "desc", List.of("Artist"),
+                EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(1), LocalDateTime.now().plusDays(1).plusHours(3))),
+                null));
+        return Integer.parseInt(event.eventId());
+    }
+
+    /** Persists a completed purchase of {@code eventId} for {@code total} (one standing ticket). */
+    private void recordPurchase(AuthTokenDTO buyer, int eventId, double total) {
+        orderReceiptRepository.save(OrderReceipt.forMember(
+                orderReceiptRepository.nextId(), buyer.userId(), total,
+                List.of(new ReceiptLine(1, total, eventId, 1, null, LocalDateTime.now()))));
+    }
+
+    private CompanySalesPresenter.Outcome.Success loadSuccess(AuthTokenDTO owner) {
+        CompanySalesPresenter.Outcome outcome = presenter.load(owner.token());
+        return assertInstanceOf(CompanySalesPresenter.Outcome.Success.class, outcome);
+    }
+
+    @Test
+    void GivenCompletedPurchase_WhenOwnerReloadsSalesReport_ThenSaleAppears() {
+        AuthTokenDTO owner = registerAndLoginMember("salesReportOwner1");
+        int companyId = companyService.registerCompany(
+                owner.token(), new CompanyRegistrationDTO("SalesReportCo1", "desc")).companyId();
+        int eventId = addEventForCompany(owner, companyId, "Report Event");
+
+        // Baseline: the report loads cleanly with no sales yet.
+        CompanySalesPresenter.Outcome.Success before = loadSuccess(owner);
+        assertEquals("SalesReportCo1", before.companyName());
+        assertTrue(before.sales().records().isEmpty(), "no sales expected before any purchase");
+
+        // A buyer completes a purchase of the company's event.
+        recordPurchase(owner, eventId, 80.0);
+
+        // Reloading the report (== clicking Refresh) surfaces the recent sale.
+        CompanySalesPresenter.Outcome.Success after = loadSuccess(owner);
+        assertEquals(1, after.sales().records().size());
+        assertEquals(80.0, after.sales().records().get(0).totalPaid());
+    }
+
+    @Test
+    void GivenSecondPurchase_WhenOwnerReloadsAgain_ThenBothSalesAppear() {
+        AuthTokenDTO owner = registerAndLoginMember("salesReportOwner2");
+        int companyId = companyService.registerCompany(
+                owner.token(), new CompanyRegistrationDTO("SalesReportCo2", "desc")).companyId();
+        int eventId = addEventForCompany(owner, companyId, "Report Event 2");
+
+        recordPurchase(owner, eventId, 80.0);
+        assertEquals(1, loadSuccess(owner).sales().records().size());
+
+        // A second purchase lands after the report was already viewed once.
+        recordPurchase(owner, eventId, 50.0);
+
+        // A further reload reflects the new sale too (no stale snapshot).
+        assertEquals(2, loadSuccess(owner).sales().records().size());
+    }
+}

--- a/src/test/java/com/ticketing/system/acceptance/CompanySalesReportAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/CompanySalesReportAcceptanceTest.java
@@ -76,7 +76,7 @@ class CompanySalesReportAcceptanceTest {
     }
 
     private CompanySalesPresenter.Outcome.Success loadSuccess(AuthTokenDTO owner) {
-        CompanySalesPresenter.Outcome outcome = presenter.load(owner.token());
+        CompanySalesPresenter.Outcome outcome = presenter.load(owner.token(), null);
         return assertInstanceOf(CompanySalesPresenter.Outcome.Success.class, outcome);
     }
 

--- a/src/test/java/com/ticketing/system/acceptance/DelayedAppointmentNotificationAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/DelayedAppointmentNotificationAcceptanceTest.java
@@ -1,0 +1,101 @@
+package com.ticketing.system.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.AppointmentResponseDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.LoginDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.NotificationDTO;
+import com.ticketing.system.Core.Application.dto.OwnerAppointmentRequestDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
+import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
+import com.ticketing.system.Core.Domain.users.IUserRepository;
+
+/**
+ * Eval point 2 — delayed (offline) notifications.
+ *
+ * <p>u1 appoints u2 as a company owner while u2 is offline. The appointment notification is
+ * stored PENDING; when u2 next logs in it is delivered <b>immediately</b> in the login payload
+ * (which the UI drops straight into the notification bell), and u2 can then confirm the
+ * appointment. This drives the real service path
+ * ({@code appointOwner} → login {@code deliverPending} → {@code respondToAppointment}).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class DelayedAppointmentNotificationAcceptanceTest {
+
+    @Autowired private AuthenticationService authService;
+    @Autowired private CompanyManagementService companyService;
+    @Autowired private INotificationRepository notificationRepository;
+    @Autowired private IProductionCompanyRepository companyRepository;
+    @Autowired private IUserRepository userRepository;
+
+    @Test
+    void GivenOfflineAppointee_WhenTheyLogIn_ThenSeeAppointmentNotificationAndCanConfirm() {
+        // --- u1: a founder/owner with a company ---
+        AuthTokenDTO u1 = registerAndLogin("apptOwner");
+        int companyId = companyService.registerCompany(
+                u1.token(), new CompanyRegistrationDTO("ApptCo", "desc")).companyId();
+
+        // --- u2: registered but OFFLINE (never logged in / no delivery yet) ---
+        String u2Name = register("apptTarget");
+        int u2Id = userRepository.findByUsername(u2Name).orElseThrow().getUserId();
+        assertTrue(notificationRepository.findByRecipientAndStatus(u2Id, NotificationStatus.PENDING).isEmpty(),
+                "no notifications before the appointment");
+
+        // --- u1 appoints u2 as owner while u2 is offline -> a PENDING notification is stored ---
+        companyService.appointOwner(u1.token(), new OwnerAppointmentRequestDTO(companyId, u2Id));
+        assertEquals(1, notificationRepository.findByRecipientAndStatus(u2Id, NotificationStatus.PENDING).size(),
+                "the offline appointment must be queued as a pending notification");
+
+        // --- u2 logs in -> the delayed notification is delivered immediately in the login payload ---
+        LoginDTO u2Login = login(u2Name);
+        List<NotificationDTO> delivered = u2Login.notifications();
+        assertTrue(delivered.stream().anyMatch(n -> "OWNER_APPOINTMENT_PENDING".equals(n.type())),
+                "u2 must immediately see the owner-appointment notification on login; got: " + delivered);
+        assertTrue(notificationRepository.findByRecipientAndStatus(u2Id, NotificationStatus.PENDING).isEmpty(),
+                "delivered notifications move out of PENDING (no re-delivery)");
+
+        // --- u2 confirms the appointment -> u2 is now a company owner ---
+        companyService.respondToAppointment(
+                u2Login.authToken().token(), new AppointmentResponseDTO(companyId, true));
+        assertTrue(companyRepository.getCompanyById(companyId).isOwner(u2Id),
+                "after confirming, u2 is an owner of the company");
+        assertFalse(companyRepository.getCompanyById(companyId).isOwner(-1));
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private AuthTokenDTO registerAndLogin(String baseName) {
+        String name = register(baseName);
+        return login(name).authToken();
+    }
+
+    /** Register a fresh user and return the unique username (does NOT establish a session). */
+    private String register(String baseName) {
+        String name = baseName + "-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 30));
+        return name;
+    }
+
+    private LoginDTO login(String name) {
+        String sid = authService.startGuestSession().sessionId();
+        return authService.login(new LoginRequestDTO(name, "Password1", sid));
+    }
+}

--- a/src/test/java/com/ticketing/system/acceptance/ManagerPermissionMatrixAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/ManagerPermissionMatrixAcceptanceTest.java
@@ -1,0 +1,178 @@
+package com.ticketing.system.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AppointmentResponseDTO;
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.CompanyPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.EventUpdateDTO;
+import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.ManagerAppointmentRequestDTO;
+import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.ZoneConfigDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.users.Permission;
+
+/**
+ * The manager-permission matrix end-to-end (real services, real appointment → permission
+ * resolution). Each manager permission grants exactly its own actions and nothing else:
+ * <ul>
+ *   <li>{@code MANAGE_INVENTORY} — edit metadata, change status, create events; NOT venue/policies.</li>
+ *   <li>{@code CONFIGURE_VENUE} — edit the venue map; NOT event metadata/status/policies.</li>
+ *   <li>{@code EDIT_POLICIES} — edit company + event purchase policies; NOT event/venue.</li>
+ * </ul>
+ * Guards the re-gating of the event-management service methods from CONFIGURE_VENUE to the
+ * intended permission.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class ManagerPermissionMatrixAcceptanceTest {
+
+    @Autowired private AuthenticationService authService;
+    @Autowired private CompanyManagementService companyService;
+    @Autowired private EventManagementService eventManagementService;
+
+    @Test
+    void ConfigureVenueManager_CanEditVenue_ButNotEventOrPolicies() {
+        Fixture f = setup("venue");
+        AuthTokenDTO m = appointManagerWith(f, "venueMgr", Permission.CONFIGURE_VENUE);
+
+        // CAN: reconfigure the venue map.
+        eventManagementService.configureVenueMap(m.token(), f.companyId,
+                new VenueMapConfigDTO(String.valueOf(f.eventId), "Arena", 1, 1, List.of(standingZone("Reworked", 80))));
+
+        // CANNOT: edit metadata / change status (MANAGE_INVENTORY) or policies (EDIT_POLICIES).
+        assertMissingPermission(() -> eventManagementService.editEventDetails(m.token(),
+                new EventUpdateDTO(String.valueOf(f.eventId), "Hacked", null, null, null, null)), "MANAGE_INVENTORY");
+        assertMissingPermission(() -> eventManagementService.changeEventStatus(m.token(), f.eventId, EventStatus.ON_SALE),
+                "MANAGE_INVENTORY");
+        assertMissingPermission(() -> eventManagementService.setEventPolicies(m.token(),
+                new EventPolicyConfigDTO(f.companyId, f.eventId, maxTickets(4))), "EDIT_POLICIES");
+    }
+
+    @Test
+    void InventoryManager_CanManageEvents_ButNotVenueOrPolicies() {
+        Fixture f = setup("inv");
+        AuthTokenDTO m = appointManagerWith(f, "invMgr", Permission.MANAGE_INVENTORY);
+
+        // CAN: edit metadata, change status (Scheduled -> On sale), create a new event.
+        eventManagementService.editEventDetails(m.token(),
+                new EventUpdateDTO(String.valueOf(f.eventId), "Renamed by Manager", null, null, null, null));
+        eventManagementService.changeEventStatus(m.token(), f.eventId, EventStatus.ON_SALE);
+        EventDetailDTO created = eventManagementService.addEvent(m.token(), new EventCreationDTO(
+                f.companyId, "Manager-Created", "desc", List.of("Artist"), EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(5), LocalDateTime.now().plusDays(5).plusHours(2))),
+                null));
+        assertNotNull(created.eventId(), "a MANAGE_INVENTORY manager can create events");
+
+        // CANNOT: venue (CONFIGURE_VENUE) or policies (EDIT_POLICIES).
+        assertMissingPermission(() -> eventManagementService.configureVenueMap(m.token(), f.companyId,
+                new VenueMapConfigDTO(String.valueOf(f.eventId), "X", 1, 1, List.of(standingZone("Z", 10)))),
+                "CONFIGURE_VENUE");
+        assertMissingPermission(() -> eventManagementService.setEventPolicies(m.token(),
+                new EventPolicyConfigDTO(f.companyId, f.eventId, maxTickets(4))), "EDIT_POLICIES");
+    }
+
+    @Test
+    void PoliciesManager_CanEditPolicies_ButNotEventsOrVenue() {
+        Fixture f = setup("pol");
+        AuthTokenDTO m = appointManagerWith(f, "polMgr", Permission.EDIT_POLICIES);
+
+        // CAN: event-level and company-level purchase policies.
+        eventManagementService.setEventPolicies(m.token(),
+                new EventPolicyConfigDTO(f.companyId, f.eventId, maxTickets(4)));
+        companyService.setCompanyPolicies(m.token(),
+                new CompanyPolicyConfigDTO(f.companyId,
+                        new PurchasePolicyDTO("MIN_TICKETS", null, 2, null, null), List.of()));
+
+        // CANNOT: edit metadata (MANAGE_INVENTORY) or venue (CONFIGURE_VENUE).
+        assertMissingPermission(() -> eventManagementService.editEventDetails(m.token(),
+                new EventUpdateDTO(String.valueOf(f.eventId), "Nope", null, null, null, null)), "MANAGE_INVENTORY");
+        assertMissingPermission(() -> eventManagementService.configureVenueMap(m.token(), f.companyId,
+                new VenueMapConfigDTO(String.valueOf(f.eventId), "X", 1, 1, List.of(standingZone("Z", 10)))),
+                "CONFIGURE_VENUE");
+    }
+
+    // ---- fixtures & helpers --------------------------------------------
+
+    private record Fixture(AuthTokenDTO owner, int companyId, int eventId) { }
+
+    /** Owner + company + a SCHEDULED standing-zone event (created by the owner, who holds all perms). */
+    private Fixture setup(String prefix) {
+        AuthTokenDTO owner = registerAndLogin(prefix + "Owner");
+        int companyId = companyService.registerCompany(owner.token(),
+                new CompanyRegistrationDTO("MatrixCo-" + owner.userId(), "desc")).companyId();
+        EventDetailDTO ev = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                companyId, "Matrix Event", "desc", List.of("Artist"), EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(3))),
+                null));
+        int eventId = Integer.parseInt(ev.eventId());
+        eventManagementService.configureVenueMap(owner.token(), companyId,
+                new VenueMapConfigDTO(ev.eventId(), "Arena", 1, 1, List.of(standingZone("Standing", 100))));
+        return new Fixture(owner, companyId, eventId);
+    }
+
+    private AuthTokenDTO appointManagerWith(Fixture f, String baseName, Permission... perms) {
+        AuthTokenDTO mgr = registerAndLogin(baseName);
+        companyService.appointManager(f.owner.token(),
+                new ManagerAppointmentRequestDTO(f.companyId, mgr.userId(), List.of(perms)));
+        companyService.respondToAppointment(mgr.token(), new AppointmentResponseDTO(f.companyId, true));
+        return mgr;
+    }
+
+    private static ZoneConfigDTO standingZone(String name, int capacity) {
+        return new ZoneConfigDTO(name, false, capacity, null, 50.0, new GridPlacementDTO(1, 1, 1, 1));
+    }
+
+    private static PurchasePolicyDTO maxTickets(int max) {
+        return new PurchasePolicyDTO("MAX_TICKETS", null, null, max, null);
+    }
+
+    private AuthTokenDTO registerAndLogin(String baseName) {
+        String name = baseName + "-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 30));
+        return authService.login(new LoginRequestDTO(name, "Password1", sid)).authToken();
+    }
+
+    private static void assertMissingPermission(Executable action, String permissionName) {
+        RuntimeException ex = assertThrows(RuntimeException.class, action);
+        String msg = String.valueOf(rootMessage(ex));
+        assertTrue(msg.contains("Missing permission") && msg.contains(permissionName),
+                "expected a missing-" + permissionName + " rejection, but was: " + msg);
+    }
+
+    private static String rootMessage(Throwable t) {
+        Throwable c = t;
+        while (c.getCause() != null && c.getCause() != c) {
+            c = c.getCause();
+        }
+        return c.getMessage();
+    }
+}

--- a/src/test/java/com/ticketing/system/acceptance/MessagingAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/MessagingAcceptanceTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
@@ -45,8 +46,15 @@ import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 //
 // The "test" context is shared across methods, so every persona/company uses a unique name and
 // assertions are written to tolerate co-resident data (membership by id, not absolute totals).
+//
+// registerAdmin() saves admins with custom usernames straight into the shared in-memory admin pool.
+// Because the platform's default-admin bootstrap only fires when NO admin exists (existsAny), those
+// rogue admins would otherwise suppress creation of the default "admin"/"admin" for every later test
+// in the shared context — breaking any test that signs in as the default admin (e.g. to open the
+// market). @DirtiesContext rebuilds the context after this class so that leakage stays contained.
 @SpringBootTest
 @ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 class MessagingAcceptanceTest {
 
     @Autowired private AuthenticationService authService;

--- a/src/test/java/com/ticketing/system/acceptance/PurchasePolicyEnforcementAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/PurchasePolicyEnforcementAcceptanceTest.java
@@ -1,0 +1,190 @@
+package com.ticketing.system.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
+import com.ticketing.system.Core.Application.dto.CheckoutResultDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.ZoneConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapDTO;
+import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Application.services.CheckoutService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.exceptions.PolicyViolationException;
+
+/**
+ * Eval point 3 — purchase policy "between 2 and 4 tickets". An event carries an
+ * {@code AND(MIN_TICKETS 2, MAX_TICKETS 4)} policy; a buyer over the maximum or under the
+ * minimum must be rejected with a <b>clear reason</b>, and a valid quantity must go through.
+ *
+ * <p>This drives the real reserve → checkout path against live services (test profile:
+ * in-memory repos + the in-process payment/issuer stubs). It is the regression guard for the
+ * fix that makes {@code Event.validateEffectivePolicy} throw {@link PolicyViolationException}
+ * (mapped by the checkout presenter to a "Cannot purchase: …" message) instead of a generic
+ * {@code IllegalStateException} (which surfaced only as "Payment could not be completed").
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class PurchasePolicyEnforcementAcceptanceTest {
+
+    @Autowired private AuthenticationService authService;
+    @Autowired private CompanyManagementService companyService;
+    @Autowired private EventManagementService eventManagementService;
+    @Autowired private ReservationService reservationService;
+    @Autowired private CheckoutService checkoutService;
+    @Autowired private CatalogService catalogService;
+    @Autowired private SystemAdminService systemAdminService;
+
+    private static final AtomicInteger SEQ = new AtomicInteger(0);
+
+    /** Reservations/checkout require the trading market open; the test profile boots closed. */
+    @BeforeEach
+    void ensureMarketOpen() {
+        if (systemAdminService.isMarketOpen()) {
+            return;
+        }
+        systemAdminService.initializePlatform(); // idempotent — no-op if already initialized
+        AuthTokenDTO admin = authService.signInAsAdmin("admin", "admin");
+        systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "eval acceptance setup", admin.token()));
+    }
+
+    @Test
+    void GivenMinTwoMaxFourPolicy_WhenBuyerReservesFive_ThenRejectedWithClearReason() {
+        Fixture f = newPolicyEvent(2, 4);
+        AuthTokenDTO buyer = registerAndLogin("polBuyer");
+
+        // MAX is enforced already at reserve — five tickets in one go is over the limit.
+        assertPolicyViolation(
+                () -> reservationService.reserveForMember(
+                        buyer.token(), f.eventId, f.zoneId, InventorySelectionDTO.standing(5)),
+                "at most 4");
+    }
+
+    @Test
+    void GivenMinTwoMaxFourPolicy_WhenBuyerBuysThree_ThenCheckoutSucceeds() {
+        Fixture f = newPolicyEvent(2, 4);
+        AuthTokenDTO buyer = registerAndLogin("polBuyer");
+
+        reservationService.reserveForMember(
+                buyer.token(), f.eventId, f.zoneId, InventorySelectionDTO.standing(3));
+
+        CheckoutResultDTO result =
+                checkoutService.checkoutMember(buyer.token(), "idem-" + SEQ.incrementAndGet(), "ILS", card());
+
+        assertNotNull(result, "a valid 3-ticket purchase must complete");
+        assertEquals(150.0, result.totalCharged(), "3 standing tickets @ 50.0");
+    }
+
+    @Test
+    void GivenMinTwoPolicy_WhenBuyerChecksOutOne_ThenRejectedWithClearReason() {
+        Fixture f = newPolicyEvent(2, 4);
+        AuthTokenDTO buyer = registerAndLogin("polBuyer");
+
+        // MIN is deferred at reserve (cart still being built) — one ticket reserves fine …
+        reservationService.reserveForMember(
+                buyer.token(), f.eventId, f.zoneId, InventorySelectionDTO.standing(1));
+
+        // … but fails at checkout, and the buyer must see the specific reason.
+        assertPolicyViolation(
+                () -> checkoutService.checkoutMember(
+                        buyer.token(), "idem-" + SEQ.incrementAndGet(), "ILS", card()),
+                "at least 2");
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private record Fixture(int companyId, int eventId, int zoneId) { }
+
+    /** Owner + company + published single-standing-zone event (@50) carrying AND(min,max). */
+    private Fixture newPolicyEvent(int min, int max) {
+        AuthTokenDTO owner = registerAndLogin("polOwner");
+        int companyId = companyService.registerCompany(
+                owner.token(), new CompanyRegistrationDTO("PolCo" + SEQ.incrementAndGet(), "desc")).companyId();
+
+        EventDetailDTO event = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                companyId, "Policy Show", "desc", List.of("Artist"), EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(3))),
+                null));
+        int eventId = Integer.parseInt(event.eventId());
+
+        ZoneConfigDTO standing = new ZoneConfigDTO(
+                "Standing", false, 100, null, 50.0, new GridPlacementDTO(1, 1, 1, 1));
+        eventManagementService.configureVenueMap(owner.token(), companyId,
+                new VenueMapConfigDTO(event.eventId(), "Test Arena", 1, 1, List.of(standing)));
+        eventManagementService.publishEvent(owner.token(), companyId, eventId);
+
+        PurchasePolicyDTO minDto = new PurchasePolicyDTO("MIN_TICKETS", null, min, null, null);
+        PurchasePolicyDTO maxDto = new PurchasePolicyDTO("MAX_TICKETS", null, null, max, null);
+        PurchasePolicyDTO and = new PurchasePolicyDTO("AND", null, null, null, List.of(minDto, maxDto));
+        eventManagementService.setEventPolicies(owner.token(), new EventPolicyConfigDTO(companyId, eventId, and));
+
+        VenueMapDTO map = catalogService.getEventVenueMap(owner.token(), eventId);
+        int zoneId = map.inventoryZones().stream()
+                .filter(z -> "STANDING".equals(z.getZoneType()))
+                .findFirst().orElseThrow().getId();
+
+        return new Fixture(companyId, eventId, zoneId);
+    }
+
+    private AuthTokenDTO registerAndLogin(String baseName) {
+        String name = baseName + SEQ.incrementAndGet();
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 25));
+        return authService.login(new LoginRequestDTO(name, "Password1", sid)).authToken();
+    }
+
+    private static CardDetailsDTO card() {
+        return new CardDetailsDTO("4111111111111111", "123", 12, 2030, "Demo Buyer");
+    }
+
+    /** Assert the action fails with a PolicyViolationException whose reason contains the fragment. */
+    private static void assertPolicyViolation(Executable action, String expectedFragment) {
+        RuntimeException ex = assertThrows(RuntimeException.class, action);
+        PolicyViolationException pve = findCause(ex, PolicyViolationException.class);
+        assertNotNull(pve, "expected a PolicyViolationException in the cause chain, but got: " + ex);
+        assertTrue(pve.getMessage().contains(expectedFragment),
+                "expected the reason to contain '" + expectedFragment + "' but was: " + pve.getMessage());
+    }
+
+    private static <T extends Throwable> T findCause(Throwable t, Class<T> type) {
+        for (Throwable c = t; c != null; c = c.getCause()) {
+            if (type.isInstance(c)) {
+                return type.cast(c);
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/ticketing/system/acceptance/RoleChainAndLayoutPermissionAcceptanceTest.java
+++ b/src/test/java/com/ticketing/system/acceptance/RoleChainAndLayoutPermissionAcceptanceTest.java
@@ -1,0 +1,216 @@
+package com.ticketing.system.acceptance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AppointmentResponseDTO;
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.CardDetailsDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.EventPolicyConfigDTO;
+import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
+import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.ManagerAppointmentRequestDTO;
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.dto.OwnerAppointmentRequestDTO;
+import com.ticketing.system.Core.Application.dto.PurchasePolicyDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.ZoneConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Application.services.CheckoutService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Core.Domain.users.IUserRepository;
+import com.ticketing.system.Core.Domain.users.Permission;
+
+/**
+ * Eval points 8 & 11 — role hierarchy and the layout-vs-policy permission boundary.
+ *
+ * <p>Builds the founder → owner → manager chain (u1 founds, appoints u2 owner; u2 appoints u3
+ * manager with CONFIGURE_VENUE only) and asserts:
+ * <ul>
+ *   <li>the chain is recorded (founder, owner, manager-with-the-granted-permission);</li>
+ *   <li>u3 CAN edit an event's layout (configure venue map) but CANNOT manage purchase policies;</li>
+ *   <li>a published event that has a sold ticket is locked against layout changes — sold tickets
+ *       can never be orphaned by a reconfiguration.</li>
+ * </ul>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class RoleChainAndLayoutPermissionAcceptanceTest {
+
+    @Autowired private AuthenticationService authService;
+    @Autowired private CompanyManagementService companyService;
+    @Autowired private EventManagementService eventManagementService;
+    @Autowired private ReservationService reservationService;
+    @Autowired private CheckoutService checkoutService;
+    @Autowired private CatalogService catalogService;
+    @Autowired private IProductionCompanyRepository companyRepository;
+    @Autowired private IUserRepository userRepository;
+    @Autowired private SystemAdminService systemAdminService;
+
+    /** Reservations/checkout require the trading market open; the test profile boots closed. */
+    @BeforeEach
+    void ensureMarketOpen() {
+        if (systemAdminService.isMarketOpen()) {
+            return;
+        }
+        systemAdminService.initializePlatform(); // idempotent — no-op if already initialized
+        AuthTokenDTO admin = authService.signInAsAdmin("admin", "admin");
+        systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "eval acceptance setup", admin.token()));
+    }
+
+    @Test
+    void GivenFounderAppointsOwnerAppointsManager_ThenChainAndGrantedPermissionsHold() {
+        Chain c = buildChain();
+
+        assertEquals(c.u1Id, companyRepository.getCompanyById(c.companyId).getFounderId(),
+                "u1 is the founder");
+        assertTrue(companyRepository.getCompanyById(c.companyId).isOwner(c.u2Id),
+                "u2 (appointed by u1) is an owner");
+        assertTrue(userRepository.getUserById(c.u3Id).hasPermissionInCompany(c.companyId, Permission.CONFIGURE_VENUE),
+                "u3 (appointed by u2) has the granted CONFIGURE_VENUE permission");
+        assertFalse(userRepository.getUserById(c.u3Id).hasPermissionInCompany(c.companyId, Permission.EDIT_POLICIES),
+                "u3 was NOT granted EDIT_POLICIES");
+    }
+
+    @Test
+    void GivenManagerWithVenuePermission_WhenEditingLayout_ThenAllowedButPolicyManagementBlocked() {
+        Chain c = buildChain();
+        int eventId = createScheduledStandingEvent(c.u1, c.companyId, "Layout Event", 100, 50.0);
+
+        // u3 can edit the event layout (CONFIGURE_VENUE) — reconfiguring with a fresh zone succeeds.
+        ZoneConfigDTO newZone = new ZoneConfigDTO("Reworked Standing", false, 120, null, 55.0,
+                new GridPlacementDTO(1, 1, 1, 1));
+        eventManagementService.configureVenueMap(c.u3.token(), c.companyId,
+                new VenueMapConfigDTO(String.valueOf(eventId), "Reworked Arena", 1, 1, List.of(newZone)));
+        assertEquals(120, standingZone(c.u3.token(), eventId).getAvailableAmount(),
+                "u3's layout edit took effect");
+
+        // u3 cannot manage purchase policies (no EDIT_POLICIES) — the policy path is blocked.
+        PurchasePolicyDTO maxPolicy = new PurchasePolicyDTO("MAX_TICKETS", null, null, 4, null);
+        assertMissingPermission(
+                () -> eventManagementService.setEventPolicies(
+                        c.u3.token(), new EventPolicyConfigDTO(c.companyId, eventId, maxPolicy)),
+                "EDIT_POLICIES");
+    }
+
+    @Test
+    void GivenPublishedEventWithSoldTicket_WhenLayoutChangeAttempted_ThenBlocked() {
+        Chain c = buildChain();
+        int eventId = createScheduledStandingEvent(c.u1, c.companyId, "Sold Event", 100, 50.0);
+        eventManagementService.publishEvent(c.u1.token(), c.companyId, eventId);
+
+        // A buyer purchases one ticket -> the event now has sold inventory.
+        AuthTokenDTO buyer = registerAndLogin("layoutBuyer");
+        int zoneId = standingZone(c.u1.token(), eventId).getId();
+        reservationService.reserveForMember(buyer.token(), eventId, zoneId, InventorySelectionDTO.standing(1));
+        checkoutService.checkoutMember(buyer.token(), "idem-layout-" + c.u3Id, "ILS", card());
+
+        // Reconfiguring the layout of a live event with a sold ticket is refused — the sale is protected.
+        ZoneConfigDTO replacement = new ZoneConfigDTO("Replacement", false, 10, null, 50.0,
+                new GridPlacementDTO(1, 1, 1, 1));
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> eventManagementService.configureVenueMap(c.u3.token(), c.companyId,
+                        new VenueMapConfigDTO(String.valueOf(eventId), "Hacked Arena", 1, 1, List.of(replacement))));
+        String msg = String.valueOf(rootMessage(ex));
+        assertTrue(msg.contains("reserved or sold") || msg.contains("DRAFT or SCHEDULED"),
+                "a layout change to an event with sold tickets must be blocked; got: " + msg);
+    }
+
+    // ---- chain construction --------------------------------------------
+
+    private record Chain(int companyId, AuthTokenDTO u1, int u1Id, AuthTokenDTO u2, int u2Id,
+                         AuthTokenDTO u3, int u3Id) { }
+
+    private Chain buildChain() {
+        AuthTokenDTO u1 = registerAndLogin("chainFounder");
+        int companyId = companyService.registerCompany(
+                u1.token(), new CompanyRegistrationDTO("ChainCo-" + u1.userId(), "desc")).companyId();
+
+        AuthTokenDTO u2 = registerAndLogin("chainOwner");
+        companyService.appointOwner(u1.token(), new OwnerAppointmentRequestDTO(companyId, u2.userId()));
+        companyService.respondToAppointment(u2.token(), new AppointmentResponseDTO(companyId, true));
+
+        AuthTokenDTO u3 = registerAndLogin("chainManager");
+        companyService.appointManager(u2.token(),
+                new ManagerAppointmentRequestDTO(companyId, u3.userId(), List.of(Permission.CONFIGURE_VENUE)));
+        companyService.respondToAppointment(u3.token(), new AppointmentResponseDTO(companyId, true));
+
+        return new Chain(companyId, u1, u1.userId(), u2, u2.userId(), u3, u3.userId());
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    /** addEvent (DRAFT) + configure one standing zone -> event is SCHEDULED and editable. */
+    private int createScheduledStandingEvent(AuthTokenDTO owner, int companyId, String name, int capacity, double price) {
+        EventDetailDTO ev = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                companyId, name, "desc", List.of("Artist"), EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(3))),
+                null));
+        int eventId = Integer.parseInt(ev.eventId());
+        ZoneConfigDTO zone = new ZoneConfigDTO("Standing", false, capacity, null, price,
+                new GridPlacementDTO(1, 1, 1, 1));
+        eventManagementService.configureVenueMap(owner.token(), companyId,
+                new VenueMapConfigDTO(ev.eventId(), "Arena", 1, 1, List.of(zone)));
+        return eventId;
+    }
+
+    private com.ticketing.system.Core.Application.dto.InventoryZoneDTO standingZone(String token, int eventId) {
+        VenueMapDTO map = catalogService.getEventVenueMap(token, eventId);
+        return map.inventoryZones().stream()
+                .filter(z -> "STANDING".equals(z.getZoneType()))
+                .findFirst().orElseThrow();
+    }
+
+    private AuthTokenDTO registerAndLogin(String baseName) {
+        String name = baseName + "-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 30));
+        return authService.login(new LoginRequestDTO(name, "Password1", sid)).authToken();
+    }
+
+    private static CardDetailsDTO card() {
+        return new CardDetailsDTO("4111111111111111", "123", 12, 2030, "Demo Buyer");
+    }
+
+    private static void assertMissingPermission(Executable action, String permissionName) {
+        RuntimeException ex = assertThrows(RuntimeException.class, action);
+        String msg = String.valueOf(rootMessage(ex));
+        assertTrue(msg.contains("Missing permission") && msg.contains(permissionName),
+                "expected a missing-" + permissionName + " rejection, but was: " + msg);
+    }
+
+    private static String rootMessage(Throwable t) {
+        Throwable c = t;
+        while (c.getCause() != null && c.getCause() != c) {
+            c = c.getCause();
+        }
+        return c.getMessage();
+    }
+}

--- a/src/test/java/com/ticketing/system/integration/SeatedReservationJpaTest.java
+++ b/src/test/java/com/ticketing/system/integration/SeatedReservationJpaTest.java
@@ -1,0 +1,149 @@
+package com.ticketing.system.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.dto.CompanyRegistrationDTO;
+import com.ticketing.system.Core.Application.dto.EventCreationDTO;
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.GridPlacementDTO;
+import com.ticketing.system.Core.Application.dto.InventorySelectionDTO;
+import com.ticketing.system.Core.Application.dto.InventoryZoneDTO;
+import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
+import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
+import com.ticketing.system.Core.Application.dto.RegisterRequestDTO;
+import com.ticketing.system.Core.Application.dto.ReservationResultDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.SeatConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO.ZoneConfigDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Application.services.CatalogService;
+import com.ticketing.system.Core.Application.services.CompanyManagementService;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Core.Domain.events.EventCategory;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.IEventRepository;
+import com.ticketing.system.Core.Domain.events.Location;
+import com.ticketing.system.Core.Domain.events.ShowDate;
+import com.ticketing.system.Infrastructure.scheduling.EventCompletionSweeper;
+
+/**
+ * Regression test for the seated-ticket reservation failure under the {@code jpa} profile.
+ *
+ * <p>A buyer reserving free, addressable seats flips several child {@code Seat} rows
+ * (AVAILABLE → RESERVED, plus the holding order key + expiry) which must persist through the
+ * {@code SeatedZone} {@code @OneToMany} seat map. The default in-memory ({@code !jpa}) suite can't
+ * catch a flush/merge or optimistic-lock problem there, and the existing JPA repo test only saves
+ * <em>AVAILABLE</em> seats — so this drives a real {@code reserve} under {@code {"test","jpa"}}
+ * (real {@code Jpa*Repository} + H2, in-process external stubs). Fails before the fix; passes after.
+ */
+@SpringBootTest
+@ActiveProfiles({"test", "jpa"})
+class SeatedReservationJpaTest {
+
+    @Autowired private AuthenticationService authService;
+    @Autowired private CompanyManagementService companyService;
+    @Autowired private EventManagementService eventManagementService;
+    @Autowired private ReservationService reservationService;
+    @Autowired private CatalogService catalogService;
+    @Autowired private SystemAdminService systemAdminService;
+    @Autowired private EventCompletionSweeper eventCompletionSweeper;
+    @Autowired private IEventRepository eventRepository;
+
+    @Test
+    void memberReservesTwoFreeSeats_underJpa_succeeds() {
+        ensureMarketOpen();
+
+        AuthTokenDTO owner = registerAndLogin("seatOwner");
+        int companyId = companyService.registerCompany(
+                owner.token(), new CompanyRegistrationDTO("SeatCo", "desc")).companyId();
+        int eventId = createPublishedSeatedEvent(owner, companyId);
+        int zoneId = seatedZone(owner.token(), eventId).getId();
+
+        AuthTokenDTO buyer = registerAndLogin("seatBuyer");
+        ReservationResultDTO result = reservationService.reserveForMember(
+                buyer.token(), eventId, zoneId, InventorySelectionDTO.seated(List.of("A1", "A2")));
+
+        assertNotNull(result, "reserving two free seats must return a result, not throw");
+        assertEquals(1, seatedZone(buyer.token(), eventId).getAvailableAmount(),
+                "2 of the 3 seats are now held");
+    }
+
+    @Test
+    void publishedFutureEvent_survivesTheCompletionSweep_andStaysReservable() {
+        ensureMarketOpen();
+        AuthTokenDTO owner = registerAndLogin("sweepOwner");
+        int companyId = companyService.registerCompany(
+                owner.token(), new CompanyRegistrationDTO("SweepCo", "desc")).companyId();
+        int eventId = createPublishedSeatedEvent(owner, companyId);
+
+        // The dev @Scheduled completion sweep runs ~60s after boot, before a buyer reserves. A
+        // future-dated event must survive it (only events whose last show has ended get COMPLETED).
+        eventCompletionSweeper.completeFinishedEvents(java.time.LocalDateTime.now(java.time.Clock.systemUTC()));
+
+        assertEquals(EventStatus.ON_SALE, eventRepository.findById(eventId).getStatus(),
+                "a future-dated event must NOT be auto-completed by the sweeper");
+
+        AuthTokenDTO buyer = registerAndLogin("sweepBuyer");
+        assertNotNull(reservationService.reserveForMember(buyer.token(), eventId,
+                seatedZone(buyer.token(), eventId).getId(), InventorySelectionDTO.seated(List.of("A1", "A2"))),
+                "the event is still ON_SALE after the sweep, so reserve must succeed");
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private void ensureMarketOpen() {
+        if (systemAdminService.isMarketOpen()) {
+            return;
+        }
+        systemAdminService.initializePlatform(); // idempotent — creates the default admin + READY
+        AuthTokenDTO admin = authService.signInAsAdmin("admin", "admin");
+        systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "seated reserve jpa test", admin.token()));
+    }
+
+    /** addEvent + configure a 3-seat seated zone (A1/A2/A3) + publish → ON_SALE. */
+    private int createPublishedSeatedEvent(AuthTokenDTO owner, int companyId) {
+        EventDetailDTO ev = eventManagementService.addEvent(owner.token(), new EventCreationDTO(
+                companyId, "Seated Show", "desc", List.of("Artist"), EventCategory.CONCERT, 4.5,
+                new Location("Israel", "Tel Aviv"),
+                List.of(new ShowDate(LocalDateTime.now().plusDays(10), LocalDateTime.now().plusDays(10).plusHours(3))),
+                null));
+        int eventId = Integer.parseInt(ev.eventId());
+        List<SeatConfigDTO> seats = List.of(
+                new SeatConfigDTO("A1", 1, 0),
+                new SeatConfigDTO("A2", 2, 0),
+                new SeatConfigDTO("A3", 3, 0));
+        ZoneConfigDTO seated = new ZoneConfigDTO("Orchestra", true, null, seats, 100.0,
+                new GridPlacementDTO(1, 1, 1, 1));
+        eventManagementService.configureVenueMap(owner.token(), companyId,
+                new VenueMapConfigDTO(ev.eventId(), "Arena", 1, 1, List.of(seated)));
+        eventManagementService.publishEvent(owner.token(), companyId, eventId);
+        return eventId;
+    }
+
+    private InventoryZoneDTO seatedZone(String token, int eventId) {
+        VenueMapDTO map = catalogService.getEventVenueMap(token, eventId);
+        return map.inventoryZones().stream()
+                .filter(z -> "SEATED".equals(z.getZoneType()))
+                .findFirst().orElseThrow();
+    }
+
+    private AuthTokenDTO registerAndLogin(String baseName) {
+        String name = baseName + "-" + java.util.UUID.randomUUID().toString().substring(0, 8);
+        String sid = authService.startGuestSession().sessionId();
+        authService.register(new RegisterRequestDTO(name, name + "@test.com", "Password1", sid, 30));
+        return authService.login(new LoginRequestDTO(name, "Password1", sid)).authToken();
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/CatalogServiceTest.java
@@ -765,6 +765,79 @@ class CatalogServiceTest {
         assertEquals(3, catalogService.search(VALID_TOKEN, "show", 3).size());
     }
 
+    // -------------------------------------------------------------------------
+    // Browse filter options: onSaleCountries / onSaleCitiesInCountry
+    // -------------------------------------------------------------------------
+
+    @Test
+    void onSaleCountries_distinctSortedAndVisibleOnly() {
+        // Build mocks into locals BEFORE stubbing the repos — helper calls invoke when(...) themselves,
+        // which Mockito rejects if nested inside an ongoing thenReturn(...) stub.
+        Event e1 = locatedEvent(1, 10, "Israel", "Tel Aviv");
+        Event e2 = locatedEvent(2, 10, "Israel", "Haifa");
+        Event e3 = locatedEvent(3, 20, "USA", "New York");
+        ProductionCompany a = createMockCompany("A", 4.0);
+        ProductionCompany b = createMockCompany("B", 4.0);
+        when(mockEventRepository.searchONSALE(any())).thenReturn(List.of(e1, e2, e3));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(a);
+        when(mockCompanyRepository.getCompanyById(20)).thenReturn(b);
+
+        assertEquals(List.of("Israel", "USA"), catalogService.onSaleCountries());
+    }
+
+    @Test
+    void onSaleCountries_excludesInactiveCompanyEvents() {
+        Event e1 = locatedEvent(1, 10, "Israel", "Tel Aviv");
+        Event e2 = locatedEvent(2, 20, "USA", "New York");
+        ProductionCompany active = createMockCompany("A", 4.0);
+        ProductionCompany inactive = mock(ProductionCompany.class);
+        when(inactive.getStatus()).thenReturn(CompanyStatus.INACTIVE);
+        when(mockEventRepository.searchONSALE(any())).thenReturn(List.of(e1, e2));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(active);
+        when(mockCompanyRepository.getCompanyById(20)).thenReturn(inactive);
+
+        assertEquals(List.of("Israel"), catalogService.onSaleCountries());
+    }
+
+    @Test
+    void onSaleCountries_skipsEventsWithoutLocation() {
+        Event noLoc = mock(Event.class);
+        when(noLoc.getCompanyId()).thenReturn(10);
+        when(noLoc.getVenueMap()).thenReturn(null);
+        ProductionCompany a = createMockCompany("A", 4.0);
+        when(mockEventRepository.searchONSALE(any())).thenReturn(List.of(noLoc));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(a);
+
+        assertTrue(catalogService.onSaleCountries().isEmpty());
+    }
+
+    @Test
+    void onSaleCitiesInCountry_filtersToCountryDistinctSorted() {
+        Event e1 = locatedEvent(1, 10, "Israel", "Tel Aviv");
+        Event e2 = locatedEvent(2, 10, "Israel", "Haifa");
+        Event e4 = locatedEvent(4, 10, "Israel", "Tel Aviv");   // duplicate city
+        Event e3 = locatedEvent(3, 20, "USA", "New York");
+        ProductionCompany a = createMockCompany("A", 4.0);
+        ProductionCompany b = createMockCompany("B", 4.0);
+        when(mockEventRepository.searchONSALE(any())).thenReturn(List.of(e1, e2, e4, e3));
+        when(mockCompanyRepository.getCompanyById(10)).thenReturn(a);
+        when(mockCompanyRepository.getCompanyById(20)).thenReturn(b);
+
+        assertEquals(List.of("Haifa", "Tel Aviv"), catalogService.onSaleCitiesInCountry("Israel"));
+    }
+
+    @Test
+    void onSaleCitiesInCountry_nullCountry_isEmpty() {
+        assertTrue(catalogService.onSaleCitiesInCountry(null).isEmpty());
+    }
+
+    private Event locatedEvent(int id, int companyId, String country, String city) {
+        Event e = mock(Event.class);
+        when(e.getCompanyId()).thenReturn(companyId);
+        when(e.getVenueMap()).thenReturn(new VenueMap(id, new Location(country, city), List.of()));
+        return e;
+    }
+
     private CatalogSearchFiltersDTO emptyFilters() {
         return new CatalogSearchFiltersDTO(
                 null, null, null, null, null, null, null, null, null, null, null, null, null);

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -74,13 +74,15 @@ class EventManagementServiceTest {
         private INotificationService notificationService;
 
         private final String OWNER_TOKEN = "owner-token";
-        private final String MANAGER_TOKEN = "manager-token";
+        private final String MANAGER_TOKEN = "manager-token";                 // CONFIGURE_VENUE manager
+        private final String MANAGE_INVENTORY_TOKEN = "inventory-manager-token"; // MANAGE_INVENTORY manager
         private final String INVALID_TOKEN = "invalid-token";
 
         private final int COMPANY_ID = 100;
         private final int EVENT_ID = 10;
         private final int OWNER_ID = 1;
         private final int MANAGER_ID = 2;
+        private final int INVENTORY_MANAGER_ID = 3;
         private final int ZONE_ID = 5;
         private final int ORDER_RECEIPT_ID = 20;
         private final String COMPANY_1_NAME = "Company1";
@@ -93,6 +95,7 @@ class EventManagementServiceTest {
         private Event event;
         private User ownerUser;
         private User managerUser;
+        private User inventoryManagerUser;
 
         @BeforeEach
         public void setUp() {
@@ -137,6 +140,11 @@ class EventManagementServiceTest {
                 managerUser = new User(MANAGER_ID, "Manager Name", "manager@example.com", "hashedpassword", 40);
                 managerUser.receiveManagerAppointment(COMPANY_ID, OWNER_ID, List.of(Permission.CONFIGURE_VENUE));
                 managerUser.acceptInvitation(COMPANY_ID);
+                inventoryManagerUser = new User(INVENTORY_MANAGER_ID, "Inventory Manager",
+                                "inventory@example.com", "hashedpassword", 40);
+                inventoryManagerUser.receiveManagerAppointment(COMPANY_ID, OWNER_ID,
+                                List.of(Permission.MANAGE_INVENTORY));
+                inventoryManagerUser.acceptInvitation(COMPANY_ID);
         }
 
         private OrderReceipt setupStateBasedHappyPath() {
@@ -522,16 +530,85 @@ class EventManagementServiceTest {
         }
 
         @Test
-        void GivenManagerWithPermission_WhenEditEventDetails_ThenSucceeds() {
+        void GivenInventoryManager_WhenEditEventDetails_ThenSucceeds() {
+                // Editing event metadata requires MANAGE_INVENTORY (not CONFIGURE_VENUE).
+                when(sessionManager.validateToken(MANAGE_INVENTORY_TOKEN)).thenReturn(true);
+                when(sessionManager.extractUserId(MANAGE_INVENTORY_TOKEN)).thenReturn(INVENTORY_MANAGER_ID);
+                when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+                when(userRepository.getUserById(INVENTORY_MANAGER_ID)).thenReturn(inventoryManagerUser);
+
+                eventService.editEventDetails(MANAGE_INVENTORY_TOKEN,
+                                new EventUpdateDTO(String.valueOf(EVENT_ID), "Manager Edited", null, null, null, null));
+
+                assertEquals("Manager Edited", event.getName());
+        }
+
+        // -------------------------------------------------------------------------
+        // Manager permission boundaries — MANAGE_INVENTORY (events) vs CONFIGURE_VENUE (venue)
+        // -------------------------------------------------------------------------
+
+        @Test
+        void GivenConfigureVenueManager_WhenEditEventDetails_ThenThrows() {
+                // A venue-only manager must NOT be able to edit event metadata.
                 when(sessionManager.validateToken(MANAGER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(MANAGER_TOKEN)).thenReturn(MANAGER_ID);
                 when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
                 when(userRepository.getUserById(MANAGER_ID)).thenReturn(managerUser);
 
-                eventService.editEventDetails(MANAGER_TOKEN,
-                                new EventUpdateDTO(String.valueOf(EVENT_ID), "Manager Edited", null, null, null, null));
+                assertThrows(RuntimeException.class, () -> eventService.editEventDetails(MANAGER_TOKEN,
+                                new EventUpdateDTO(String.valueOf(EVENT_ID), "Nope", null, null, null, null)));
+                assertEquals("Concert", event.getName());
+        }
 
-                assertEquals("Manager Edited", event.getName());
+        @Test
+        void GivenInventoryManager_WhenChangeEventStatus_ThenSucceeds() {
+                when(sessionManager.validateToken(MANAGE_INVENTORY_TOKEN)).thenReturn(true);
+                when(sessionManager.extractUserId(MANAGE_INVENTORY_TOKEN)).thenReturn(INVENTORY_MANAGER_ID);
+                when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+                when(userRepository.getUserById(INVENTORY_MANAGER_ID)).thenReturn(inventoryManagerUser);
+
+                eventService.changeEventStatus(MANAGE_INVENTORY_TOKEN, EVENT_ID, EventStatus.ON_SALE);
+
+                assertEquals(EventStatus.ON_SALE, event.getStatus());
+        }
+
+        @Test
+        void GivenConfigureVenueManager_WhenChangeEventStatus_ThenThrows() {
+                when(sessionManager.validateToken(MANAGER_TOKEN)).thenReturn(true);
+                when(sessionManager.extractUserId(MANAGER_TOKEN)).thenReturn(MANAGER_ID);
+                when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+                when(userRepository.getUserById(MANAGER_ID)).thenReturn(managerUser);
+
+                assertThrows(RuntimeException.class,
+                                () -> eventService.changeEventStatus(MANAGER_TOKEN, EVENT_ID, EventStatus.ON_SALE));
+                assertEquals(EventStatus.SCHEDULED, event.getStatus());
+        }
+
+        @Test
+        void GivenInventoryManager_WhenCancelEventAndRefund_ThenEventIsCanceled() {
+                when(sessionManager.validateToken(MANAGE_INVENTORY_TOKEN)).thenReturn(true);
+                when(sessionManager.extractUserId(MANAGE_INVENTORY_TOKEN)).thenReturn(INVENTORY_MANAGER_ID);
+                when(userRepository.getUserById(INVENTORY_MANAGER_ID)).thenReturn(inventoryManagerUser);
+                when(mockEventRepo.findById(EVENT_ID)).thenReturn(event);
+                when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
+                when(orderReceiptRepository.findByEventId(EVENT_ID)).thenReturn(List.of());
+                when(mockTicketRepo.findByEventId(EVENT_ID)).thenReturn(List.of());
+
+                eventService.cancelEventAndRefund(MANAGE_INVENTORY_TOKEN, EVENT_ID);
+
+                assertEquals(EventStatus.CANCELED, event.getStatus());
+        }
+
+        @Test
+        void GivenInventoryManager_WhenConfigureVenueMap_ThenThrows() {
+                // MANAGE_INVENTORY does NOT grant venue editing (that's CONFIGURE_VENUE).
+                when(sessionManager.validateToken(MANAGE_INVENTORY_TOKEN)).thenReturn(true);
+                when(sessionManager.extractUserId(MANAGE_INVENTORY_TOKEN)).thenReturn(INVENTORY_MANAGER_ID);
+                when(userRepository.getUserById(INVENTORY_MANAGER_ID)).thenReturn(inventoryManagerUser);
+
+                VenueMapConfigDTO config = new VenueMapConfigDTO(String.valueOf(EVENT_ID), "Venue", 1, 1, List.of());
+                assertThrows(RuntimeException.class,
+                                () -> eventService.configureVenueMap(MANAGE_INVENTORY_TOKEN, COMPANY_ID, config));
         }
 
         @Test

--- a/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/EventManagementServiceTest.java
@@ -738,13 +738,33 @@ class EventManagementServiceTest {
         }
 
         @Test
-        void GivenManagerWithoutManageInventoryPermission_WhenListEventsForCompany_ThenThrowsException() {
+        void GivenManagerMember_WhenListEventsForCompany_ThenReturnsEvents() {
+                // The events list is a read-only hub: any active member may see it (managerUser holds
+                // CONFIGURE_VENUE, not MANAGE_INVENTORY), so a venue/sales manager can reach the
+                // per-event venue editor. Per-event mutations stay gated by their own permission.
                 when(sessionManager.validateToken(MANAGER_TOKEN)).thenReturn(true);
                 when(sessionManager.extractUserId(MANAGER_TOKEN)).thenReturn(MANAGER_ID);
                 when(userRepository.getUserById(MANAGER_ID)).thenReturn(managerUser);
+                when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
+                when(mockEventRepo.searchByCompanyAll(eq(COMPANY_ID), any())).thenReturn(List.of(event));
+
+                List<EventDetailDTO> result = eventService.listEventsForCompany(MANAGER_TOKEN, COMPANY_ID);
+
+                assertNotNull(result);
+                assertEquals(1, result.size());
+                assertEquals(String.valueOf(EVENT_ID), result.get(0).eventId());
+        }
+
+        @Test
+        void GivenNonMember_WhenListEventsForCompany_ThenThrowsException() {
+                User stranger = new User(999, "Stranger", "stranger@example.com", "hashedpassword", 30);
+                when(sessionManager.validateToken("stranger-token")).thenReturn(true);
+                when(sessionManager.extractUserId("stranger-token")).thenReturn(999);
+                when(userRepository.getUserById(999)).thenReturn(stranger);
+                when(mockCompanyRepo.getCompanyById(COMPANY_ID)).thenReturn(company);
 
                 assertThrows(RuntimeException.class,
-                                () -> eventService.listEventsForCompany(MANAGER_TOKEN, COMPANY_ID));
+                                () -> eventService.listEventsForCompany("stranger-token", COMPANY_ID));
         }
 
         @Test

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
@@ -20,6 +20,7 @@ import com.ticketing.system.Core.Application.dto.PaymentRequestDTO;
 import com.ticketing.system.Core.Application.dto.PaymentResultDTO;
 import com.ticketing.system.Core.Application.dto.RefundResultDTO;
 import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayUnreachableException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 import com.ticketing.system.Infrastructure.external.WsepCommunicationException;
 import com.ticketing.system.Infrastructure.external.WsepHttpClient;
@@ -81,21 +82,32 @@ class WsepPaymentGatewayTest {
     }
 
     @Test
-    void charge_minusOneIsDeclined() {
+    void charge_minusOneIsDecline_notUnreachable() {
         when(http.post(any())).thenReturn("-1");
-        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+        // A real WSEP "-1" decline must be the base PaymentGatewayException, NOT the unreachable
+        // subtype — that's what keeps the buyer's "Payment declined" UX distinct from the generic one.
+        PaymentGatewayException ex =
+                assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+        assertFalse(ex instanceof PaymentGatewayUnreachableException,
+                "a real decline must NOT be the unreachable subtype");
     }
 
     @Test
-    void charge_unparseableBodyThrows() {
+    void charge_unparseableBodyIsUnreachable_notDecline() {
         when(http.post(any())).thenReturn("not-a-number");
-        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+        assertThrows(PaymentGatewayUnreachableException.class, () -> gateway.charge(request()));
     }
 
     @Test
-    void charge_transportFailureBecomesPaymentGatewayException() {
+    void charge_nonPositiveBodyIsUnreachable_notDecline() {
+        when(http.post(any())).thenReturn("0");
+        assertThrows(PaymentGatewayUnreachableException.class, () -> gateway.charge(request()));
+    }
+
+    @Test
+    void charge_transportFailureIsUnreachable_notDecline() {
         when(http.post(any())).thenThrow(new WsepCommunicationException("refused", new RuntimeException()));
-        assertThrows(PaymentGatewayException.class, () -> gateway.charge(request()));
+        assertThrows(PaymentGatewayUnreachableException.class, () -> gateway.charge(request()));
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/persistence/EventPersistence/IEventRepositoryContractTest.java
@@ -52,6 +52,17 @@ public abstract class IEventRepositoryContractTest {
                 venueMap, List.of(showDate), new NoPurchasePolicy(), new DiscountPolicy(0));
     }
 
+    // An event whose zones span several prices (cheapest = 30); used for the "cheapest price" filter tests.
+    protected Event buildMultiZoneEvent(int id) {
+        VenueMap venueMap = new VenueMap(id, LOCATION, List.of(
+                new StandingZone(1, "Cheap", 100, 30),
+                new StandingZone(2, "Mid", 100, 50),
+                new StandingZone(3, "Premium", 100, 100)));
+        ShowDate showDate = new ShowDate(FUTURE_START, FUTURE_END);
+        return new Event(id, "Tiered Show", 4.5, List.of("Artist A"), EventCategory.CONCERT, 10,
+                EventStatus.ON_SALE, venueMap, List.of(showDate), new NoPurchasePolicy(), new DiscountPolicy(0));
+    }
+
     // === save ===
 
     @Test
@@ -299,6 +310,27 @@ public abstract class IEventRepositoryContractTest {
         List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
                 null, null, null, null, 100.0, 500.0, null, null, null, null, null, null, null));
 
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void givenMultiZoneEvent_whenCheapestPriceInRange_thenMatches() {
+        eventRepo.save(buildMultiZoneEvent(1)); // zones 30 / 50 / 100, cheapest = 30
+
+        List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
+                null, null, null, null, 20.0, 40.0, null, null, null, null, null, null, null));
+
+        assertEquals(1, result.size()); // the cheapest ticket (30) is within [20, 40]
+    }
+
+    @Test
+    void givenMultiZoneEvent_whenCheapestPriceBelowMin_thenExcludedEvenIfPricierZonesFit() {
+        eventRepo.save(buildMultiZoneEvent(1)); // cheapest = 30
+
+        List<Event> result = eventRepo.searchAll(new CatalogSearchFiltersDTO(
+                null, null, null, null, 40.0, 200.0, null, null, null, null, null, null, null));
+
+        // Matching is on the cheapest ticket (30), not the 50/100 zones, so the event is excluded.
         assertTrue(result.isEmpty());
     }
 

--- a/src/test/java/com/ticketing/system/unit/presentation/AdminComplaintQueuePresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/AdminComplaintQueuePresenterTest.java
@@ -58,14 +58,36 @@ class AdminComplaintQueuePresenterTest {
     }
 
     @Test
-    void load_forwardsStatusFilter() {
-        when(messaging.viewAllComplaints(eq(TOKEN), any())).thenReturn(List.of());
+    void load_open_returnsOnlyOpenAndResponded_andQueriesWithoutServerStatus() {
+        ConversationDTO open = complaint("c1", "OPEN");
+        ConversationDTO responded = complaint("c2", "RESPONDED");
+        ConversationDTO resolved = complaint("c3", "RESOLVED");
+        ConversationDTO closed = complaint("c4", "CLOSED");
+        when(messaging.viewAllComplaints(eq(TOKEN), any()))
+            .thenReturn(List.of(open, responded, resolved, closed));
 
-        presenter.load(TOKEN, "Open");
+        AdminComplaintQueuePresenter.Outcome.Success ok =
+            assertInstanceOf(AdminComplaintQueuePresenter.Outcome.Success.class, presenter.load(TOKEN, "Open"));
+        assertEquals(List.of(open, responded), ok.complaints());
 
+        // Grouping is client-side: the service is always queried with no server status filter.
         ArgumentCaptor<ComplaintFilterDTO> captor = ArgumentCaptor.forClass(ComplaintFilterDTO.class);
         verify(messaging).viewAllComplaints(eq(TOKEN), captor.capture());
-        assertEquals("Open", captor.getValue().status());
+        assertNull(captor.getValue().status());
+    }
+
+    @Test
+    void load_resolved_returnsOnlyResolvedAndClosed() {
+        ConversationDTO open = complaint("c1", "OPEN");
+        ConversationDTO responded = complaint("c2", "RESPONDED");
+        ConversationDTO resolved = complaint("c3", "RESOLVED");
+        ConversationDTO closed = complaint("c4", "CLOSED");
+        when(messaging.viewAllComplaints(eq(TOKEN), any()))
+            .thenReturn(List.of(open, responded, resolved, closed));
+
+        AdminComplaintQueuePresenter.Outcome.Success ok =
+            assertInstanceOf(AdminComplaintQueuePresenter.Outcome.Success.class, presenter.load(TOKEN, "Resolved"));
+        assertEquals(List.of(resolved, closed), ok.complaints());
     }
 
     @Test

--- a/src/test/java/com/ticketing/system/unit/presentation/CapabilitiesTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CapabilitiesTest.java
@@ -1,11 +1,16 @@
 package com.ticketing.system.unit.presentation;
 
+import com.ticketing.system.Core.Domain.users.Permission;
 import com.ticketing.system.Presentation.security.Capabilities;
 import com.ticketing.system.Presentation.security.Capability;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -47,5 +52,67 @@ class CapabilitiesTest {
         assertTrue(Capabilities.hasAny(Capability.BROWSE_CATALOG, Capability.CHECKOUT));
         assertFalse(Capabilities.hasAll(Capability.BROWSE_CATALOG, Capability.CHECKOUT));
         assertFalse(Capabilities.hasAny(Capability.CHECKOUT, Capability.OWNER_WORKSPACE));
+    }
+
+    // ---- manager permission → capability mapping (the workspace gating matrix) ----
+    // capabilitiesFromPermissions is private static; we reflectively exercise the pure mapping so the
+    // matrix is pinned without faking a VaadinSession (which forCurrentUser would require).
+
+    @Test
+    void everyManagerPermissionGrantsTheReadOnlyEventsHub() {
+        for (Permission p : Permission.values()) {
+            assertTrue(capsFor(p).contains(Capability.VIEW_COMPANY_EVENTS),
+                p + " must grant VIEW_COMPANY_EVENTS — every manager lands on the My Events hub");
+        }
+    }
+
+    @Test
+    void eachManagerPermissionGrantsExactlyItsOwnAction() {
+        assertEquals(EnumSet.of(Capability.VIEW_COMPANY_EVENTS, Capability.VIEW_COMPANY_SALES),
+            capsFor(Permission.VIEW_SALES));
+        assertEquals(EnumSet.of(Capability.VIEW_COMPANY_EVENTS, Capability.EDIT_PURCHASE_POLICIES),
+            capsFor(Permission.EDIT_POLICIES));
+        assertEquals(EnumSet.of(Capability.VIEW_COMPANY_EVENTS, Capability.RESPOND_INQUIRIES),
+            capsFor(Permission.RESPOND_TO_INQUIRIES));
+        assertEquals(EnumSet.of(Capability.VIEW_COMPANY_EVENTS, Capability.MANAGE_VENUE_MAPS),
+            capsFor(Permission.CONFIGURE_VENUE));
+    }
+
+    @Test
+    void manageInventoryOwnsTheFullEventLifecycleIncludingCancel() {
+        Set<Capability> caps = capsFor(Permission.MANAGE_INVENTORY);
+        assertTrue(caps.contains(Capability.VIEW_COMPANY_EVENTS));
+        assertTrue(caps.contains(Capability.EDIT_COMPANY_EVENTS));
+        assertTrue(caps.contains(Capability.CANCEL_EVENT),
+            "MANAGE_INVENTORY grants cancel+refund as part of the event lifecycle");
+    }
+
+    @Test
+    void aSalesOnlyManagerCannotEditOrCancelEvents() {   // no privilege escalation through the shared hub
+        Set<Capability> caps = capsFor(Permission.VIEW_SALES);
+        assertFalse(caps.contains(Capability.EDIT_COMPANY_EVENTS),
+            "VIEW_SALES sees My Events but must not edit them");
+        assertFalse(caps.contains(Capability.CANCEL_EVENT),
+            "VIEW_SALES must not be able to cancel/refund events");
+    }
+
+    @Test
+    void combinedPermissionsGrantTheUnionOfTheirCapabilities() {
+        Set<Capability> caps = capsFor(Permission.VIEW_SALES, Permission.MANAGE_INVENTORY);
+        assertTrue(caps.containsAll(EnumSet.of(
+            Capability.VIEW_COMPANY_EVENTS, Capability.VIEW_COMPANY_SALES,
+            Capability.EDIT_COMPANY_EVENTS, Capability.CANCEL_EVENT)),
+            "a manager holding both permissions gets the union of their capabilities");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Set<Capability> capsFor(Permission... permissions) {
+        try {
+            Method m = Capabilities.class.getDeclaredMethod("capabilitiesFromPermissions", List.class);
+            m.setAccessible(true);
+            return (Set<Capability>) m.invoke(null, List.of(permissions));
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("could not invoke Capabilities.capabilitiesFromPermissions", e);
+        }
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/CheckoutPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CheckoutPresenterTest.java
@@ -1,0 +1,66 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.services.CheckoutService;
+import com.ticketing.system.Core.Application.services.ReservationService;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayException;
+import com.ticketing.system.Core.Domain.exceptions.PaymentGatewayUnreachableException;
+import com.ticketing.system.Presentation.presenters.order.CheckoutPresenter;
+import com.ticketing.system.Presentation.session.SessionIdentity;
+
+/**
+ * Pins the payment-failure mapping in {@link CheckoutPresenter#payAsMember} (issue #428): a real
+ * gateway decline and a gateway-unreachable failure must map to DIFFERENT outcomes, because the
+ * View renders a clear "Payment declined" for the former and a generic error for the latter.
+ *
+ * <p>{@code CheckoutService} rethrows failures wrapped as
+ * {@code new RuntimeException("Checkout failed, tickets returned to stock", cause)}; the test mocks
+ * that exact wrapper so the presenter's one-level cause-unwrap is exercised faithfully.
+ */
+class CheckoutPresenterTest {
+
+    private CheckoutService checkoutService;
+    private CheckoutPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        ReservationService reservationService = mock(ReservationService.class);
+        checkoutService = mock(CheckoutService.class);
+        SessionIdentity identity = mock(SessionIdentity.class);
+        presenter = new CheckoutPresenter(reservationService, checkoutService, identity);
+    }
+
+    /** Drives the member checkout path, which builds the card and calls checkoutService.checkoutMember(...). */
+    private CheckoutPresenter.PayOutcome pay() {
+        return presenter.payAsMember("member-token", "idem-1",
+                "4111111111111111", "986", "12 / 30", "Jane Holder");
+    }
+
+    @Test
+    void pay_gatewayUnreachable_mapsToGatewayUnavailable() {
+        when(checkoutService.checkoutMember(any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("Checkout failed, tickets returned to stock",
+                        new PaymentGatewayUnreachableException("payment gateway unreachable: timeout")));
+
+        assertInstanceOf(CheckoutPresenter.PayOutcome.GatewayUnavailable.class, pay());
+    }
+
+    @Test
+    void pay_declined_mapsToPaymentDeclined() {
+        when(checkoutService.checkoutMember(any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("Checkout failed, tickets returned to stock",
+                        new PaymentGatewayException("payment declined by gateway")));
+
+        // The unreachable arm precedes the PaymentGatewayException arm and unreachable IS-A
+        // PaymentGatewayException, so this also pins that a real decline does NOT fall into the
+        // GatewayUnavailable arm.
+        assertInstanceOf(CheckoutPresenter.PayOutcome.PaymentDeclined.class, pay());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -2,7 +2,7 @@ package com.ticketing.system.unit.presentation;
 
 import com.ticketing.system.Core.Application.dto.CatalogSearchFiltersDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventStatus;
@@ -46,62 +46,91 @@ class CompanyEventListPresenterTest {
     @Test
     void load_nullToken_returnsNotAuthenticated() {
         assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
-                presenter.load(null, CatalogSearchFiltersDTO.empty()));
+                presenter.load(null, null, CatalogSearchFiltersDTO.empty()));
         verifyNoInteractions(eventService, companyService);
     }
 
     @Test
     void load_invalidToken_returnsNotAuthenticated() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad"));
+        when(companyService.findMyCompanies(TOKEN)).thenThrow(new InvalidTokenException("bad"));
 
         assertInstanceOf(CompanyEventListPresenter.Outcome.NotAuthenticated.class,
-                presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
+                presenter.load(TOKEN, null, CatalogSearchFiltersDTO.empty()));
     }
 
     @Test
-    void load_noOwnedCompanies_returnsNoCompany() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+    void load_noCompanies_returnsNoCompany() {
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of());
 
         assertInstanceOf(CompanyEventListPresenter.Outcome.NoCompany.class,
-                presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
+                presenter.load(TOKEN, null, CatalogSearchFiltersDTO.empty()));
         verifyNoInteractions(eventService);
     }
 
     @Test
-    void load_success_returnsEventsForFirstOwnedCompany() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+    void load_success_returnsEventsForFirstCompany() {
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         List<EventDetailDTO> events = List.of(event(EVENT_ID, "Gala Night"));
         when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(events);
 
         CompanyEventListPresenter.Outcome.Success ok =
                 assertInstanceOf(CompanyEventListPresenter.Outcome.Success.class,
-                        presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
+                        presenter.load(TOKEN, null, CatalogSearchFiltersDTO.empty()));
 
         assertEquals(1, ok.events().size());
         assertEquals("Gala Night", ok.events().get(0).name());
     }
 
     @Test
+    void load_managerMembership_returnsThatCompanysEvents() {
+        // The exact bug (#429): a manager holds a Manager appointment, not an Owner one, so the old
+        // owner-only lookup returned NoCompany. findMyCompanies keeps managers; the presenter must
+        // resolve the company and serve its events.
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID, "Manager")));
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any()))
+                .thenReturn(List.of(event(EVENT_ID, "Manager-Visible Show")));
+
+        CompanyEventListPresenter.Outcome.Success ok =
+                assertInstanceOf(CompanyEventListPresenter.Outcome.Success.class,
+                        presenter.load(TOKEN, null, CatalogSearchFiltersDTO.empty()));
+
+        assertEquals(1, ok.events().size());
+        assertEquals("Manager-Visible Show", ok.events().get(0).name());
+    }
+
+    @Test
+    void load_honorsSelectedCompanyAmongMemberships() {
+        // Multiple memberships: the workspace's selected company id must win over "first".
+        when(companyService.findMyCompanies(TOKEN))
+                .thenReturn(List.of(company(99, "Co-owner"), company(COMPANY_ID, "Manager")));
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(List.of());
+
+        presenter.load(TOKEN, COMPANY_ID, CatalogSearchFiltersDTO.empty());
+
+        verify(eventService).listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any());
+    }
+
+    @Test
     void load_passesFiltersThroughToService() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         CatalogSearchFiltersDTO filters = new CatalogSearchFiltersDTO(
                 "Othello", null, null, null, null, null, null, null, null, null, null, null, null);
         when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), eq(filters))).thenReturn(List.of());
 
-        presenter.load(TOKEN, filters);
+        presenter.load(TOKEN, null, filters);
 
         verify(eventService).listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), eq(filters));
     }
 
     @Test
     void load_serviceThrowsRuntime_returnsFailure() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         when(eventService.listEventsForCompany(anyString(), anyInt(), any()))
                 .thenThrow(new RuntimeException("db error"));
 
         CompanyEventListPresenter.Outcome.Failure fail =
                 assertInstanceOf(CompanyEventListPresenter.Outcome.Failure.class,
-                        presenter.load(TOKEN, CatalogSearchFiltersDTO.empty()));
+                        presenter.load(TOKEN, null, CatalogSearchFiltersDTO.empty()));
 
         assertEquals("db error", fail.reason());
     }
@@ -249,50 +278,54 @@ class CompanyEventListPresenterTest {
 
     @Test
     void countries_nullToken_isEmpty() {
-        assertTrue(presenter.countries(null).isEmpty());
+        assertTrue(presenter.countries(null, null).isEmpty());
         verifyNoInteractions(eventService, companyService);
     }
 
     @Test
-    void countries_noOwnedCompany_isEmpty() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+    void countries_noCompany_isEmpty() {
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of());
 
-        assertTrue(presenter.countries(TOKEN).isEmpty());
+        assertTrue(presenter.countries(TOKEN, null).isEmpty());
         verifyNoInteractions(eventService);
     }
 
     @Test
-    void countries_distinctSortedFromOwnedCompanyEvents() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+    void countries_distinctSortedFromCompanyEvents() {
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(List.of(
                 eventAt(1, "Israel", "Tel Aviv"),
                 eventAt(2, "USA", "New York"),
                 eventAt(3, "Israel", "Haifa")));
 
-        assertEquals(List.of("Israel", "USA"), presenter.countries(TOKEN));
+        assertEquals(List.of("Israel", "USA"), presenter.countries(TOKEN, null));
     }
 
     @Test
     void cities_filtersToCountryDistinctSorted() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
         when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(List.of(
                 eventAt(1, "Israel", "Tel Aviv"),
                 eventAt(2, "Israel", "Haifa"),
                 eventAt(4, "Israel", "Tel Aviv"),   // duplicate city
                 eventAt(3, "USA", "New York")));
 
-        assertEquals(List.of("Haifa", "Tel Aviv"), presenter.cities(TOKEN, "Israel"));
+        assertEquals(List.of("Haifa", "Tel Aviv"), presenter.cities(TOKEN, null, "Israel"));
     }
 
     @Test
     void cities_nullCountry_isEmpty() {
-        assertTrue(presenter.cities(TOKEN, null).isEmpty());
+        assertTrue(presenter.cities(TOKEN, null, null).isEmpty());
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
 
-    private static ProductionCompanyDTO company(int id) {
-        return new ProductionCompanyDTO(id, "Company " + id, "desc", "ACTIVE", 1);
+    private static MyCompanyDTO company(int id) {
+        return company(id, "Co-owner");
+    }
+
+    private static MyCompanyDTO company(int id, String role) {
+        return new MyCompanyDTO(id, "Company " + id, role);
     }
 
     private static EventDetailDTO eventAt(int id, String country, String city) {

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -298,12 +298,12 @@ class CompanyEventListPresenterTest {
     private static EventDetailDTO eventAt(int id, String country, String city) {
         return new EventDetailDTO(String.valueOf(id), "E" + id, null, null, null,
                 new Location(country, city), String.valueOf(COMPANY_ID), "Company " + COMPANY_ID,
-                EventStatus.SCHEDULED, new ArrayList<>(), new ArrayList<>());
+                EventStatus.SCHEDULED, new ArrayList<>(), new ArrayList<>(), 0.0);
     }
 
     private static EventDetailDTO event(int id, String name) {
         return new EventDetailDTO(String.valueOf(id), name, null, null, null, null,
                 String.valueOf(COMPANY_ID), "Company " + COMPANY_ID, EventStatus.SCHEDULED,
-                new ArrayList<>(), new ArrayList<>());
+                new ArrayList<>(), new ArrayList<>(), 0.0);
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -213,15 +213,15 @@ class CompanyEventListPresenterTest {
     }
 
     @Test
-    void deleteEvent_withPurchaseHistory_returnsFailureWithMessage() {
-        doThrow(new BusinessRuleViolationException("Can't delete event with purchase history"))
+    void deleteEvent_withSalesHistory_returnsFailureWithMessage() {
+        doThrow(new BusinessRuleViolationException("Can't delete an event with sales history"))
                 .when(eventService).deleteEvent(TOKEN, EVENT_ID);
 
         CompanyEventListPresenter.ActionOutcome.Failure fail =
                 assertInstanceOf(CompanyEventListPresenter.ActionOutcome.Failure.class,
                         presenter.deleteEvent(TOKEN, EVENT_ID));
 
-        assertEquals("Can't delete event with purchase history", fail.reason());
+        assertEquals("Can't delete an event with sales history", fail.reason());
     }
 
     // ── changeEventStatus ─────────────────────────────────────────────────────

--- a/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/CompanyEventListPresenterTest.java
@@ -6,6 +6,7 @@ import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.events.Location;
 import com.ticketing.system.Core.Domain.exceptions.BusinessRuleViolationException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
@@ -244,10 +245,60 @@ class CompanyEventListPresenterTest {
         assertEquals("invalid transition", fail.reason());
     }
 
+    // ── countries / cities (owner-scope filter options) ───────────────────────
+
+    @Test
+    void countries_nullToken_isEmpty() {
+        assertTrue(presenter.countries(null).isEmpty());
+        verifyNoInteractions(eventService, companyService);
+    }
+
+    @Test
+    void countries_noOwnedCompany_isEmpty() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+
+        assertTrue(presenter.countries(TOKEN).isEmpty());
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void countries_distinctSortedFromOwnedCompanyEvents() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(List.of(
+                eventAt(1, "Israel", "Tel Aviv"),
+                eventAt(2, "USA", "New York"),
+                eventAt(3, "Israel", "Haifa")));
+
+        assertEquals(List.of("Israel", "USA"), presenter.countries(TOKEN));
+    }
+
+    @Test
+    void cities_filtersToCountryDistinctSorted() {
+        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(COMPANY_ID)));
+        when(eventService.listEventsForCompany(eq(TOKEN), eq(COMPANY_ID), any())).thenReturn(List.of(
+                eventAt(1, "Israel", "Tel Aviv"),
+                eventAt(2, "Israel", "Haifa"),
+                eventAt(4, "Israel", "Tel Aviv"),   // duplicate city
+                eventAt(3, "USA", "New York")));
+
+        assertEquals(List.of("Haifa", "Tel Aviv"), presenter.cities(TOKEN, "Israel"));
+    }
+
+    @Test
+    void cities_nullCountry_isEmpty() {
+        assertTrue(presenter.cities(TOKEN, null).isEmpty());
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private static ProductionCompanyDTO company(int id) {
         return new ProductionCompanyDTO(id, "Company " + id, "desc", "ACTIVE", 1);
+    }
+
+    private static EventDetailDTO eventAt(int id, String country, String city) {
+        return new EventDetailDTO(String.valueOf(id), "E" + id, null, null, null,
+                new Location(country, city), String.valueOf(COMPANY_ID), "Company " + COMPANY_ID,
+                EventStatus.SCHEDULED, new ArrayList<>(), new ArrayList<>());
     }
 
     private static EventDetailDTO event(int id, String name) {

--- a/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventDetailsPresenterTest.java
@@ -43,7 +43,7 @@ class EventDetailsPresenterTest {
     private static EventDetailDTO detail() {
         return new EventDetailDTO("1", "Coldplay", 4.8, "Music of the Spheres",
                 EventCategory.MUSIC, new Location("Israel", "Tel Aviv"), "10", "Live Nation",
-                EventStatus.ON_SALE, List.of(), List.of("Coldplay"));
+                EventStatus.ON_SALE, List.of(), List.of("Coldplay"), 75.0);
     }
 
     private static VenueMapDTO venueMap() {

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -185,6 +185,6 @@ class EventManagementPresenterTest {
     private static EventDetailDTO detailWithId(String id) {
         return new EventDetailDTO(id, "Gala Night", null, "A great show", EventCategory.COMEDY,
                 new Location("Israel", "Tel Aviv"), "1", "Company 1", EventStatus.DRAFT,
-                List.of(), List.of("Headliner"));
+                List.of(), List.of("Headliner"), 0.0);
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/EventManagementPresenterTest.java
@@ -18,7 +18,7 @@ import org.mockito.ArgumentCaptor;
 
 import com.ticketing.system.Core.Application.dto.EventCreationDTO;
 import com.ticketing.system.Core.Application.dto.EventDetailDTO;
-import com.ticketing.system.Core.Application.dto.ProductionCompanyDTO;
+import com.ticketing.system.Core.Application.dto.MyCompanyDTO;
 import com.ticketing.system.Core.Application.services.CompanyManagementService;
 import com.ticketing.system.Core.Application.services.EventManagementService;
 import com.ticketing.system.Core.Domain.events.EventCategory;
@@ -48,8 +48,8 @@ class EventManagementPresenterTest {
         presenter = new EventManagementPresenter(eventService, companyService);
     }
 
-    private static ProductionCompanyDTO company(int id) {
-        return new ProductionCompanyDTO(id, "Company " + id, "desc", "ACTIVE", 1);
+    private static MyCompanyDTO company(int id) {
+        return new MyCompanyDTO(id, "Company " + id, "Co-owner");
     }
 
     private static LocalDateTime futureStart() {
@@ -68,7 +68,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_success_returnsNewEventId() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1)));
         when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("5"));
 
         EventManagementPresenter.CreateOutcome outcome = createWith(null, futureStart(), futureEnd());
@@ -80,7 +80,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_prefersSelectedCompanyWhenOwned() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
         when(eventService.addEvent(eq(TOKEN), any())).thenReturn(detailWithId("9"));
 
         createWith(2, futureStart(), futureEnd());
@@ -93,7 +93,7 @@ class EventManagementPresenterTest {
     @Test
     void create_preferredNotOwned_returnsNoCompany() {
         // A selected company the caller doesn't own must not silently retarget to another company.
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1), company(2)));
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.NoCompany.class,
                 createWith(99, futureStart(), futureEnd()));
@@ -102,7 +102,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_noOwnedCompany_returnsNoCompany() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of());
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of());
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.NoCompany.class,
                 createWith(null, futureStart(), futureEnd()));
@@ -121,7 +121,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_invalidToken_returnsNotAuthenticated() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1)));
         when(eventService.addEvent(eq(TOKEN), any())).thenThrow(new InvalidTokenException());
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.NotAuthenticated.class,
@@ -163,7 +163,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_pastShowDate_returnsInvalidInput() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1)));
 
         // A past start makes the domain ShowDate constructor reject the request before addEvent.
         EventManagementPresenter.CreateOutcome outcome =
@@ -175,7 +175,7 @@ class EventManagementPresenterTest {
 
     @Test
     void create_serviceFailure_returnsFailure() {
-        when(companyService.findOwnedCompanies(TOKEN)).thenReturn(List.of(company(1)));
+        when(companyService.findMyCompanies(TOKEN)).thenReturn(List.of(company(1)));
         when(eventService.addEvent(eq(TOKEN), any())).thenThrow(new RuntimeException("boom"));
 
         assertInstanceOf(EventManagementPresenter.CreateOutcome.Failure.class,

--- a/src/test/java/com/ticketing/system/unit/presentation/SalesDateRangeTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SalesDateRangeTest.java
@@ -1,0 +1,50 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Presentation.views.admin.SalesDateRange;
+
+/** Window math for the Company Sales date filter (pure; no Vaadin). */
+class SalesDateRangeTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 6, 30); // Q2
+
+    @Test
+    void allTimeAndUnknownAndNull_haveNoLowerBound() {
+        assertNull(SalesDateRange.startOf("All time", TODAY));
+        assertNull(SalesDateRange.startOf(null, TODAY));
+        assertNull(SalesDateRange.startOf("nonsense", TODAY));
+    }
+
+    @Test
+    void last7Days_isSevenDaysBack() {
+        assertEquals(TODAY.minusDays(7).atStartOfDay(), SalesDateRange.startOf("Last 7 days", TODAY));
+    }
+
+    @Test
+    void last30Days_excludesA45DayOldOrderButKeepsRecentOnes() {
+        LocalDateTime from = SalesDateRange.startOf("Last 30 days", TODAY);
+        assertNotNull(from);
+        assertTrue(TODAY.minusDays(45).atStartOfDay().isBefore(from), "45-day-old purchase is excluded");
+        assertFalse(TODAY.minusDays(10).atStartOfDay().isBefore(from), "10-day-old purchase is kept");
+    }
+
+    @Test
+    void thisQuarter_startsOnFirstDayOfTheQuarter() {
+        assertEquals(LocalDate.of(2026, 4, 1).atStartOfDay(), SalesDateRange.startOf("This quarter", TODAY));
+    }
+
+    @Test
+    void thisYear_startsOnJanuaryFirst() {
+        assertEquals(LocalDate.of(2026, 1, 1).atStartOfDay(), SalesDateRange.startOf("This year", TODAY));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/SalesSummaryTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/SalesSummaryTest.java
@@ -1,0 +1,61 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.PurchaseRecordDTO;
+import com.ticketing.system.Core.Application.dto.PurchaseHistoryDTO.TicketRecordDTO;
+import com.ticketing.system.Core.Domain.Tickets.TicketStatus;
+import com.ticketing.system.Presentation.views.admin.SalesSummary;
+
+/** Refund-aware headline figures for the Company Sales page (pure; no Vaadin). */
+class SalesSummaryTest {
+
+    @Test
+    void revenueAndTickets_excludeRefundedOrders() {
+        // 600 non-refunded + 300 refunded -> headline should reflect only the 600 order.
+        PurchaseRecordDTO paid = order(600.0, false, ticket("Gala", 600.0));
+        PurchaseRecordDTO refunded = order(300.0, true, ticket("Gala", 300.0));
+
+        SalesSummary s = SalesSummary.of(List.of(paid, refunded));
+
+        assertEquals(600.0, s.revenue(), "refunded order is excluded from revenue");
+        assertEquals(1, s.ticketsSold(), "refunded order's ticket is not counted as sold");
+        assertEquals(600.0, s.avgOrderValue(), "AOV is over non-refunded orders only");
+        assertEquals("Gala", s.topEvent());
+    }
+
+    @Test
+    void allRefunded_isZeroAndNoTopEvent() {
+        SalesSummary s = SalesSummary.of(List.of(order(300.0, true, ticket("X", 300.0))));
+
+        assertEquals(0.0, s.revenue());
+        assertEquals(0, s.ticketsSold());
+        assertEquals(0.0, s.avgOrderValue());
+        assertEquals(SalesSummary.NO_TOP_EVENT, s.topEvent());
+    }
+
+    @Test
+    void topEvent_isTheHighestGrossingNonRefundedEvent() {
+        PurchaseRecordDTO a = order(100.0, false, ticket("Small", 100.0));
+        PurchaseRecordDTO b = order(500.0, false, ticket("Big", 500.0));
+
+        assertEquals("Big", SalesSummary.of(List.of(a, b)).topEvent());
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private static PurchaseRecordDTO order(double total, boolean refunded, TicketRecordDTO... tickets) {
+        return new PurchaseRecordDTO(1, 1, null, LocalDateTime.now(), total, refunded,
+                List.of(), List.of(tickets), "buyer");
+    }
+
+    private static TicketRecordDTO ticket(String eventName, double price) {
+        return new TicketRecordDTO(1, 1, 1, 1, null, price, TicketStatus.PAID,
+                eventName, "Zone", "Co", "CONCERT", null, "Venue", null);
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/VenueMapPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/VenueMapPresenterTest.java
@@ -1,0 +1,100 @@
+package com.ticketing.system.unit.presentation;
+
+import com.ticketing.system.Core.Application.dto.EventDetailDTO;
+import com.ticketing.system.Core.Application.dto.VenueMapConfigDTO;
+import com.ticketing.system.Core.Application.services.EventManagementService;
+import com.ticketing.system.Core.Domain.events.EventStatus;
+import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Presentation.presenters.company.VenueMapPresenter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit guard for {@code VenueMapPresenter.saveMap}: the venue map is persisted to the
+ * <em>event's own</em> company (resolved via {@code getEventDetail(...).companyId()}), not the
+ * caller's "first owned company". This is what lets a manager granted {@code CONFIGURE_VENUE} —
+ * who has no Owner appointment — save a layout edit (#429), and what targets the correct company
+ * for a multi-company owner.
+ */
+class VenueMapPresenterTest {
+
+    private static final String TOKEN = "manager-token";
+    private static final int EVENT_ID = 7;
+    private static final int COMPANY_ID = 42;
+
+    private EventManagementService eventService;
+    private VenueMapPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        eventService = mock(EventManagementService.class);
+        presenter = new VenueMapPresenter(eventService);
+    }
+
+    @Test
+    void saveMap_nullToken_returnsNotAuthenticatedWithoutTouchingService() {
+        assertInstanceOf(VenueMapPresenter.SaveOutcome.NotAuthenticated.class,
+                presenter.saveMap(null, String.valueOf(EVENT_ID), config()));
+        verifyNoInteractions(eventService);
+    }
+
+    @Test
+    void saveMap_resolvesCompanyFromEvent_thenConfiguresAndSucceeds() {
+        when(eventService.getEventDetail(TOKEN, EVENT_ID)).thenReturn(eventInCompany(COMPANY_ID));
+        VenueMapConfigDTO config = config();
+
+        VenueMapPresenter.SaveOutcome outcome =
+                presenter.saveMap(TOKEN, String.valueOf(EVENT_ID), config);
+
+        assertInstanceOf(VenueMapPresenter.SaveOutcome.Success.class, outcome);
+        // The companyId handed to configureVenueMap is the EVENT's company, not any owned-company list.
+        verify(eventService).configureVenueMap(eq(TOKEN), eq(COMPANY_ID), eq(config));
+    }
+
+    @Test
+    void saveMap_invalidToken_returnsNotAuthenticated() {
+        when(eventService.getEventDetail(eq(TOKEN), anyInt()))
+                .thenThrow(new InvalidTokenException("bad"));
+
+        assertInstanceOf(VenueMapPresenter.SaveOutcome.NotAuthenticated.class,
+                presenter.saveMap(TOKEN, String.valueOf(EVENT_ID), config()));
+    }
+
+    @Test
+    void saveMap_serviceThrowsRuntime_returnsFailureWithMessage() {
+        when(eventService.getEventDetail(TOKEN, EVENT_ID)).thenReturn(eventInCompany(COMPANY_ID));
+        doThrow(new IllegalStateException("Cannot reconfigure venue map while tickets are reserved or sold"))
+                .when(eventService).configureVenueMap(eq(TOKEN), eq(COMPANY_ID), any());
+
+        VenueMapPresenter.SaveOutcome.Failure fail =
+                assertInstanceOf(VenueMapPresenter.SaveOutcome.Failure.class,
+                        presenter.saveMap(TOKEN, String.valueOf(EVENT_ID), config()));
+
+        assertEquals("Cannot reconfigure venue map while tickets are reserved or sold", fail.reason());
+    }
+
+    // ---- helpers --------------------------------------------------------
+
+    private static VenueMapConfigDTO config() {
+        return new VenueMapConfigDTO(String.valueOf(EVENT_ID), "Venue", 1, 1, List.of());
+    }
+
+    private static EventDetailDTO eventInCompany(int companyId) {
+        return new EventDetailDTO(String.valueOf(EVENT_ID), "Show", null, null, null, null,
+                String.valueOf(companyId), "Company " + companyId, EventStatus.SCHEDULED,
+                List.of(), List.of(), 0.0);
+    }
+}


### PR DESCRIPTION
## Summary

UI / workspace fixes and polish for the evaluation build, layered on top of `dev`. The branch tightens manager-permission gating across the owner workspace, fixes catalog / My Events / sales filters, and replaces several generic toasts with informative, reason-bearing messages. All changes are presentation/application-layer; no domain rules changed except message wording. Built green with `./mvnw -q -Pno-vaadin clean test` (1500 tests, 0 failures).

## Manager permissions & workspace gating
Each manager permission now grants exactly its own abilities, and the workspace hides actions/data a member can't act on.

- **Managers get correct access** to their company's events, venue editor, and sales (presenter uses `findMyCompanies`, company-scoped) — a venue/sales manager now sees **My Events** and their **Sales History** instead of "You don't own a company yet."
- **Per-permission action gating**: a manager only sees buttons for actions they hold (MANAGE_INVENTORY, CONFIGURE_VENUE, EDIT_POLICIES, VIEW_SALES, RESPOND_TO_INQUIRIES); combined permissions = the union. Clicking a route they lack shows a clear "not in your permissions — contact an owner" toast instead of a dead bounce.
- **Dashboard stats are gated**: the **Revenue** stat is hidden from members without VIEW_SALES, and **Open inquiries** from members without RESPOND_TO_INQUIRIES — matching the existing tile gates.

## Catalog / My Events / sales UX
- **Browse**: data-driven country/city filters and a rating sort.
- **Price filter** matches an event's cheapest ticket, surfaced as a **From** price column on My Events.
- **My Events**: readable dates, decimal ratings accepted.
- **Company Sales History**: working date-range filter on order/purchase date, a Refresh control, refunded orders excluded from total revenue and tagged "Refunded"; dropped the dead Export-CSV / Event filter (#430).
- **Admin** complaint queue: All / Open / Resolved filter.

## Informative messages (replacing generic toasts)
- **Seat picker** now surfaces the *real* reserve-failure reason (e.g. "Market is not currently open for transactions", "event is not on sale") instead of a constant "please try again", and logs the exception. Adds a `{test,jpa}` regression test for the seated-reserve + JPA persistence path (previously uncovered).
- **Event delete**: deleting a cancelled event that still has sales now says **"Can't delete an event with sales history"** (and surfaces "Only CANCELED events can be deleted"), instead of a generic toast.
- **Draft → Scheduled / publish**: status-specific success ("Event scheduled — you can publish it (put it On Sale) when ready.") and, on failure, the real reason (e.g. "Event cannot be scheduled without a venue map and at least one inventory zone").

## Checkout
- Distinguish a gateway-unreachable failure from a card-declined one (#428); MVP OrderSession handoff.

## Other
- Owner-dashboard org-tree tile, real my-profile identity, MVP cart/notification wiring, reply toasts.
- `dev` merged into the branch to stay in sync (no outstanding conflicts).

## Testing
- `./mvnw -q -Pno-vaadin clean test` — **1500 tests, 0 failures** (incl. the new `SeatedReservationJpaTest` and the `CompanyEventListPresenterTest` message coverage).
