### PR TITLE
[Eval 6] DB-down robustness: friendly errors, global handler, recovers after reconnect

### DIFF
--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/AdminLoginPresenter.java
@@ -4,6 +4,7 @@ import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import com.ticketing.system.Presentation.support.ServiceErrors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +32,11 @@ public class AdminLoginPresenter {
         } catch (AuthenticationFailedException e) {
             return new Outcome.InvalidCredentials();
         } catch (RuntimeException e) {
+            // A DB outage surfaces here as a connectivity exception — tell it apart from a real
+            // failure so the user sees "service unavailable", not a misleading "sign-in failed".
+            if (ServiceErrors.isDatabaseUnavailable(e)) {
+                return new Outcome.ServiceUnavailable();
+            }
             return new Outcome.Failure(e.getMessage());
         }
     }
@@ -39,6 +45,7 @@ public class AdminLoginPresenter {
         record Success(AuthTokenDTO authToken) implements Outcome { }
         record InvalidCredentials() implements Outcome { }
         record Locked(String reason) implements Outcome { }
+        record ServiceUnavailable() implements Outcome { }
         record Failure(String reason) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/presenters/auth/LoginPresenter.java
+++ b/src/main/java/com/ticketing/system/Presentation/presenters/auth/LoginPresenter.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Core.Application.dto.LoginRequestDTO;
 import com.ticketing.system.Core.Application.services.AuthenticationService;
 import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
 import com.ticketing.system.Core.Domain.exceptions.GuestSessionRequiredException;
+import com.ticketing.system.Presentation.support.ServiceErrors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -43,6 +44,11 @@ public class LoginPresenter {
         } catch (GuestSessionRequiredException e) {
             return new Outcome.GuestSessionMissing(e.getMessage());
         } catch (RuntimeException e) {
+            // A DB outage surfaces here as a connectivity exception — tell it apart from a real
+            // failure so the user sees "service unavailable", not a misleading "sign-in failed".
+            if (ServiceErrors.isDatabaseUnavailable(e)) {
+                return new Outcome.ServiceUnavailable();
+            }
             return new Outcome.Failure(e.getMessage());
         }
     }
@@ -52,6 +58,7 @@ public class LoginPresenter {
         record Success(LoginDTO loginDTO) implements Outcome { }
         record InvalidCredentials() implements Outcome { }
         record GuestSessionMissing(String reason) implements Outcome { }
+        record ServiceUnavailable() implements Outcome { }
         record Failure(String reason) implements Outcome { }
     }
 }

