### PR TITLE
fix(#455): market boots non-deterministically closed — WSEP handshake retry + self-heal

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/SystemAdminService.java
@@ -157,7 +157,14 @@ public class SystemAdminService {
     // are gated on this state (see isMarketOpen()).
     public synchronized MarketStateDTO openMarket(MarketControlRequestDTO request) {
         requireSystemAdmin(tokenOf(request));
+        return doOpenMarket();
+    }
 
+    // Core market-open logic, shared by the admin-gated openMarket() and the system-internal
+    // ensureMarketOpen() recovery hook. Re-verifies both external services + structural invariants
+    // before flipping to OPEN; idempotent on an already-open market; re-opens from CLOSED; rejects an
+    // UNINITIALIZED platform.
+    private MarketStateDTO doOpenMarket() {
         if (status == PlatformStatus.OPEN) {
             log.info("Market already open; ignoring open request.");
             return buildMarketState();
@@ -179,6 +186,27 @@ public class SystemAdminService {
         this.lastOpenedAt = LocalDateTime.now();
         log.info("Market opened.");
         return buildMarketState();
+    }
+
+    // System-internal, idempotent recovery hook (#455): bring the market to OPEN if it safely can.
+    // Used by the dev auto-opener and the self-heal scheduler so a transient external-service blip at
+    // boot (e.g. a cold-starting WSEP endpoint) doesn't leave the market closed with no recovery
+    // (V3 Req 6). NOT admin-gated — the platform acts on itself, not on a user request. Respects an
+    // admin's deliberate close: never auto-reopens a CLOSED market. Never throws.
+    public synchronized void ensureMarketOpen() {
+        if (status == PlatformStatus.OPEN || status == PlatformStatus.CLOSED) {
+            return; // already open, or deliberately closed by an admin — leave it alone
+        }
+        try {
+            if (status == PlatformStatus.UNINITIALIZED) {
+                initializePlatform();   // UNINITIALIZED -> READY (the WSEP handshake now retries internally)
+            }
+            if (status == PlatformStatus.READY) {
+                doOpenMarket();         // READY -> OPEN
+            }
+        } catch (RuntimeException e) {
+            log.warn("Market auto-open attempt did not succeed (will retry): {}", e.getMessage());
+        }
     }
 
     // UC-32 — close the trading market (admin/ops incident control; no dedicated

--- a/src/main/java/com/ticketing/system/Infrastructure/dev/DevMarketOpener.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/dev/DevMarketOpener.java
@@ -1,29 +1,29 @@
 package com.ticketing.system.Infrastructure.dev;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
-import com.ticketing.system.Core.Application.dto.MarketControlRequestDTO;
-import com.ticketing.system.Core.Application.interfaces.ISessionManager;
 import com.ticketing.system.Core.Application.services.SystemAdminService;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Opens the trading market automatically in the {@code dev} profile so the app —
- * and the demo seeders' purchase flows — work out of the box without an admin
- * manually opening it. Production never runs this: a real operator opens the
- * market through UC-32 once the platform has been verified.
+ * Opens the trading market automatically in the {@code dev} profile so the app — and the demo
+ * seeders' purchase flows — work out of the box without an admin manually opening it. Production
+ * never runs this: a real operator opens the market through UC-32 (made reliable by the WSEP
+ * handshake retry).
  *
- * <p>Ordering matters now that reserve/checkout are gated on an OPEN market:
- * {@code @Order(1)} places this after {@code PlatformInitializationRunner}
- * (@Order(0), which brings the platform to READY) and before the purchasing
- * {@code ScenarioRunner} (@Order(2)). The market is therefore OPEN before the
- * scenario attempts any reservation or checkout.
+ * <p>Ordering matters because reserve/checkout are gated on an OPEN market: {@code @Order(1)} places
+ * this after {@code PlatformInitializationRunner} (@Order(0), which brings the platform to READY) and
+ * before the purchasing {@code ScenarioRunner} (@Order(2)), so the market is OPEN before the scenario
+ * attempts any reservation or checkout.
+ *
+ * <p>Delegates to the system-internal {@link SystemAdminService#ensureMarketOpen()} (idempotent, and
+ * the handshake it triggers now retries). If a transient external-service outage still leaves the
+ * market closed here, {@code MarketSelfHealScheduler} keeps re-attempting until it opens (#455).
  */
 @Component
 @Profile("dev")
@@ -31,33 +31,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DevMarketOpener implements ApplicationRunner {
 
-    // Mirrors SystemAdminService.DEFAULT_ADMIN_ID — the default admin minted during init.
-    private static final int DEFAULT_ADMIN_ID = 1;
-
     private final SystemAdminService systemAdminService;
-    private final ISessionManager sessionManager;
-    private final String adminUsername;
 
-    public DevMarketOpener(SystemAdminService systemAdminService,
-                           ISessionManager sessionManager,
-                           @Value("${platform.admin.username}") String adminUsername) {
+    public DevMarketOpener(SystemAdminService systemAdminService) {
         this.systemAdminService = systemAdminService;
-        this.sessionManager = sessionManager;
-        this.adminUsername = adminUsername;
     }
 
     @Override
     public void run(ApplicationArguments args) {
-        try {
-            // Mint a short-lived admin session for the default admin and open the market
-            // through the real authorization path (requireSystemAdmin).
-            String adminToken = sessionManager.generateAdminToken(DEFAULT_ADMIN_ID, adminUsername);
-            systemAdminService.openMarket(new MarketControlRequestDTO("OPEN", "dev auto-open", adminToken));
+        systemAdminService.ensureMarketOpen();
+        if (systemAdminService.isMarketOpen()) {
             log.info("[dev] Trading market auto-opened for development.");
-        } catch (RuntimeException e) {
-            // Non-fatal: if the platform never reached READY (e.g. a stubbed service was
-            // toggled unreachable), leave the market closed and let the dev open it manually.
-            log.warn("[dev] Could not auto-open the market (platform may not be initialized): {}", e.getMessage());
+        } else {
+            log.warn("[dev] Market not open yet (platform or external services not ready); "
+                    + "the self-heal scheduler will keep retrying.");
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepHttpClient.java
@@ -10,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -33,13 +34,19 @@ public class WsepHttpClient {
 
     private final String baseUrl;
     private final long requestTimeoutSeconds;
+    private final int handshakeAttempts;
+    private final long handshakeBackoffMs;
     private final HttpClient http;
 
     public WsepHttpClient(
             @Value("${wsep.base-url:https://damp-lynna-wsep-1984852e.koyeb.app/}") String baseUrl,
-            @Value("${wsep.request-timeout-seconds:20}") long requestTimeoutSeconds) {
+            @Value("${wsep.request-timeout-seconds:20}") long requestTimeoutSeconds,
+            @Value("${wsep.handshake-attempts:3}") int handshakeAttempts,
+            @Value("${wsep.handshake-backoff-ms:1000}") long handshakeBackoffMs) {
         this.baseUrl = baseUrl;
         this.requestTimeoutSeconds = requestTimeoutSeconds;
+        this.handshakeAttempts = handshakeAttempts;
+        this.handshakeBackoffMs = handshakeBackoffMs;
         this.http = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
@@ -95,6 +102,44 @@ public class WsepHttpClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new WsepCommunicationException("WSEP request interrupted", e);
+        }
+    }
+
+    /**
+     * Like {@link #post}, but retries on a transport failure with a short backoff. Use ONLY for
+     * <b>idempotent</b> actions — the reachability {@code handshake}. NEVER for {@code pay} /
+     * {@code issue_ticket} / {@code refund}: those are non-idempotent and a blind retry could
+     * double-charge or double-issue. The retry lets a cold-starting WSEP endpoint (a free-tier host
+     * that sleeps when idle) wake on an early attempt and answer on a later one, instead of failing
+     * the market open at boot (#455 / #365).
+     */
+    public String postWithRetry(Form form) {
+        return withRetry(() -> post(form));
+    }
+
+    // Bounded retry around a transport call: retries only WsepCommunicationException (a transport
+    // failure), rethrowing the last one after exhausting attempts. Package-private for unit testing.
+    String withRetry(Supplier<String> action) {
+        int attempts = Math.max(1, handshakeAttempts);
+        WsepCommunicationException last = null;
+        for (int attempt = 1; attempt <= attempts; attempt++) {
+            try {
+                return action.get();
+            } catch (WsepCommunicationException e) {
+                last = e;
+                if (attempt < attempts) {
+                    sleepBackoff(attempt);
+                }
+            }
+        }
+        throw last;
+    }
+
+    private void sleepBackoff(int attempt) {
+        try {
+            Thread.sleep(handshakeBackoffMs * attempt); // linear backoff: 1x, 2x, … gives the host time to wake
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepPaymentGateway.java
@@ -51,7 +51,9 @@ public class WsepPaymentGateway implements IPaymentGateway {
     @Override
     public boolean verifyConnection() {
         try {
-            boolean ok = "OK".equalsIgnoreCase(http.post(WsepHttpClient.action("handshake")));
+            // Retried (idempotent handshake): a cold-starting WSEP endpoint may miss the first attempt
+            // but answer a later one, so a transient blip doesn't leave the market closed at boot (#455).
+            boolean ok = "OK".equalsIgnoreCase(http.postWithRetry(WsepHttpClient.action("handshake")));
             log.debug("wsep handshake: reachable={}", ok);
             return ok;
         } catch (RuntimeException e) {

--- a/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/external/WsepTicketIssuer.java
@@ -53,7 +53,9 @@ public class WsepTicketIssuer implements ITicketIssuer {
     @Override
     public boolean verifyConnection() {
         try {
-            boolean ok = "OK".equalsIgnoreCase(http.post(WsepHttpClient.action("handshake")));
+            // Retried (idempotent handshake): a cold-starting WSEP endpoint may miss the first attempt
+            // but answer a later one, so a transient blip doesn't leave the market closed at boot (#455).
+            boolean ok = "OK".equalsIgnoreCase(http.postWithRetry(WsepHttpClient.action("handshake")));
             log.debug("wsep handshake (issuer): reachable={}", ok);
             return ok;
         } catch (RuntimeException e) {

--- a/src/main/java/com/ticketing/system/Infrastructure/scheduling/MarketSelfHealScheduler.java
+++ b/src/main/java/com/ticketing/system/Infrastructure/scheduling/MarketSelfHealScheduler.java
@@ -1,0 +1,35 @@
+package com.ticketing.system.Infrastructure.scheduling;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Self-heals the trading market in the {@code dev} profile (#455). If a transient external-service
+ * outage — e.g. a cold-starting WSEP endpoint — left the market closed at boot, this periodically
+ * re-attempts the open so the system recovers <i>without a restart</i> (V3 Req 6).
+ *
+ * <p>{@link SystemAdminService#ensureMarketOpen()} is idempotent and respects an admin's deliberate
+ * close, so this is a no-op once the market is open (or was closed on purpose). Dev-only: production
+ * opens the market through an admin (UC-32), which the WSEP handshake retry already makes reliable.
+ */
+@Component
+@Profile("dev")
+@Slf4j
+public class MarketSelfHealScheduler {
+
+    private final SystemAdminService systemAdminService;
+
+    public MarketSelfHealScheduler(SystemAdminService systemAdminService) {
+        this.systemAdminService = systemAdminService;
+    }
+
+    @Scheduled(fixedDelayString = "${market.self-heal-delay-ms:30000}")
+    public void reopenMarketIfNeeded() {
+        systemAdminService.ensureMarketOpen();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,3 +91,12 @@ platform:
 # the single koyeb endpoint both adapters POST to.
 wsep:
   base-url: ${WSEP_BASE_URL:https://damp-lynna-wsep-1984852e.koyeb.app/}
+  # The reachability handshake is retried (idempotent) so a cold-starting WSEP host doesn't leave the
+  # market closed at boot (#455/#365). pay/issue/refund are never retried (non-idempotent).
+  handshake-attempts: ${WSEP_HANDSHAKE_ATTEMPTS:3}
+  handshake-backoff-ms: ${WSEP_HANDSHAKE_BACKOFF_MS:1000}
+
+# Market self-heal (dev): if a transient external-service outage leaves the market closed at boot,
+# MarketSelfHealScheduler re-attempts the open on this interval until it succeeds (recover, no restart).
+market:
+  self-heal-delay-ms: ${MARKET_SELF_HEAL_DELAY_MS:30000}

--- a/src/test/java/com/ticketing/system/Infrastructure/external/WsepHttpClientRetryTest.java
+++ b/src/test/java/com/ticketing/system/Infrastructure/external/WsepHttpClientRetryTest.java
@@ -1,0 +1,57 @@
+package com.ticketing.system.Infrastructure.external;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The bounded retry behind the WSEP reachability handshake (#455 / #365): a cold-starting endpoint may
+ * miss early attempts but answer a later one. Exercises {@code withRetry} directly (package-private) so
+ * no real HTTP is involved; backoff is 0 to keep the test fast.
+ */
+class WsepHttpClientRetryTest {
+
+    // attempts=3, backoff=0; base-url/timeout are irrelevant to withRetry (post() is never called here).
+    private WsepHttpClient client() {
+        return new WsepHttpClient("http://localhost", 1, 3, 0);
+    }
+
+    @Test
+    void withRetry_succeedsOnALaterAttempt_afterTransientFailures() {
+        AtomicInteger calls = new AtomicInteger();
+        String result = client().withRetry(() -> {
+            if (calls.incrementAndGet() < 3) {
+                throw new WsepCommunicationException("cold-start timeout", new RuntimeException());
+            }
+            return "OK";
+        });
+        assertEquals("OK", result);
+        assertEquals(3, calls.get(), "should retry until the endpoint finally answers");
+    }
+
+    @Test
+    void withRetry_rethrowsAfterExhaustingAttempts() {
+        AtomicInteger calls = new AtomicInteger();
+        WsepCommunicationException ex = assertThrows(WsepCommunicationException.class,
+                () -> client().withRetry(() -> {
+                    calls.incrementAndGet();
+                    throw new WsepCommunicationException("still down", new RuntimeException());
+                }));
+        assertEquals(3, calls.get(), "should try exactly maxAttempts times");
+        assertEquals("still down", ex.getMessage());
+    }
+
+    @Test
+    void withRetry_doesNotRetryWhenTheFirstAttemptSucceeds() {
+        AtomicInteger calls = new AtomicInteger();
+        String result = client().withRetry(() -> {
+            calls.incrementAndGet();
+            return "OK";
+        });
+        assertEquals("OK", result);
+        assertEquals(1, calls.get());
+    }
+}

--- a/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
+++ b/src/test/java/com/ticketing/system/unit/application/SystemAdminServiceTest.java
@@ -253,6 +253,48 @@ class SystemAdminServiceTest {
         assertThrows(UnauthorizedActionException.class, () -> svc.closeMarket(request));
     }
 
+    // --- #455: ensureMarketOpen (system self-heal — no admin token, recovers from a boot-time outage) ---
+
+    @Test
+    void givenReachableServices_whenEnsureMarketOpen_thenOpens() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        SystemAdminService svc = serviceWith(List.of(reachablePayment()), List.of(reachableIssuer()));
+        svc.ensureMarketOpen();   // UNINITIALIZED -> READY -> OPEN in one shot
+        assertTrue(svc.isMarketOpen());
+    }
+
+    @Test
+    void givenServicesDownThenUp_whenEnsureMarketOpenTwice_thenSelfHealsToOpen() {
+        when(adminRepository.existsAny()).thenReturn(true);
+        IPaymentGateway gateway = mock(IPaymentGateway.class);
+        when(gateway.verifyConnection()).thenReturn(false);   // WSEP cold / unreachable at boot
+        SystemAdminService svc = serviceWith(List.of(gateway), List.of(reachableIssuer()));
+
+        svc.ensureMarketOpen();                               // can't reach payment -> stays closed, no throw
+        assertFalse(svc.isMarketOpen());
+
+        when(gateway.verifyConnection()).thenReturn(true);    // WSEP recovers
+        svc.ensureMarketOpen();                               // self-heal -> opens
+        assertTrue(svc.isMarketOpen());
+    }
+
+    @Test
+    void givenAdminClosedMarket_whenEnsureMarketOpen_thenStaysClosed() {
+        SystemAdminService svc = readyService();
+        svc.openMarket(openRequest());
+        svc.closeMarket(closeRequest());                      // admin deliberately closes the market
+        svc.ensureMarketOpen();                               // must NOT auto-reopen a deliberate close
+        assertFalse(svc.isMarketOpen());
+        assertEquals("CLOSED", svc.viewMarketState().currentStatus());
+    }
+
+    @Test
+    void givenNoReachableServices_whenEnsureMarketOpen_thenNeverThrowsAndStaysClosed() {
+        SystemAdminService svc = serviceWith(List.of(), List.of());
+        assertDoesNotThrow(svc::ensureMarketOpen);            // self-heal must never throw out to its caller
+        assertFalse(svc.isMarketOpen());
+    }
+
     @Test
     void givenInitializedPlatform_whenViewMarketState_thenReportsHealth() {
         SystemAdminService svc = readyService();

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepPaymentGatewayTest.java
@@ -46,13 +46,14 @@ class WsepPaymentGatewayTest {
 
     @Test
     void verifyConnection_trueOnOk_falseOtherwise_falseOnTransportError() {
-        when(http.post(any())).thenReturn("OK");
+        // verifyConnection now goes through the retrying postWithRetry (idempotent handshake).
+        when(http.postWithRetry(any())).thenReturn("OK");
         assertTrue(gateway.verifyConnection());
 
-        when(http.post(any())).thenReturn("down");
+        when(http.postWithRetry(any())).thenReturn("down");
         assertFalse(gateway.verifyConnection());
 
-        when(http.post(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
+        when(http.postWithRetry(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
         assertFalse(gateway.verifyConnection());
     }
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepTicketIssuerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/external/WsepTicketIssuerTest.java
@@ -37,13 +37,14 @@ class WsepTicketIssuerTest {
 
     @Test
     void verifyConnection_trueOnOk_falseOtherwise() {
-        when(http.post(any())).thenReturn("OK");
+        // verifyConnection now goes through the retrying postWithRetry (idempotent handshake).
+        when(http.postWithRetry(any())).thenReturn("OK");
         assertTrue(issuer.verifyConnection());
 
-        when(http.post(any())).thenReturn("down");
+        when(http.postWithRetry(any())).thenReturn("down");
         assertFalse(issuer.verifyConnection());
 
-        when(http.post(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
+        when(http.postWithRetry(any())).thenThrow(new WsepCommunicationException("x", new RuntimeException()));
         assertFalse(issuer.verifyConnection());
     }
 

--- a/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/MarketSelfHealSchedulerTest.java
+++ b/src/test/java/com/ticketing/system/unit/infrastructure/scheduling/MarketSelfHealSchedulerTest.java
@@ -1,0 +1,23 @@
+package com.ticketing.system.unit.infrastructure.scheduling;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+
+import com.ticketing.system.Core.Application.services.SystemAdminService;
+import com.ticketing.system.Infrastructure.scheduling.MarketSelfHealScheduler;
+
+/**
+ * The self-heal tick is a thin delegate — it just re-runs the idempotent {@code ensureMarketOpen()}
+ * (whose open/close/no-op behaviour is covered in SystemAdminServiceTest).
+ */
+class MarketSelfHealSchedulerTest {
+
+    @Test
+    void reopenMarketIfNeeded_delegatesToEnsureMarketOpen() {
+        SystemAdminService admin = mock(SystemAdminService.class);
+        new MarketSelfHealScheduler(admin).reopenMarketIfNeeded();
+        verify(admin).ensureMarketOpen();
+    }
+}


### PR DESCRIPTION
Closes #455. Also implements the core of #365 (WSEP transport resilience / SLR.5).

## Root cause
Since the JPA onboarding, the platform "market" booted OPEN on some dev runs and CLOSED on others; a closed market makes **every** reservation fail with "Market is not currently open" (`ReservationService`). The de-masked error (from #427) is what finally surfaced "market is closed" as the real reason.

Opening the market requires a **live WSEP handshake**, done as a **single attempt with no retry**. Both `initializePlatform()` and `openMarket()` call `requireExternalServicesReachable()` → `verifyConnection()` → one `WsepHttpClient.post()`. The WSEP endpoint is a free-tier **Koyeb host that cold-starts when idle**, so the first handshake after idle times out → `ExternalServiceUnavailableException` → swallowed → platform stays `UNINITIALIZED` → `DevMarketOpener` can't open → market **CLOSED**, with no retry and no recovery. On fast-handshake boots it reached `OPEN`. That's the "sometimes open, sometimes closed."

## Fix
1. **Retry the reachability handshake** (`WsepHttpClient.postWithRetry`, bounded + linear backoff, config `wsep.handshake-attempts`/`handshake-backoff-ms`). Applied **only** to the idempotent `handshake` (both `verifyConnection`s); `pay`/`issue_ticket`/`refund` stay single-attempt — never blind-retried (non-idempotent). This lets a cold-starting host miss the first attempt and answer a later one.
2. **Self-heal the open** — `SystemAdminService.ensureMarketOpen()` (system-internal, idempotent, no admin token) re-runs init→open if the market isn't open; `MarketSelfHealScheduler` (dev) re-attempts on an interval so the market recovers **without a restart** (V3 Req 6). It respects an admin's deliberate `CLOSE` — never auto-reopens a closed market. `DevMarketOpener` now delegates to `ensureMarketOpen()`.

## Verification — `./mvnw -Pno-vaadin test` green (1513, 0 failures)
- `WsepHttpClientRetryTest` — the handshake retry recovers after transient failures, rethrows after exhausting attempts, doesn't retry on success.
- `SystemAdminServiceTest` — `ensureMarketOpen` opens when services are reachable; **self-heals** when an unreachable gateway later recovers; **stays closed** after an admin close; **never throws** with no reachable services.
- `MarketSelfHealSchedulerTest` — the tick delegates to `ensureMarketOpen`.

The retry + self-heal are proven deterministically by the unit tests (a real Koyeb cold-start can't be reproduced on demand). A dev boot is the end-to-end confirmation.

## Notes
- `DevMarketOpener` kept at `@Order(1)` (the plan floated `@Order(2)`, but that collides with `ScenarioRunner @Order(2)`, which must run *after* the market opens). The duplicate `@Order(1)` with `DevUserSeeder` is harmless (market-open doesn't depend on user seeding).
- Dev's `wsep.request-timeout-seconds: 8` is left as-is — it's intentional (fast "gateway unreachable" demo); the retry, not a longer timeout, handles cold-starts.
- Auto-open stays dev-only (as before); production opens via admin (UC-32), now reliable thanks to the handshake retry.
