### PR TITLE
Pre-submission cleanup (#460): drop mock export + typed, id-free write-path exceptions

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/CompanyManagementService.java
@@ -28,7 +28,9 @@ import com.ticketing.system.Core.Domain.company.CompanyStatus;
 import com.ticketing.system.Core.Domain.company.IProductionCompanyRepository;
 import com.ticketing.system.Core.Domain.company.ProductionCompany;
 import com.ticketing.system.Core.Domain.exceptions.CompanyNotFoundException;
+import com.ticketing.system.Core.Domain.exceptions.DomainException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.Tickets.ITicketRepository;
 import com.ticketing.system.Core.Domain.Tickets.Ticket;
@@ -100,7 +102,7 @@ public class CompanyManagementService {
             targetUser = userRepository.getUserById(request.targetUserId());
         } catch (UserNotFoundException e) {
             log.warn("User appointer/appointee not found during appointment: {}", e.getMessage());
-            throw new RuntimeException("User not found");
+            throw e;
         }
 
         appointer.requireOwnerInCompany(request.companyId()); // check if appointer has permissions
@@ -202,7 +204,7 @@ public class CompanyManagementService {
             manager = userRepository.getUserById(edit.targetUserId());
         } catch (UserNotFoundException e) {
             log.warn("Manager not found during permission edit: {}", e.getMessage());
-            throw new RuntimeException("Manager not found");
+            throw e;
         }
 
         if (edit.newPermissions() == null || edit.newPermissions().isEmpty()) {
@@ -236,7 +238,7 @@ public class CompanyManagementService {
         if (company.getFounderId() == revokeRequest.targetUserId()) {
             log.warn("Cannot revoke appointment: target user {} is the founder of company {}",
                     revokeRequest.targetUserId(), company.getCompanyId());
-            throw new RuntimeException("Cannot revoke appointment of the founder");
+            throw new UnauthorizedActionException("revoke the appointment of a company founder");
         }
 
         targetUser.revokeAppointment(revokeRequest.companyId(), ownerId); // checks done in here.
@@ -270,7 +272,7 @@ public class CompanyManagementService {
         if (byEmail.isPresent())
             return byEmail.get().getUserId();
 
-        throw new UserNotFoundException(identifier);
+        throw new UserNotFoundException();
     }
 
     // ---------------------------------------------------------------------------
@@ -283,11 +285,11 @@ public class CompanyManagementService {
         int requesterId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
-            throw new CompanyNotFoundException(companyId);
+            throw new CompanyNotFoundException();
         }
         User requester = userRepository.getUserById(requesterId);
         if (requester == null) {
-            throw new UserNotFoundException(requesterId);
+            throw new UserNotFoundException();
         }
         requester.requireOwnerInCompany(companyId);
 
@@ -310,11 +312,11 @@ public class CompanyManagementService {
         int requesterId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
-            throw new CompanyNotFoundException(companyId);
+            throw new CompanyNotFoundException();
         }
         User requester = userRepository.getUserById(requesterId);
         if (requester == null) {
-            throw new UserNotFoundException(requesterId);
+            throw new UserNotFoundException();
         }
         requester.requireOwnerInCompany(companyId);
 
@@ -339,7 +341,7 @@ public class CompanyManagementService {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
 
         List<ProductionCompanyDTO> owned = new ArrayList<>();
@@ -373,7 +375,7 @@ public class CompanyManagementService {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
 
         List<MyCompanyDTO> companies = new ArrayList<>();
@@ -409,7 +411,7 @@ public class CompanyManagementService {
         int userId = authenticate(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
 
         List<InvitationDTO> invitations = new ArrayList<>();
@@ -491,6 +493,8 @@ public class CompanyManagementService {
                     newProductionCompany.getFounderId() // DTO field is founderId
             );
 
+        } catch (DomainException e) {
+            throw e; // a known business failure (e.g. duplicate) keeps its type/message; don't mask it
         } catch (Exception e) {
             log.error("Error occurred while saving company '{}': {}", request.getName(), e.getMessage());
             throw new RuntimeException("Failed to register company due to a server error", e);
@@ -505,11 +509,11 @@ public class CompanyManagementService {
         int userId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(config.companyId());
         if (company == null) {
-            throw new CompanyNotFoundException(config.companyId());
+            throw new CompanyNotFoundException();
         }
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new RuntimeException("User not found");
+            throw new UserNotFoundException();
         }
         user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
         PurchasePolicy policy = buildPurchasePolicyFromDTO(config.defaultPurchasePolicy());
@@ -534,17 +538,17 @@ public class CompanyManagementService {
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
             log.warn("Company {} not found", companyId);
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         }
 
         User currUser = userRepository.getUserById(requesterId);
         if (currUser == null) {
             log.warn("User {} not found", requesterId);
-            throw new RuntimeException("User not found");
+            throw new UserNotFoundException();
         }
         if (!currUser.hasPermissionInCompany(companyId, Permission.VIEW_SALES)) {
             log.warn("User {} does not have permission to view sales history for company {}", requesterId, companyId);
-            throw new RuntimeException("Insufficient permissions");
+            throw new UnauthorizedActionException("view this company's data");
         }
 
         List<Integer> companyEventIds = eventRepository.findIdsByCompany(companyId);
@@ -588,19 +592,19 @@ public class CompanyManagementService {
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
             log.warn("Company {} not found", companyId);
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         }
 
         User currUser = userRepository.getUserById(requesterId);
         if (currUser == null) {
             log.warn("User {} not found", requesterId);
-            throw new RuntimeException("User not found");
+            throw new UserNotFoundException();
         }
         if (!currUser.isOwnerInCompany(companyId)) {
             log.warn("User {} does not have permission to view organizational tree for company {}, he's not an owner",
                     requesterId,
                     companyId);
-            throw new RuntimeException("Insufficient permissions");
+            throw new UnauthorizedActionException("view this company's data");
         }
 
         log.info("Successfully retrieved organizational tree for company {}", companyId);
@@ -634,7 +638,7 @@ public class CompanyManagementService {
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
             log.warn("Company {} not found", companyId);
-            throw new CompanyNotFoundException(companyId);
+            throw new CompanyNotFoundException();
         }
         log.info("Admin viewing organizational tree for company {}", companyId);
         return buildOrganizationalTree(companyId, company.getFounderId());
@@ -690,7 +694,7 @@ public class CompanyManagementService {
     public List<UserCompanyDTO> listForUser(int userId) {
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
         List<UserCompanyDTO> memberships = new ArrayList<>();
         for (CompanyAppointment appointment : user.getAllCompanyAppointments()) {
@@ -713,7 +717,7 @@ public class CompanyManagementService {
     public boolean isOwnerOf(int userId, int companyId) {
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
         CompanyAppointment appointment = user.getActiveCompanyAppointment(companyId);
         return appointment != null && appointment.getRole() == CompanyRole.Owner;
@@ -807,10 +811,10 @@ public class CompanyManagementService {
         int userId = authenticate(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null)
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         User user = userRepository.getUserById(userId);
         if (user == null)
-            throw new RuntimeException("User not found");
+            throw new UserNotFoundException();
         user.requirePermissionInCompany(companyId, Permission.EDIT_POLICIES);
         return policyToDTO(company.getPurchasePolicy());
     }

--- a/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/EventManagementService.java
@@ -17,6 +17,7 @@ import com.ticketing.system.Core.Domain.exceptions.CompanyNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.EventNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidStateTransitionException;
 import com.ticketing.system.Core.Domain.exceptions.InvalidTokenException;
+import com.ticketing.system.Core.Domain.exceptions.UnauthorizedActionException;
 import com.ticketing.system.Core.Domain.exceptions.UserNotFoundException;
 import com.ticketing.system.Core.Domain.exceptions.RefundFailedException;
 import com.ticketing.system.Core.Domain.orders.TransactionRecord;
@@ -128,7 +129,7 @@ public class EventManagementService {
             company = companyRepository.getCompanyById(request.companyId());
         } catch (RuntimeException e) {
             log.error("Error - company not found: {}, {}", request.companyId(), e.getMessage());
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         }
 
         User user = userRepository.getUserById(ownerId);
@@ -185,12 +186,12 @@ public class EventManagementService {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
 
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null) {
-            throw new CompanyNotFoundException("Company not found for ID: " + companyId);
+            throw new CompanyNotFoundException();
         }
 
         // The events list is a read-only management hub. Any active member of the company may see
@@ -210,16 +211,16 @@ public class EventManagementService {
         int userId = validateTokenAndGetUserId(token);
         Event event = eventRepository.findById(eventId);
         if (event == null) {
-            throw new EventNotFoundException(eventId);
+            throw new EventNotFoundException();
         }
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
         user.requirePermissionInCompany(event.getCompanyId(), Permission.MANAGE_INVENTORY);
         ProductionCompany company = companyRepository.getCompanyById(event.getCompanyId());
         if (company == null) {
-            throw new CompanyNotFoundException("Company not found for ID: " + event.getCompanyId());
+            throw new CompanyNotFoundException();
         }
 
         return new EventDetailDTO(
@@ -249,11 +250,11 @@ public class EventManagementService {
         int userId = validateTokenAndGetUserId(token);
         User user = userRepository.getUserById(userId);
         if (user == null) {
-            throw new UserNotFoundException(userId);
+            throw new UserNotFoundException();
         }
         Event event = eventRepository.findById(eventId);
         if (event == null) {
-            throw new EventNotFoundException("Event not found for ID: " + eventId);
+            throw new EventNotFoundException();
         }
         user.requirePermissionInCompany(event.getCompanyId(), Permission.CONFIGURE_VENUE);
 
@@ -318,7 +319,7 @@ public class EventManagementService {
             Event event = eventRepository.findById(eventId);
 
             if (event.getCompanyId() != companyId) {
-                throw new RuntimeException("Event does not belong to this company");
+                throw new UnauthorizedActionException("act on an event that does not belong to this company");
             }
 
             List<InventoryZone> zones = new ArrayList<>();
@@ -653,7 +654,7 @@ public class EventManagementService {
             companyRepository.getCompanyById(companyId);
         } catch (RuntimeException e) {
             log.error("Error - company not found: {}, {}", companyId, e.getMessage());
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         }
 
         user.requirePermissionInCompany(companyId, Permission.CONFIGURE_VENUE);
@@ -663,11 +664,11 @@ public class EventManagementService {
             event = eventRepository.findById(eventId);
         } catch (EventNotFoundException e) {
             log.warn("Event {} not found", eventId);
-            throw new RuntimeException("Event not found");
+            throw new EventNotFoundException();
         }
 
         if (event.getCompanyId() != companyId) {
-            throw new RuntimeException("Event does not belong to this company");
+            throw new UnauthorizedActionException("act on an event that does not belong to this company");
         }
 
         return event;
@@ -754,7 +755,7 @@ public class EventManagementService {
             Event event = eventRepository.findById(eventId);
 
             if (event.getCompanyId() != companyId) {
-                throw new RuntimeException("Event does not belong to this company");
+                throw new UnauthorizedActionException("act on an event that does not belong to this company");
             }
 
             User user = userRepository.getUserById(userId);
@@ -917,16 +918,15 @@ public class EventManagementService {
 
             log.info("Event {} canceled and refund flow completed", eventId);
 
-        } catch (EventNotFoundException e) { // TODO: check if these Catches are good
+        } catch (EventNotFoundException e) {
             log.warn("Event {} not found for cancellation", eventId);
-            throw new RuntimeException("Event not found");
+            throw e;
         } catch (RefundFailedException e) {
             log.error("Refund failed during cancellation of event {}: {}", eventId, e.getMessage());
-            throw new RuntimeException("Refund failed: " + e.getMessage());
-        } catch (Exception e) {
+            throw e;
+        } catch (RuntimeException e) {
             log.error("Unexpected error during cancellation of event {}: {}", eventId, e.getMessage());
-            throw new RuntimeException("Error during cancellation: " + e.getMessage());
-
+            throw e;
         } finally {
             eventRepository.unlock(eventId);
         }
@@ -986,7 +986,7 @@ public class EventManagementService {
     @Transactional
     public void setEventPolicies(String token, EventPolicyConfigDTO config) {
         if (!sessionManager.validateToken(token)) {
-            throw new RuntimeException("Invalid token");
+            throw new InvalidTokenException();
         }
 
         if (config == null) {
@@ -1000,22 +1000,22 @@ public class EventManagementService {
 
             ProductionCompany company = companyRepository.getCompanyById(config.companyId());
             if (company == null) {
-                throw new RuntimeException("Company not found");
+                throw new CompanyNotFoundException();
             }
 
             User user = userRepository.getUserById(userId);
             if (user == null) {
-                throw new RuntimeException("User not found");
+                throw new UserNotFoundException();
             }
             user.requirePermissionInCompany(config.companyId(), Permission.EDIT_POLICIES);
 
             Event event = eventRepository.findById(config.eventId());
             if (event == null) {
-                throw new RuntimeException("Event not found");
+                throw new EventNotFoundException();
             }
 
             if (event.getCompanyId() != config.companyId()) {
-                throw new RuntimeException("Event does not belong to this company");
+                throw new UnauthorizedActionException("act on an event that does not belong to this company");
             }
 
             PurchasePolicy companyPurchasePolicy = company.getPurchasePolicy();
@@ -1126,20 +1126,20 @@ public class EventManagementService {
     @Transactional(readOnly = true)
     public PurchasePolicyDTO getEventPurchasePolicy(String token, int companyId, int eventId) {
         if (!sessionManager.validateToken(token))
-            throw new RuntimeException("Invalid token");
+            throw new InvalidTokenException();
         int userId = sessionManager.extractUserId(token);
         ProductionCompany company = companyRepository.getCompanyById(companyId);
         if (company == null)
-            throw new RuntimeException("Company not found");
+            throw new CompanyNotFoundException();
         User user = userRepository.getUserById(userId);
         if (user == null)
-            throw new RuntimeException("User not found");
+            throw new UserNotFoundException();
         user.requirePermissionInCompany(companyId, Permission.EDIT_POLICIES);
         Event event = eventRepository.findById(eventId);
         if (event == null)
-            throw new RuntimeException("Event not found");
+            throw new EventNotFoundException();
         if (event.getCompanyId() != companyId)
-            throw new RuntimeException("Event does not belong to this company");
+            throw new UnauthorizedActionException("act on an event that does not belong to this company");
         PurchasePolicy stored = event.getPurchasePolicy();
         if (stored instanceof AndPurchasePolicy a) {
             return policyToDTO(a.getRightPolicy());

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/CompanyNotFoundException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/CompanyNotFoundException.java
@@ -4,6 +4,12 @@ package com.ticketing.system.Core.Domain.exceptions;
 // UC-18, UC-19, UC-22, UC-25.
 public class CompanyNotFoundException extends EntityNotFoundException {
 
+    // Id-free message for user-facing paths — the id is written to the server log at the throw site,
+    // not leaked to the UI (avoids exposing internal identifiers / enabling enumeration).
+    public CompanyNotFoundException() {
+        super("Company not found");
+    }
+
     public CompanyNotFoundException(Object companyId) {
         super("ProductionCompany", companyId);
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/EventNotFoundException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/EventNotFoundException.java
@@ -4,6 +4,12 @@ package com.ticketing.system.Core.Domain.exceptions;
 // Lets services catch selectively (e.g. UC-19/20/21/22/31).
 public class EventNotFoundException extends EntityNotFoundException {
 
+    // Id-free message for user-facing paths — the id is written to the server log at the throw site,
+    // not leaked to the UI (avoids exposing internal identifiers / enabling enumeration).
+    public EventNotFoundException() {
+        super("Event not found");
+    }
+
     public EventNotFoundException(Object eventId) {
         super("Event not found: ", eventId);
     }

--- a/src/main/java/com/ticketing/system/Core/Domain/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/ticketing/system/Core/Domain/exceptions/UserNotFoundException.java
@@ -4,6 +4,12 @@ package com.ticketing.system.Core.Domain.exceptions;
 // UC-12, UC-13, UC-16, UC-23/24, UC-31, etc.
 public class UserNotFoundException extends EntityNotFoundException {
 
+    // Id-free message for user-facing paths — the id is written to the server log at the throw site,
+    // not leaked to the UI (avoids exposing internal identifiers / enabling enumeration).
+    public UserNotFoundException() {
+        super("User not found");
+    }
+
     public UserNotFoundException(Object userId) {
         super("User", userId);
     }

--- a/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/CompanyEventListView.java
@@ -98,17 +98,12 @@ public class CompanyEventListView extends LkPage {
         this.presenter = presenter;
         title("My Events");
         subtitle("All events under the selected company.");
-        LkBtn bulkExport = new LkBtn("Bulk Export").variant(LkBtn.Variant.secondary)
-            .onClick(e -> Toasts.success("Event list exported to CSV (mock)."));
         // "New Event" is an event-management action — hidden for a member who can't edit events
         // (e.g. a venue-only manager), so the page is browse + per-event venue/sales for them.
         if (Capabilities.has(Capability.EDIT_COMPANY_EVENTS)) {
-            actions(bulkExport,
-                new LkBtn("New Event").variant(LkBtn.Variant.primary)
-                    .icon(new LkIcon("plus", 15))
-                    .onClick(e -> UI.getCurrent().navigate("owner/events/new")));
-        } else {
-            actions(bulkExport);
+            actions(new LkBtn("New Event").variant(LkBtn.Variant.primary)
+                .icon(new LkIcon("plus", 15))
+                .onClick(e -> UI.getCurrent().navigate("owner/events/new")));
         }
         add(buildFilters());
         add(eventsCard);


### PR DESCRIPTION
Pre-submission frontend/endpoint cleanup (issue #460), from the 3-agent audit. Branches off `dev` (which already has #458's `GlobalUiErrorHandler` and #459's market fix).

## Frontend
- Removed the non-functional **"Bulk Export"** button in `CompanyEventListView` — it toasted `"Event list exported to CSV (mock)."` and did nothing.

## Write-path exception hygiene
- Replaced raw `throw new RuntimeException("…")` in `EventManagementService` (19 sites) and `CompanyManagementService` (13 sites) with existing typed domain exceptions (`CompanyNotFoundException`, `UserNotFoundException`, `EventNotFoundException`, `UnauthorizedActionException`, `InvalidTokenException`). They're `DomainException`/`RuntimeException` subclasses, so presenters and the `GlobalUiErrorHandler` (#458) can classify them and show a precise message instead of a generic error page.
- `cancelEventAndRefund` and `registerCompany` now **rethrow** caught domain exceptions instead of re-wrapping them into an untyped `RuntimeException` (and the stale `// TODO: check if these Catches are good` is gone). `registerCompany` also catches `DomainException` first so a real business failure isn't masked as "server error".

## Security: keep internal ids out of user-facing messages
- Per review feedback, the not-found exceptions now use **id-free messages** (new no-arg constructors). Internal entity ids stay in the **server logs** (already emitted at every throw site), never in user-facing text — avoids leaking / enabling enumeration of sequential internal ids.
- This also swept **pre-existing** id-leaking throws in these two services, including three that embedded the id directly in the message (e.g. `"Event not found for ID: " + id`).

## Deferred
- `CheckoutService`'s 2 raw-`RuntimeException` sites are left to **#418**, which already reworks checkout error messaging (avoids a merge conflict).

## Verification
- `./mvnw -Pno-vaadin test` → **1532 tests, 0 failures**. Existing `assertThrows(RuntimeException.class)` tests stay green (the new types are `RuntimeException` subclasses); the reservation `"Event not found: 100"` message assertion is unaffected (`ReservationService` untouched).

Closes #460.