--- a/src/main/java/com/ticketing/system/Presentation/security/GlobalUiErrorHandler.java
+++ b/src/main/java/com/ticketing/system/Presentation/security/GlobalUiErrorHandler.java
@@ -1,0 +1,70 @@
+package com.ticketing.system.Presentation.security;
+
+import com.ticketing.system.Presentation.components.Toasts;
+import com.ticketing.system.Presentation.support.ServiceErrors;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Installs a session-wide Vaadin {@link com.vaadin.flow.server.ErrorHandler} so that an uncaught
+ * exception during <i>any</i> UI interaction shows a friendly toast instead of Vaadin's default
+ * internal-error popup (or a raw stack trace in dev mode). A database outage gets the specific
+ * "temporarily unavailable" message; anything else gets a generic apology. The full stack is always
+ * logged server-side, so developers still see the detail in the logs.
+ *
+ * <p>Registered exactly like {@link GuestSessionBootstrap}: a {@link VaadinServiceInitListener} that
+ * sets the handler on every new {@code VaadinSession}. This is the safety net behind the per-flow
+ * handling (e.g. the login presenters) — it catches whatever a view forgot to.
+ */
+@Component
+@Slf4j
+public class GlobalUiErrorHandler implements VaadinServiceInitListener {
+
+    static final String GENERIC_MESSAGE = "Something went wrong — please try again.";
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.getSource().addSessionInitListener(sessionInit ->
+            sessionInit.getSession().setErrorHandler(this::handle));
+    }
+
+    private void handle(ErrorEvent errorEvent) {
+        Throwable error = errorEvent.getThrowable();
+        if (ServiceErrors.isDatabaseUnavailable(error)) {
+            log.warn("UI request failed — database unavailable: {}", rootCauseMessage(error));
+        } else {
+            log.error("Unhandled error during a UI request", error);
+        }
+        showToast(messageFor(error));
+    }
+
+    /** The user-facing message for an uncaught error — friendly either way, specific for a DB outage. */
+    static String messageFor(Throwable error) {
+        return ServiceErrors.isDatabaseUnavailable(error)
+            ? ServiceErrors.DB_UNAVAILABLE_MESSAGE
+            : GENERIC_MESSAGE;
+    }
+
+    private void showToast(String message) {
+        UI ui = UI.getCurrent();
+        if (ui != null) {
+            // We hold the session lock here; access() runs the toast before the response is sent.
+            ui.access(() -> Toasts.failure(message));
+        } else {
+            log.debug("no active UI on the error thread — toast suppressed (error already logged)");
+        }
+    }
+
+    private static String rootCauseMessage(Throwable error) {
+        Throwable cause = error;
+        while (cause.getCause() != null && cause.getCause() != cause) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage();
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/support/ServiceErrors.java
+++ b/src/main/java/com/ticketing/system/Presentation/support/ServiceErrors.java
@@ -1,0 +1,59 @@
+package com.ticketing.system.Presentation.support;
+
+import java.net.ConnectException;
+import java.sql.SQLException;
+import java.sql.SQLNonTransientConnectionException;
+import java.sql.SQLTransientConnectionException;
+
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+/**
+ * Classifies presentation-facing errors. The one question it answers today: is a thrown error the
+ * database / persistence layer being unreachable (DB down, connection refused, pool timed out) — as
+ * opposed to a bug or a violated domain rule? The login flow uses this to show "the service is
+ * temporarily unavailable" instead of "sign-in failed", and the global error handler uses it to keep
+ * a DB outage friendly anywhere in the UI.
+ *
+ * <p>Deliberately narrow: only connectivity / resource failures count. Constraint violations,
+ * optimistic-lock conflicts and empty results are {@code DataAccessException}s too, but they are NOT
+ * outages — counting them would mislabel a real bug as "try again later", so they are excluded.
+ */
+public final class ServiceErrors {
+
+    /** Single source of truth for the user-facing outage message (login view + global handler). */
+    public static final String DB_UNAVAILABLE_MESSAGE =
+        "The service is temporarily unavailable — please try again in a moment.";
+
+    private ServiceErrors() { }
+
+    /** True when {@code error} (or anything in its cause chain) is the database being unreachable. */
+    public static boolean isDatabaseUnavailable(Throwable error) {
+        for (Throwable cause = error; cause != null; cause = nextCause(cause)) {
+            if (cause instanceof CannotCreateTransactionException        // couldn't open a tx (no connection)
+                    || cause instanceof DataAccessResourceFailureException // Spring "resource failed" translation
+                    || cause instanceof SQLTransientConnectionException   // HikariCP pool timed out
+                    || cause instanceof SQLNonTransientConnectionException
+                    || cause instanceof ConnectException) {               // TCP connection refused (dead host/port)
+                return true;
+            }
+            if (cause instanceof SQLException sql && isConnectionSqlState(sql.getSQLState())) {
+                return true;
+            }
+            if (cause.getClass().getSimpleName().equals("JDBCConnectionException")) {
+                return true; // Hibernate connectivity error — matched by name to avoid a hard dependency
+            }
+        }
+        return false;
+    }
+
+    // SQLState class "08" = connection exception (SQL standard); Postgres uses 57P0x for admin shutdown.
+    private static boolean isConnectionSqlState(String sqlState) {
+        return sqlState != null && (sqlState.startsWith("08") || sqlState.startsWith("57P"));
+    }
+
+    private static Throwable nextCause(Throwable t) {
+        Throwable cause = t.getCause();
+        return cause == t ? null : cause; // guard a self-referential cause chain
+    }
+}

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/AdminLoginView.java
@@ -5,6 +5,7 @@ import com.ticketing.system.Presentation.components.kit.LkAuthCard;
 import com.ticketing.system.Presentation.layouts.MainLayout;
 import com.ticketing.system.Presentation.presenters.auth.AdminLoginPresenter;
 import com.ticketing.system.Presentation.session.AuthSession;
+import com.ticketing.system.Presentation.support.ServiceErrors;
 import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.UI;
@@ -69,6 +70,8 @@ public class AdminLoginView extends LkAuthCard {
                 Toasts.failure("Invalid admin username or password.");
             case AdminLoginPresenter.Outcome.Locked locked ->
                 Toasts.failure("Your account is temporarily locked after too many failed attempts. Please try again later.");
+            case AdminLoginPresenter.Outcome.ServiceUnavailable ignored ->
+                Toasts.failure(ServiceErrors.DB_UNAVAILABLE_MESSAGE);
             case AdminLoginPresenter.Outcome.Failure fail ->
                 Toasts.failure("Sign-in failed — please try again.");
         }

--- a/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/auth/LoginView.java
@@ -9,6 +9,7 @@ import com.ticketing.system.Presentation.presenters.auth.LoginPresenter;
 import com.ticketing.system.Presentation.session.AuthSession;
 import com.ticketing.system.Presentation.session.GuestSession;
 import com.ticketing.system.Presentation.session.NotificationSession;
+import com.ticketing.system.Presentation.support.ServiceErrors;
 import com.ticketing.system.Presentation.views.admin.AdminDashboardView;
 import com.ticketing.system.Presentation.views.catalog.BrowseEventsView;
 import com.vaadin.flow.component.Key;
@@ -114,6 +115,8 @@ public class LoginView extends LkAuthCard {
                 Toasts.warn("Your session timed out — reloading…");
                 UI.getCurrent().getPage().reload();
             }
+            case LoginPresenter.Outcome.ServiceUnavailable ignored ->
+                Toasts.failure(ServiceErrors.DB_UNAVAILABLE_MESSAGE);
             case LoginPresenter.Outcome.Failure fail ->
                 Toasts.failure("Sign-in failed — please try again.");
         }

