### PR TITLE
[Eval 5] Transaction boundaries on the notification services

### DIFF
--- a/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/NotificationDispatchService.java
@@ -17,6 +17,8 @@ import com.ticketing.system.Core.Domain.notifications.NotificationStatus;
 // The Domain-Events pattern was committed at UC-35 (see design_walkthrough_summary.md §6).
 // Listener wiring (which domain events trigger dispatchFromEvent) lives in code, off-diagram.
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -38,6 +40,7 @@ public class NotificationDispatchService {
      * to the bell on the next tick. Live WebSocket/SSE push (#225) will replace
      * the scheduler path when implemented.
      */
+    @Transactional
     public void dispatch(Notification notification) {
         if (!notification.isPending()) {
             throw new IllegalArgumentException(
@@ -63,6 +66,11 @@ public class NotificationDispatchService {
     }
 
     // UC-37: triggered by MemberLoggedIn event.
+    // Deliberately NOT part of a surrounding transaction: NOT_SUPPORTED suspends the caller's tx
+    // (e.g. the @Transactional login), so each pending notification is delivered + persisted on its
+    // own repository transaction. One failed push — or a mid-flush error — can't roll back the others
+    // or the login itself. Per-item by design (Eval 5 acceptance #1's documented exception).
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public List<NotificationDTO> deliverPending(int userId) {
         log.info("Delivering pending notifications for userId={}", userId);
 

--- a/src/main/java/com/ticketing/system/Core/Application/services/NotificationService.java
+++ b/src/main/java/com/ticketing/system/Core/Application/services/NotificationService.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketing.system.Core.Application.interfaces.INotificationService;
 import com.ticketing.system.Core.Domain.notifications.INotificationRepository;
@@ -23,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+// Each write op (notify*/markRead/revertSentToPending) runs inside one service-level transaction (Eval 5).
+@Transactional
 public class NotificationService implements INotificationService {
 
     private final NotificationDispatchService dispatcher;


### PR DESCRIPTION
Closes #466. Completes the last transaction-boundary gap for Eval 5 (parent #426; core #359/#360/#361).

## What
The notification services were the only application services with **no** `@Transactional`. This adds boundaries, and — importantly — keeps `deliverPending` per-item *by decoupling it* rather than leaving it silently inside the login transaction.

- **`NotificationService`** → class-level `@Transactional` (covers `notify*` / `markRead` / `revertSentToPending`).
- **`NotificationDispatchService.dispatch()`** → `@Transactional` (single atomic write).
- **`NotificationDispatchService.deliverPending()`** → `@Transactional(propagation = NOT_SUPPORTED)`.

## Why the `NOT_SUPPORTED`
`deliverPending` is called from `AuthenticationService.login()`, which is `@Transactional`. Left unannotated, its per-notification saves **joined the login transaction** — so one failed push could roll back a whole login. `NOT_SUPPORTED` suspends the caller's tx, so each notification is delivered/persisted on its **own** repository transaction: per-item by design, and a notification hiccup can never fail a login.

## Acceptance (Eval 5)
- ✅ Every notification-service write op now has a defined transaction boundary → acceptance #1 literally met.
- ✅ `deliverPending` stays per-item, decoupled from login (documented in code).
- ✅ Domain still has **zero** `@Transactional`.
- ✅ `./mvnw -Pno-vaadin test` → 1532 tests, 0 failures.