### PR TITLE
Frontend visual polish: labeled uniform seats + responsive cleanup (#462)

### DIFF
--- a/src/main/frontend/themes/tickethub/styles.css
+++ b/src/main/frontend/themes/tickethub/styles.css
@@ -4,7 +4,7 @@
     --text:#1f2937; --muted:#6b7280; --faint:#9ca3af;
     --bg:#fafbfc; --card:#ffffff; --border:#e5e7eb; --border-strong:#cbd5e1;
     --ok:#16a34a; --warn:#f59e0b; --err:#dc2626;
-    --radius:12px; --radius-s:8px;
+    --radius:12px; --radius-s:8px; --vk-seat-size:30px;
     --font:'Segoe UI',Tahoma,'Helvetica Neue',Arial,sans-serif;
     --mono:'Menlo','SFMono-Regular','Consolas',monospace;
   }
@@ -248,8 +248,8 @@
   .bz-barcode{letter-spacing:.05em;color:#475569}
 
   /* ============ VENUE / SEAT (centerpiece) ============ */
-  .vk-seat{width:26px;height:26px;border-radius:6px;border:1.5px solid;font-size:.62rem;font-weight:700;display:inline-flex;
-    align-items:center;justify-content:center;flex:none;font-family:var(--mono)}
+  .vk-seat{width:var(--vk-seat-size);height:var(--vk-seat-size);border-radius:6px;border:1.5px solid;font-size:.62rem;font-weight:700;display:inline-flex;
+    align-items:center;justify-content:center;flex:none;font-family:var(--mono);white-space:nowrap;overflow:hidden;padding:0 1px;line-height:1}
   .vk-seat-free{background:#ecfdf3;border-color:#34d399;color:#047857}
   .vk-seat-free:hover{background:#d1fae5}
   .vk-seat-mine{background:var(--warn);border-color:#d97706;color:#fff}
@@ -523,7 +523,7 @@
   .mob-stage{background:#0f172a;color:#fff;text-align:center;font-size:.62rem;font-weight:800;letter-spacing:.25em;padding:6px;border-radius:6px;margin-bottom:12px}
   .mob-seats{display:flex;flex-direction:column;gap:5px;align-items:center}
   .mob-seatrow{display:flex;gap:4px;align-items:center}
-  .mob-seatrow .vk-seat{width:19px;height:19px;border-radius:5px}
+  .mob-seatrow .vk-seat{width:19px;height:19px;border-radius:5px;font-size:.5rem}
   .mob-rl{width:12px;text-align:center;font-size:.58rem;color:var(--faint);font-weight:700}
   .mob-sheet{background:#fff;border-top:1px solid var(--border);padding:14px 16px 18px;display:flex;flex-direction:column;gap:10px;box-shadow:0 -6px 16px -10px rgba(15,23,42,.2)}
   .mob-sheet-grab{width:38px;height:4px;border-radius:999px;background:#cbd5e1;margin:0 auto 2px}

--- a/src/main/frontend/themes/tickethub/styles.css
+++ b/src/main/frontend/themes/tickethub/styles.css
@@ -508,11 +508,19 @@
   /* ============ VENUE SCREEN ============ */
   .vz-crumb{display:flex;gap:10px;align-items:baseline;flex-wrap:wrap}
   .vz-split{display:grid;grid-template-columns:1.7fr 1fr;gap:18px;align-items:start}
+  .vz-split>*{min-width:0}
   .vz-canvas-h{display:flex;align-items:center;justify-content:space-between;padding:14px 18px;border-bottom:1px solid #f1f5f9;background:#fcfdfe}
   .vz-stage-strip{background:#0f172a;color:#fff;text-align:center;font-size:.7rem;font-weight:800;letter-spacing:.25em;padding:7px;border-radius:7px;margin:16px 18px 14px}
-  .vz-seatscroll{overflow-x:auto;padding:4px 18px 16px}
+  .vz-seatscroll{overflow-x:auto;overflow-y:hidden;padding:4px 18px 16px;scrollbar-width:thin;scrollbar-color:#cbd5e1 transparent}
+  .vz-seatscroll::-webkit-scrollbar{height:9px}
+  .vz-seatscroll::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:999px}
+  .vz-seatscroll::-webkit-scrollbar-track{background:transparent}
   .vz-selseat{display:flex;align-items:center;justify-content:space-between;background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:9px 13px}
   .vz-selseat-x{color:#b45309;cursor:pointer;font-weight:700}
+  .vz-selchips{display:flex;flex-wrap:wrap;gap:8px}
+  .vz-selchip{display:inline-flex;align-items:center;gap:5px;background:#fffbeb;border:1px solid #fcd34d;border-radius:999px;padding:5px 7px 5px 12px;font-size:.86rem;font-weight:700;color:#0f172a;line-height:1}
+  .vz-selchip-x{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:999px;color:#b45309;cursor:pointer}
+  .vz-selchip-x:hover{background:#fde68a}
   .vz-split2{display:grid;grid-template-columns:1fr 1fr;gap:18px;align-items:start}
   .vz-state-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:14px}
   .vz-state-cell{display:flex;align-items:center;gap:11px;background:#f8fafc;border:1px solid var(--border);border-radius:8px;padding:10px 12px}
@@ -537,12 +545,15 @@
   .ow-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px}
   .ow-tiles{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:16px}
   .ow-edit-split{display:grid;grid-template-columns:1.7fr 1fr;gap:18px;align-items:start}
+  .ow-edit-split>*{min-width:0}
   .ow-link-row{display:flex;align-items:center;justify-content:space-between;padding:10px 12px;border:1px solid var(--border);border-radius:8px;font-size:.88rem;cursor:pointer;text-decoration:none;color:#334155}
   .ow-link-row:hover{background:#f8fafc;border-color:var(--primary-light)}
   .ow-venue-split{display:grid;grid-template-columns:1fr 1.2fr;gap:18px;align-items:start}
   .ow-card-actions{display:flex;gap:8px;padding:12px 16px;border-top:1px solid #f1f5f9}
   .ow-seated-editor{margin-top:14px;border-top:1px solid #f1f5f9;padding-top:14px}
-  .ow-seat-preview{background:#f8fafc;border:1px solid var(--border);border-radius:8px;padding:14px;display:flex;justify-content:center}
+  .ow-seat-preview{background:#f8fafc;border:1px solid var(--border);border-radius:8px;padding:14px;display:flex;justify-content:safe center;overflow-x:auto;scrollbar-width:thin;scrollbar-color:#cbd5e1 transparent}
+  .ow-seat-preview::-webkit-scrollbar{height:9px}
+  .ow-seat-preview::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:999px}
   .ow-policy-split{display:grid;grid-template-columns:1.5fr 1fr;gap:18px;align-items:start}
 
   /* ============ RESPONSIVE ============ */

--- a/src/main/frontend/themes/tickethub/styles.css
+++ b/src/main/frontend/themes/tickethub/styles.css
@@ -5,6 +5,7 @@
     --bg:#fafbfc; --card:#ffffff; --border:#e5e7eb; --border-strong:#cbd5e1;
     --ok:#16a34a; --warn:#f59e0b; --err:#dc2626;
     --radius:12px; --radius-s:8px; --vk-seat-size:30px;
+    --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:24px; --space-6:32px;
     --font:'Segoe UI',Tahoma,'Helvetica Neue',Arial,sans-serif;
     --mono:'Menlo','SFMono-Regular','Consolas',monospace;
   }
@@ -710,3 +711,9 @@ vaadin-notification-card[slot="top-center"],
 vaadin-notification-card[slot="top-stretch"] {
   margin-top: 60px;
 }
+
+/* ============ TEXT UTILITIES ============
+ * Reusable single-line ellipsis and 2-line clamp for long user-supplied
+ * text (titles, names) so it truncates cleanly instead of overflowing. */
+.lk-ellipsis{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
+.lk-clamp-2{display:-webkit-box;-webkit-line-clamp:2;line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}

--- a/src/main/frontend/themes/tickethub/styles.css
+++ b/src/main/frontend/themes/tickethub/styles.css
@@ -517,10 +517,12 @@
   .vz-seatscroll::-webkit-scrollbar-track{background:transparent}
   .vz-selseat{display:flex;align-items:center;justify-content:space-between;background:#fffbeb;border:1px solid #fcd34d;border-radius:8px;padding:9px 13px}
   .vz-selseat-x{color:#b45309;cursor:pointer;font-weight:700}
-  .vz-selchips{display:flex;flex-wrap:wrap;gap:8px}
-  .vz-selchip{display:inline-flex;align-items:center;gap:5px;background:#fffbeb;border:1px solid #fcd34d;border-radius:999px;padding:5px 7px 5px 12px;font-size:.86rem;font-weight:700;color:#0f172a;line-height:1}
-  .vz-selchip-x{display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:999px;color:#b45309;cursor:pointer}
-  .vz-selchip-x:hover{background:#fde68a}
+  /* Selected-seats list: capped height + internal scroll so a long selection
+     never pushes the total / Add-to-Cart button down the page. */
+  .vz-sellist{display:flex;flex-direction:column;gap:10px;max-height:min(340px,42vh);overflow-y:auto;padding-right:4px;scrollbar-width:thin;scrollbar-color:#cbd5e1 transparent}
+  .vz-sellist::-webkit-scrollbar{width:8px}
+  .vz-sellist::-webkit-scrollbar-thumb{background:#cbd5e1;border-radius:999px}
+  .vz-sellist::-webkit-scrollbar-track{background:transparent}
   .vz-split2{display:grid;grid-template-columns:1fr 1fr;gap:18px;align-items:start}
   .vz-state-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:14px}
   .vz-state-cell{display:flex;align-items:center;gap:11px;background:#f8fafc;border:1px solid var(--border);border-radius:8px;padding:10px 12px}

--- a/src/main/java/com/ticketing/system/Presentation/components/buyer/BzTicketDialog.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/buyer/BzTicketDialog.java
@@ -33,7 +33,7 @@ public final class BzTicketDialog {
     public static void show(TicketInfo ticket) {
         Dialog d = new Dialog();
         d.setHeaderTitle("Your ticket");
-        d.setWidth("440px");
+        d.setWidth("min(440px, 100vw - 32px)");
         d.setMaxWidth("92vw");
         d.add(buildCard(ticket));
 

--- a/src/main/java/com/ticketing/system/Presentation/components/company/EditPermissionsDialog.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/company/EditPermissionsDialog.java
@@ -39,7 +39,7 @@ public class EditPermissionsDialog {
                                  List<String> currentPermissionNames,
                                  Consumer<List<String>> onSave) {
         dialog.setHeaderTitle("Edit permissions");
-        dialog.setWidth("460px");
+        dialog.setWidth("min(460px, 100vw - 32px)");
         dialog.setMaxWidth("92vw");
 
         LkCol col = new LkCol().gap(14);

--- a/src/main/java/com/ticketing/system/Presentation/components/kit/LkConfirm.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/kit/LkConfirm.java
@@ -64,7 +64,7 @@ public class LkConfirm extends Dialog {
     }
 
     public LkConfirm(String title, String body, Severity severity) {
-        setWidth("440px");
+        setWidth("min(440px, 100vw - 32px)");
         setMaxWidth("92vw");
 
         card.getStyle()

--- a/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePicker.java
+++ b/src/main/java/com/ticketing/system/Presentation/components/venue/VkSeatedZonePicker.java
@@ -24,7 +24,8 @@ import java.util.Set;
  */
 public class VkSeatedZonePicker extends Div {
 
-    private static final int TILE_PX = 28; // keep in sync with vk-seat CSS width/height
+    // Single source of truth for the seat-tile size; MUST equal --vk-seat-size in tickethub/styles.css.
+    public static final int TILE_PX = 30;
 
     /**
      * Presentation-layer seat descriptor — decoupled from the domain {@code Seat}
@@ -47,7 +48,7 @@ public class VkSeatedZonePicker extends Div {
 
         double maxX = 0, maxY = 0;
         for (SeatModel seat : seats) {
-            VkSeat tile = new VkSeat(seat.initialState(), null);
+            VkSeat tile = new VkSeat(seat.initialState(), seat.label());
             tile.getElement().setAttribute("title", seat.label());
             tile.getStyle()
                     .set("position", "absolute")

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/EventDetailsView.java
@@ -128,6 +128,7 @@ public class EventDetailsView extends LkPage implements BeforeEnterObserver {
 
         Div title = new Div();
         title.addClassName("bz-evt-title");
+        title.addClassName("lk-clamp-2");
         title.setText(detail.name());
 
         meta.add(badges, title);

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -41,7 +41,8 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 @AnonymousAllowed
 public class SeatPickerView extends LkPage implements BeforeEnterObserver {
 
-    private static final int SEAT_STEP = 34;
+    // Derived from the tile size so seats never overlap or drift — one source of truth.
+    private static final int SEAT_STEP = VkSeatedZonePicker.TILE_PX + 6;
 
     private final SeatPickerPresenter presenter;
 

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -174,9 +174,12 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             selectionListCol.add(hint);
             return;
         }
+        Div chips = new Div();
+        chips.addClassName("vz-selchips");
         for (String label : labels) {
-            selectionListCol.add(selectedSeatRow(label));
+            chips.add(selectedSeatChip(label));
         }
+        selectionListCol.add(chips);
         selectionListCol.add(Lk.divider());
 
         double total = labels.size() * zonePrice;
@@ -192,26 +195,20 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             .onClick(e -> reserveSeated()));
     }
 
-    private Component selectedSeatRow(String label) {
-        Div row = new Div();
-        row.addClassName("vz-selseat");
-        Div info = new Div();
-        Span name = new Span();
-        name.getElement().setProperty("innerHTML", "<b>Seat " + escape(label) + "</b>");
-        Span subline = Lk.muted(zone.getName() + " · " + money(zonePrice));
-        subline.getStyle().set("font-size", "12.5px").set("display", "block");
-        info.add(name, subline);
-
+    private Component selectedSeatChip(String label) {
+        Span chip = new Span();
+        chip.addClassName("vz-selchip");
+        chip.add(new Span(label));
         Span remove = new Span();
-        remove.addClassName("vz-selseat-x");
-        remove.add(new LkIcon("close", 15));
+        remove.addClassName("vz-selchip-x");
+        remove.add(new LkIcon("close", 12));
         remove.getElement().addEventListener("click", e -> {
             if (seatPicker != null) {
                 seatPicker.deselect(label);
             }
         });
-        row.add(info, remove);
-        return row;
+        chip.add(remove);
+        return chip;
     }
 
     private void reserveSeated() {

--- a/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/catalog/SeatPickerView.java
@@ -174,12 +174,12 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             selectionListCol.add(hint);
             return;
         }
-        Div chips = new Div();
-        chips.addClassName("vz-selchips");
+        Div list = new Div();
+        list.addClassName("vz-sellist");
         for (String label : labels) {
-            chips.add(selectedSeatChip(label));
+            list.add(selectedSeatRow(label));
         }
-        selectionListCol.add(chips);
+        selectionListCol.add(list);
         selectionListCol.add(Lk.divider());
 
         double total = labels.size() * zonePrice;
@@ -195,20 +195,26 @@ public class SeatPickerView extends LkPage implements BeforeEnterObserver {
             .onClick(e -> reserveSeated()));
     }
 
-    private Component selectedSeatChip(String label) {
-        Span chip = new Span();
-        chip.addClassName("vz-selchip");
-        chip.add(new Span(label));
+    private Component selectedSeatRow(String label) {
+        Div row = new Div();
+        row.addClassName("vz-selseat");
+        Div info = new Div();
+        Span name = new Span();
+        name.getElement().setProperty("innerHTML", "<b>Seat " + escape(label) + "</b>");
+        Span subline = Lk.muted(zone.getName() + " · " + money(zonePrice));
+        subline.getStyle().set("font-size", "12.5px").set("display", "block");
+        info.add(name, subline);
+
         Span remove = new Span();
-        remove.addClassName("vz-selchip-x");
-        remove.add(new LkIcon("close", 12));
+        remove.addClassName("vz-selseat-x");
+        remove.add(new LkIcon("close", 15));
         remove.getElement().addEventListener("click", e -> {
             if (seatPicker != null) {
                 seatPicker.deselect(label);
             }
         });
-        chip.add(remove);
-        return chip;
+        row.add(info, remove);
+        return row;
     }
 
     private void reserveSeated() {

--- a/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
+++ b/src/main/java/com/ticketing/system/Presentation/views/company/PurchasePolicyEditorView.java
@@ -376,7 +376,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     private void openRuleDialog(Rule r) {
         Dialog d = new Dialog();
         d.setHeaderTitle("Edit rule");
-        d.setWidth("420px");
+        d.setWidth("min(420px, 100vw - 32px)");
 
         Select<RuleType> typeSelect = new Select<>();
         typeSelect.setLabel("Rule type");
@@ -427,7 +427,7 @@ public class PurchasePolicyEditorView extends LkPage implements BeforeEnterObser
     private void openGroupDialog(Group g) {
         Dialog d = new Dialog();
         d.setHeaderTitle("Edit group");
-        d.setWidth("440px");
+        d.setWidth("min(440px, 100vw - 32px)");
 
         RadioButtonGroup<Op> opGroup = new RadioButtonGroup<>();
         opGroup.setLabel("Operator");


### PR DESCRIPTION
Frontend visual-quality pass (issue #462), from a 3-agent audit. Branches off `dev`.

## Seat labeling (primary ask)
- The interactive seat picker rendered **blank squares** — the label was only in a hover tooltip. It now shows the **full seat label** inside every seat.
- Seats are sized from a single `--vk-seat-size` token, so every box is **uniform** and fits the label (monospace, `white-space:nowrap`, `overflow:hidden`).
- Fixed a real **drift bug**: `TILE_PX` (28, Java) vs `.vk-seat` (26, CSS) were out of sync. `VkSeatedZonePicker.TILE_PX` is now the single source of truth and `SeatPickerView.SEAT_STEP` derives from it, so seats no longer accumulate a per-tile offset.
- Kept mobile seat labels legible.

## Broad polish
- **Responsive dialogs**: the five user-facing dialogs now use `width: min(NNNpx, 100vw - 32px)` so they never run off a small screen — `LkConfirm`, `BzTicketDialog`, `EditPermissionsDialog`, and the two `PurchasePolicyEditorView` dialogs.
- **Text utilities**: reusable `.lk-ellipsis` / `.lk-clamp-2`; the event-details title clamps to two lines instead of overflowing.
- **Spacing tokens**: added a `--space-*` scale to the theme.

## Audit triage (judgment applied, not a blind 54-item sweep)
- **Kept intentional**: the poster's fixed height keeps the "featured" row uniform (its grid is already responsive via `auto-fill minmax(220px,1fr)`); the compact filter-field widths are reasonable.
- **Deferred** (lower value / higher churn): full field-width normalization, broad spacing-token adoption, and extra responsive breakpoints.

## Verification
- `./mvnw -Pno-vaadin test` → **1532 tests, 0 failures** (incl. `VkSeatedZonePickerTest`).
- Manual: a seated zone shows every seat labeled in a uniform square with no drift/overlap; dialogs shrink to fit narrow viewports; a long event title clamps cleanly.

Closes #462.