--- a/src/test/java/com/ticketing/system/Presentation/security/GlobalUiErrorHandlerTest.java
+++ b/src/test/java/com/ticketing/system/Presentation/security/GlobalUiErrorHandlerTest.java
@@ -1,0 +1,28 @@
+package com.ticketing.system.Presentation.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.ticketing.system.Presentation.support.ServiceErrors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+/**
+ * The global handler's user-facing message selection. Shows a DB outage gets the specific
+ * "temporarily unavailable" text while anything else gets a generic (still friendly) apology —
+ * the toast rendering itself is exercised by the live UI, not unit-tested.
+ */
+class GlobalUiErrorHandlerTest {
+
+    @Test
+    void dbOutage_getsTheTemporarilyUnavailableMessage() {
+        assertEquals(ServiceErrors.DB_UNAVAILABLE_MESSAGE,
+            GlobalUiErrorHandler.messageFor(new CannotCreateTransactionException("no connection")));
+    }
+
+    @Test
+    void anyOtherError_getsTheGenericMessage() {
+        assertEquals(GlobalUiErrorHandler.GENERIC_MESSAGE,
+            GlobalUiErrorHandler.messageFor(new IllegalStateException("boom")));
+    }
+}

--- a/src/test/java/com/ticketing/system/integration/DbOutageRecoveryLocalPgIT.java
+++ b/src/test/java/com/ticketing/system/integration/DbOutageRecoveryLocalPgIT.java
@@ -1,0 +1,151 @@
+package com.ticketing.system.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ticketing.system.Presentation.support.ServiceErrors;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Manual robustness check for #427, run against a real local Postgres through the same HikariCP pool
+ * production uses. It drives the full TA loop at the connection layer — DB up → stop it → DB up again
+ * — and asserts the three properties the issue needs:
+ * <ol>
+ *   <li><b>No crash, recognized outage:</b> a query while Postgres is stopped throws, and
+ *       {@link ServiceErrors#isDatabaseUnavailable} recognizes the <i>real</i> exception (so the UI
+ *       would show the friendly "temporarily unavailable" message, not a stack trace).</li>
+ *   <li><b>Recovery:</b> after Postgres restarts, the <i>same</i> pool serves queries again — no app
+ *       restart (HikariCP validate-on-borrow from #362).</li>
+ * </ol>
+ *
+ * <p><b>Disabled by default</b> (needs a local Postgres + {@code pg_ctl}); CI never runs it. To run:
+ * <pre>
+ *   pg_ctl -D /opt/homebrew/var/postgresql@14 -l /tmp/pg_eval.log -w start
+ *   createdb ticketing_eval
+ *   LOCAL_PG_IT=true ./mvnw -o -Pno-vaadin test -Dtest=DbOutageRecoveryLocalPgIT
+ * </pre>
+ * Overridable via env: {@code PG_CTL}, {@code PG_DATA}, {@code PG_URL}, {@code PG_USER}, {@code PG_PASSWORD}.
+ */
+@EnabledIfEnvironmentVariable(named = "LOCAL_PG_IT", matches = "true")
+class DbOutageRecoveryLocalPgIT {
+
+    private static final String PG_CTL   = env("PG_CTL", "/opt/homebrew/bin/pg_ctl");
+    private static final String PG_DATA  = env("PG_DATA", "/opt/homebrew/var/postgresql@14");
+    private static final String PG_LOG   = "/tmp/pg_eval.log";
+    private static final String PG_URL   = env("PG_URL", "jdbc:postgresql://localhost:5432/ticketing_eval");
+    private static final String PG_USER  = env("PG_USER", System.getProperty("user.name"));
+    private static final String PG_PASS  = env("PG_PASSWORD", "");
+
+    @Test
+    void databaseDown_isRecognizedAsAnOutage_andRecoversAfterRestart() throws Exception {
+        try (HikariDataSource ds = pool()) {
+            JdbcTemplate jdbc = new JdbcTemplate(ds);
+
+            // Phase 1 — Postgres up: a query works.
+            assertEquals(1, jdbc.queryForObject("SELECT 1", Integer.class));
+
+            // Phase 2 — stop Postgres: the same query fails, and we recognize it as an outage.
+            pgCtl("stop");
+            DataAccessException outage = assertThrows(DataAccessException.class,
+                () -> jdbc.queryForObject("SELECT 1", Integer.class));
+            System.out.println("[#427] real Postgres-down surfaced as: " + describe(outage));
+            assertTrue(ServiceErrors.isDatabaseUnavailable(outage),
+                "the real Postgres-down exception must be classified as a DB outage, was: " + describe(outage));
+
+            // Phase 3 — restart Postgres: the SAME pool serves queries again (no app restart).
+            pgCtl("start");
+            assertEquals(1, queryWithRetry(jdbc),
+                "after Postgres returns, the pool must recover without recreating the datasource");
+        }
+    }
+
+    /** The literal TA scenario: Postgres is already down when a fresh request (login) tries to connect. */
+    @Test
+    void freshRequestWhileDown_isRecognizedAsAnOutage() throws Exception {
+        pgCtl("stop");
+        try (HikariDataSource ds = pool()) {
+            JdbcTemplate jdbc = new JdbcTemplate(ds);
+            DataAccessException outage = assertThrows(DataAccessException.class,
+                () -> jdbc.queryForObject("SELECT 1", Integer.class));
+            System.out.println("[#427] fresh connection while down surfaced as: " + describe(outage));
+            assertTrue(ServiceErrors.isDatabaseUnavailable(outage),
+                "a fresh connection to a down DB must be classified as an outage, was: " + describe(outage));
+        } finally {
+            pgCtl("start");
+        }
+    }
+
+    @AfterAll
+    static void ensurePostgresIsLeftRunning() throws Exception {
+        pgCtl("start"); // no-op if already running; never leave the box with PG down
+    }
+
+    private static HikariDataSource pool() {
+        HikariConfig cfg = new HikariConfig();
+        cfg.setJdbcUrl(PG_URL);
+        cfg.setUsername(PG_USER);
+        cfg.setPassword(PG_PASS);
+        cfg.setMaximumPoolSize(2);
+        cfg.setMinimumIdle(0);
+        cfg.setConnectionTimeout(3000);          // fail fast while the DB is down instead of hanging
+        cfg.setInitializationFailTimeout(-1);    // start the pool even if the DB is down (mirrors #362) so
+                                                 // the failure surfaces at query time, where the UI handles it
+        return new HikariDataSource(cfg);
+    }
+
+    // Recovery can take a moment after pg_ctl returns; retry briefly so the assertion isn't flaky.
+    private static Integer queryWithRetry(JdbcTemplate jdbc) throws InterruptedException {
+        RuntimeException last = null;
+        for (int attempt = 0; attempt < 10; attempt++) {
+            try {
+                return jdbc.queryForObject("SELECT 1", Integer.class);
+            } catch (RuntimeException e) {
+                last = e;
+                Thread.sleep(500);
+            }
+        }
+        throw last;
+    }
+
+    private static void pgCtl(String action) throws Exception {
+        List<String> cmd = new ArrayList<>(List.of(PG_CTL, "-D", PG_DATA, action, "-w"));
+        if ("stop".equals(action)) {
+            cmd.add("-m");
+            cmd.add("fast");
+        } else if ("start".equals(action)) {
+            cmd.add("-l");
+            cmd.add(PG_LOG);
+        }
+        Process p = new ProcessBuilder(cmd).redirectErrorStream(true).start();
+        String out = new String(p.getInputStream().readAllBytes());
+        p.waitFor();
+        System.out.println("[#427] pg_ctl " + action + ": " + out.trim());
+    }
+
+    private static String describe(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        for (Throwable c = t; c != null && c != c.getCause(); c = c.getCause()) {
+            if (sb.length() > 0) {
+                sb.append(" <- ");
+            }
+            sb.append(c.getClass().getSimpleName()).append("(").append(c.getMessage()).append(")");
+        }
+        return sb.toString();
+    }
+
+    private static String env(String key, String fallback) {
+        String v = System.getenv(key);
+        return (v == null || v.isBlank()) ? fallback : v;
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/AdminLoginPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/AdminLoginPresenterTest.java
@@ -1,0 +1,77 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.ticketing.system.Core.Application.dto.AuthTokenDTO;
+import com.ticketing.system.Core.Application.services.AuthenticationService;
+import com.ticketing.system.Core.Domain.exceptions.AccountLockedException;
+import com.ticketing.system.Core.Domain.exceptions.AuthenticationFailedException;
+import com.ticketing.system.Presentation.presenters.auth.AdminLoginPresenter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+class AdminLoginPresenterTest {
+
+    private AuthenticationService authenticationService;
+    private AdminLoginPresenter presenter;
+
+    @BeforeEach
+    void setUp() {
+        authenticationService = mock(AuthenticationService.class);
+        presenter = new AdminLoginPresenter(authenticationService);
+    }
+
+    @Test
+    void success_returnsSuccessWrappingTheToken() {
+        AuthTokenDTO token = new AuthTokenDTO("jwt", 9_999_999_999L, 1, "root");
+        when(authenticationService.signInAsAdmin("root", "pw")).thenReturn(token);
+
+        AdminLoginPresenter.Outcome outcome = presenter.attemptAdminLogin("root", "pw");
+
+        AdminLoginPresenter.Outcome.Success ok =
+            assertInstanceOf(AdminLoginPresenter.Outcome.Success.class, outcome);
+        assertSame(token, ok.authToken());
+    }
+
+    @Test
+    void authenticationFailed_returnsInvalidCredentials() {
+        when(authenticationService.signInAsAdmin("root", "wrong"))
+            .thenThrow(new AuthenticationFailedException());
+
+        assertInstanceOf(AdminLoginPresenter.Outcome.InvalidCredentials.class,
+            presenter.attemptAdminLogin("root", "wrong"));
+    }
+
+    @Test
+    void accountLocked_returnsLocked() {
+        when(authenticationService.signInAsAdmin("root", "pw"))
+            .thenThrow(new AccountLockedException("locked for 15 minutes"));
+
+        assertInstanceOf(AdminLoginPresenter.Outcome.Locked.class,
+            presenter.attemptAdminLogin("root", "pw"));
+    }
+
+    @Test
+    void databaseUnavailable_returnsServiceUnavailable() {
+        // A DB outage surfaces as a connectivity exception — must map to ServiceUnavailable.
+        when(authenticationService.signInAsAdmin("root", "pw"))
+            .thenThrow(new DataAccessResourceFailureException("could not get a connection"));
+
+        assertInstanceOf(AdminLoginPresenter.Outcome.ServiceUnavailable.class,
+            presenter.attemptAdminLogin("root", "pw"));
+    }
+
+    @Test
+    void unexpectedRuntime_returnsFailure() {
+        when(authenticationService.signInAsAdmin("root", "pw"))
+            .thenThrow(new IllegalStateException("boom"));
+
+        assertInstanceOf(AdminLoginPresenter.Outcome.Failure.class,
+            presenter.attemptAdminLogin("root", "pw"));
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/presentation/LoginPresenterTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/LoginPresenterTest.java
@@ -19,6 +19,7 @@ import com.ticketing.system.Presentation.presenters.auth.LoginPresenter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.transaction.CannotCreateTransactionException;
 
 class LoginPresenterTest {
 
@@ -93,5 +94,17 @@ class LoginPresenterTest {
         LoginPresenter.Outcome.Failure fail =
             assertInstanceOf(LoginPresenter.Outcome.Failure.class, outcome);
         assertEquals("database down", fail.reason());
+    }
+
+    @Test
+    void databaseUnavailable_returnsServiceUnavailable() {
+        // A real DB outage surfaces as a connectivity exception (here, can't open a transaction)
+        // — it must map to ServiceUnavailable, not the generic Failure shown for unexpected errors.
+        when(authenticationService.login(any()))
+            .thenThrow(new CannotCreateTransactionException("Could not open JPA EntityManager for transaction"));
+
+        LoginPresenter.Outcome outcome = presenter.attemptLogin("adam", "password123", "guest-sid");
+
+        assertInstanceOf(LoginPresenter.Outcome.ServiceUnavailable.class, outcome);
     }
 }

--- a/src/test/java/com/ticketing/system/unit/presentation/ServiceErrorsTest.java
+++ b/src/test/java/com/ticketing/system/unit/presentation/ServiceErrorsTest.java
@@ -1,0 +1,97 @@
+package com.ticketing.system.unit.presentation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ConnectException;
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
+
+import com.ticketing.system.Presentation.support.ServiceErrors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.transaction.CannotCreateTransactionException;
+
+/**
+ * The DB-outage classifier is the deterministic core of #427: it decides whether a thrown error is
+ * the database being unreachable (→ friendly "temporarily unavailable") or something else. Tested
+ * with the real Spring/JDBC exception types so no live DB is needed, and with the look-alikes that
+ * must NOT be treated as an outage.
+ */
+class ServiceErrorsTest {
+
+    // ---- outages: must be detected ----
+
+    @Test
+    void cannotOpenTransaction_isAnOutage() {
+        assertTrue(ServiceErrors.isDatabaseUnavailable(
+            new CannotCreateTransactionException("Could not open JPA EntityManager for transaction")));
+    }
+
+    @Test
+    void resourceFailure_isAnOutage() {
+        assertTrue(ServiceErrors.isDatabaseUnavailable(
+            new DataAccessResourceFailureException("could not get a connection")));
+    }
+
+    @Test
+    void hikariPoolTimeout_isAnOutage() {
+        assertTrue(ServiceErrors.isDatabaseUnavailable(
+            new SQLTransientConnectionException("Connection is not available, request timed out")));
+    }
+
+    @Test
+    void connectionRefused_deepInTheCauseChain_isAnOutage() {
+        Throwable wrapped = new RuntimeException("checkout failed",
+            new IllegalStateException("layer", new ConnectException("Connection refused")));
+        assertTrue(ServiceErrors.isDatabaseUnavailable(wrapped));
+    }
+
+    @Test
+    void connectionSqlState08_isAnOutage() {
+        assertTrue(ServiceErrors.isDatabaseUnavailable(
+            new SQLException("connection failure", "08006")));
+    }
+
+    @Test
+    void wrappedTransactionException_isStillAnOutage() {
+        // Mirrors how services wrap failures (e.g. CheckoutService's "Checkout failed" wrapper).
+        Throwable wrapped = new RuntimeException("Sign-in failed",
+            new CannotCreateTransactionException("no connection"));
+        assertTrue(ServiceErrors.isDatabaseUnavailable(wrapped));
+    }
+
+    // ---- look-alikes: must NOT be treated as an outage ----
+
+    @Test
+    void constraintViolation_isNotAnOutage() {
+        assertFalse(ServiceErrors.isDatabaseUnavailable(
+            new DataIntegrityViolationException("duplicate key value violates unique constraint")));
+    }
+
+    @Test
+    void optimisticLockConflict_isNotAnOutage() {
+        assertFalse(ServiceErrors.isDatabaseUnavailable(
+            new OptimisticLockingFailureException("row was updated by another transaction")));
+    }
+
+    @Test
+    void plainBug_isNotAnOutage() {
+        assertFalse(ServiceErrors.isDatabaseUnavailable(new IllegalStateException("boom")));
+        assertFalse(ServiceErrors.isDatabaseUnavailable(new NullPointerException()));
+    }
+
+    @Test
+    void nonConnectionSqlState_isNotAnOutage() {
+        assertFalse(ServiceErrors.isDatabaseUnavailable(
+            new SQLException("syntax error", "42601")));
+    }
+
+    @Test
+    void nullIsHandledGracefully() {
+        assertFalse(ServiceErrors.isDatabaseUnavailable(null));
+    }
+}


### PR DESCRIPTION
Closes #427.

## Summary
Makes the UI robust to a database outage: no crash, a friendly message, and automatic recovery once the DB returns. Two layers, both built on the connectivity-aware classifier:

- **`ServiceErrors`** (new) — classifies whether a thrown error is the database being *unreachable* (walks the cause chain; matches `CannotCreateTransactionException`, `DataAccessResourceFailureException`, Hikari `SQLTransientConnectionException`, `ConnectException`, SQLState `08*`/`57P*`). Deliberately narrow — constraint violations and optimistic-lock conflicts are **not** treated as outages, so a real bug is never mislabeled "try again later".
- **`GlobalUiErrorHandler`** (new) — a session-wide Vaadin `ErrorHandler` (registered like `GuestSessionBootstrap`). Any uncaught exception anywhere in the UI now shows a friendly toast — the specific "temporarily unavailable" message for an outage, a generic apology otherwise — and the full stack is logged server-side. This removes Vaadin's default internal-error / raw-stack surface.
- **Login** (`LoginPresenter`/`AdminLoginPresenter` + their views) — a DB outage now maps to a new `ServiceUnavailable` outcome shown as "The service is temporarily unavailable — please try again", distinct from the bad-credentials message. (Login already didn't crash; this makes the message accurate.)

## Acceptance
- [x] **DB down → friendly message, no crash.** Outage exceptions are caught (login) / handled globally and classified; the user sees a friendly toast, never a stack trace.
- [x] **Global error handler prevents raw stack traces anywhere.** `GlobalUiErrorHandler` is installed on every session.
- [x] **After the DB returns, works again without a restart.** HikariCP validate-on-borrow (#362) reconnects; proven below.

## Verification
Deterministic unit tests (`ServiceErrorsTest`, `GlobalUiErrorHandlerTest`, `LoginPresenterTest`, `AdminLoginPresenterTest`) feed the **real** Spring/JDBC exception types — no live DB needed — and cover the look-alikes that must NOT be treated as outages.

Plus a real local-Postgres down/up cycle (`DbOutageRecoveryLocalPgIT`, gated by `LOCAL_PG_IT`, never runs in CI), which confirmed against an actual Postgres:
- fresh request while down → `CannotGetJdbcConnectionException ← SQLTransientConnectionException ← PSQLException("Connection refused") ← ConnectException` → classified as outage;
- in-flight connection killed → `DataAccessResourceFailureException` → classified as outage;
- after `pg_ctl start`, the **same** Hikari pool served queries again — recovery without an app restart.

`./mvnw -Pno-vaadin test` — **1524 tests, 0 failures** (the IT is gated off).

## Notes
- Builds on #362 (HikariCP DB-reconnect), which is already on this branch via `dev`.
- The gated IT is committed as reproducible documentation of the robustness check; run instructions are in its javadoc.
